### PR TITLE
chore: do not open Storybook automatically in the browser

### DIFF
--- a/packages/cube-frontend-ui-library/package.json
+++ b/packages/cube-frontend-ui-library/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "scripts": {
     "tsc": "tsc",
-    "storybook": "storybook dev -p 6006",
+    "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
     "serve-storybook": "pnpm dlx http-server ./storybook-static"
   },


### PR DESCRIPTION
Storybook automatically opens default browser every time `pnpm ui-library:dev` is run.
After discussion, we have decided to disable this behavior.

reference: https://storybook.js.org/docs/api/cli-options