### PR TITLE
feat: create CosCheckbox and its storybook

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
@@ -1,5 +1,5 @@
-import { ChangeEvent, InputHTMLAttributes, useState, RefObject } from 'react'
 import { cva } from 'class-variance-authority'
+import { ChangeEvent, InputHTMLAttributes, RefObject, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import CheckboxUnselected from '../../components/CosIcon/monochrome/checkbox.svg?react'
 import CheckboxSelected from '../../components/CosIcon/monochrome/checkbox_checked_filled.svg?react'
@@ -13,7 +13,13 @@ export type CosCheckboxProps = Omit<
   'checked' | 'defaultChecked'
 > & {
   label: string
+  /**
+   * Use `null` for indeterminate state.
+   */
   checked?: boolean | null
+  /**
+   * Use `null` for indeterminate state.
+   */
   defaultChecked?: boolean | null
   isLoading?: boolean
   ref?: RefObject<HTMLInputElement | null>
@@ -75,6 +81,8 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
     ? controlledChecked
     : uncontrolledChecked
 
+  const isIndeterminate = effectiveChecked === null
+
   const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
     if (!isControlled) {
       setUncontrolledChecked(event.target.checked)
@@ -84,7 +92,7 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
 
   const renderIcon = () => {
     const IconComponent = (() => {
-      if (effectiveChecked === null) return CheckboxIndeterminate
+      if (isIndeterminate) return CheckboxIndeterminate
       return effectiveChecked ? CheckboxSelected : CheckboxUnselected
     })()
 
@@ -92,7 +100,7 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
       <div
         className={twMerge(
           checkbox.iconWrap({
-            isSelected: effectiveChecked || effectiveChecked === null,
+            isSelected: effectiveChecked || isIndeterminate,
             disabled,
           }),
         )}

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
@@ -56,7 +56,6 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
   const {
     label,
     id,
-    className,
     defaultChecked = false,
     checked: controlledChecked,
     onChange: onControlledCheckedChange,
@@ -106,10 +105,7 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
   if (isLoading) return <CosCheckboxSkeleton />
 
   return (
-    <label
-      htmlFor={id}
-      className={twMerge(checkbox.container({ disabled }), className)}
-    >
+    <label htmlFor={id} className={twMerge(checkbox.container({ disabled }))}>
       <input
         {...restProps}
         id={id}

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
@@ -1,0 +1,125 @@
+import { ChangeEvent, forwardRef, InputHTMLAttributes, useState } from 'react'
+import { cva } from 'class-variance-authority'
+import { twMerge } from 'tailwind-merge'
+import CheckboxUnselected from '../../components/CosIcon/monochrome/checkbox.svg?react'
+import CheckboxSelected from '../../components/CosIcon/monochrome/checkbox_checked_filled.svg?react'
+import CheckboxIndeterminate from '../../components/CosIcon/monochrome/checkbox_undeterminate_filled.svg?react'
+import { CosCheckboxSkeleton } from './CosCheckboxSkeleton'
+
+export type CosCheckboxStatus = 'unselected' | 'selected' | 'indeterminate'
+
+export type CosCheckboxProps = Omit<
+  InputHTMLAttributes<HTMLInputElement>,
+  'checked' | 'defaultChecked'
+> & {
+  label: string
+  indeterminate?: boolean
+  checked?: boolean | null
+  defaultChecked?: boolean | null
+  isLoading?: boolean
+}
+
+const checkbox = {
+  container: cva(
+    'inline-flex w-fit cursor-pointer gap-x-2 text-primary-body2',
+    {
+      variants: {
+        disabled: {
+          true: 'cursor-default',
+        },
+      },
+    },
+  ),
+  icon: cva(
+    [
+      'icon-md mt-0.5 shrink-0',
+      'text-functional-border-darker hover:text-functional-hover-primary',
+    ],
+    {
+      variants: {
+        isSelected: {
+          true: 'text-primary',
+        },
+        disabled: {
+          true: 'text-functional-disable-text hover:text-functional-disable-text',
+        },
+      },
+    },
+  ),
+  label: cva('max-w-[152px] text-functional-text', {
+    variants: {
+      disabled: {
+        true: 'text-functional-disable-text',
+      },
+    },
+  }),
+}
+
+export const CosCheckbox = forwardRef<HTMLInputElement, CosCheckboxProps>(
+  (props: CosCheckboxProps, ref) => {
+    const {
+      label,
+      indeterminate,
+      id,
+      className,
+      defaultChecked,
+      checked: controlledChecked,
+      onChange: onControlledCheckedChange,
+      disabled,
+      isLoading = false,
+      ...restProps
+    } = props
+
+    const [uncontrolledChecked, setUncontrolledChecked] = useState<
+      boolean | null
+    >(defaultChecked || indeterminate ? null : false)
+
+    const isControlled = controlledChecked !== undefined
+
+    const effectiveChecked = isControlled
+      ? controlledChecked
+      : uncontrolledChecked
+
+    const handleChange = (event: ChangeEvent<HTMLInputElement>) => {
+      if (!isControlled) {
+        setUncontrolledChecked(event.target.checked)
+      }
+      onControlledCheckedChange?.(event)
+    }
+
+    const renderIcon = (checked: boolean | null, indeterminate?: boolean) => {
+      const className = twMerge(
+        checkbox.icon({
+          disabled,
+          isSelected: effectiveChecked === null || effectiveChecked,
+        }),
+      )
+
+      const IconComponent = (() => {
+        if (indeterminate && checked === null) return CheckboxIndeterminate
+        return checked ? CheckboxSelected : CheckboxUnselected
+      })()
+
+      return <IconComponent className={className} />
+    }
+
+    if (isLoading) return <CosCheckboxSkeleton />
+
+    return (
+      <label htmlFor={id} className={twMerge(checkbox.container({ disabled }))}>
+        <input
+          {...restProps}
+          id={id}
+          ref={ref}
+          type="checkbox"
+          checked={effectiveChecked ?? false}
+          onChange={handleChange}
+          disabled={disabled}
+          className="hidden"
+        />
+        {renderIcon(effectiveChecked, indeterminate)}
+        <span className={twMerge(checkbox.label({ disabled }))}>{label}</span>
+      </label>
+    )
+  },
+)

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckboxGrid.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckboxGrid.tsx
@@ -9,19 +9,14 @@ export type CosCheckboxGridProps = PropsWithChildren<{
 }>
 
 export const CosCheckboxGrid = (props: CosCheckboxGridProps) => {
-  const { children, className, direction } = props
-  return direction === 'vertical' ? (
-    <div className={twMerge('flex flex-col gap-y-3', className)}>
-      {children}
-    </div>
-  ) : (
-    <div
-      className={twMerge(
-        'grid grid-cols-[repeat(auto-fill,180px)] gap-x-4 gap-y-6',
-        className,
-      )}
-    >
-      {children}
-    </div>
+  const { children, className: classNameProp, direction } = props
+
+  const className = twMerge(
+    direction === 'vertical'
+      ? 'flex flex-col gap-y-3'
+      : 'grid grid-cols-[repeat(auto-fill,180px)] gap-x-4 gap-y-6',
+    classNameProp,
   )
+
+  return <div className={className}>{children}</div>
 }

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckboxGrid.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckboxGrid.tsx
@@ -1,0 +1,27 @@
+import { PropsWithChildren } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+export type CosCheckboxGridDirection = 'vertical' | 'wrap'
+
+export type CosCheckboxGridProps = PropsWithChildren<{
+  className?: string
+  direction: CosCheckboxGridDirection
+}>
+
+export const CosCheckboxGrid = (props: CosCheckboxGridProps) => {
+  const { children, className, direction } = props
+  return direction === 'vertical' ? (
+    <div className={twMerge('flex flex-col gap-y-3', className)}>
+      {children}
+    </div>
+  ) : (
+    <div
+      className={twMerge(
+        'grid grid-cols-[repeat(auto-fill,180px)] gap-x-4 gap-y-6',
+        className,
+      )}
+    >
+      {children}
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckboxSkeleton.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckboxSkeleton.tsx
@@ -1,0 +1,10 @@
+import { CosSkeleton } from '../../internal/components/CosSkeleton/CosSkeleton'
+
+export const CosCheckboxSkeleton = () => {
+  return (
+    <div className="inline-flex gap-x-2">
+      <CosSkeleton className="size-5" />
+      <CosSkeleton className="h-5 w-[152px]" />
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/index.ts
+++ b/packages/cube-frontend-ui-library/src/index.ts
@@ -1,5 +1,7 @@
 export * from './components/CosButton/CosButton'
 export * from './components/CosButton/CosButtonSkeleton'
+export * from './components/CosCheckbox/CosCheckbox'
+export * from './components/CosCheckbox/CosCheckboxGrid'
 export * from './components/CosHyperlink/CosHyperlink'
 export * from './components/CosIcon/CosIcon'
 export * from './components/CosIcon/utils'

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CheckboxGrid.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CheckboxGrid.tsx
@@ -1,0 +1,15 @@
+import { PropsWithChildren } from 'react'
+
+export type CheckboxGridProps = PropsWithChildren<{
+  title: string
+}>
+
+export const CheckboxGrid = (props: CheckboxGridProps) => {
+  const { children, title } = props
+  return (
+    <div className="grid grid-cols-4 gap-12">
+      <div className="primary-body2 col-span-1 font-medium">{title}</div>
+      {children}
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CosCheckbox.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CosCheckbox.stories.tsx
@@ -36,11 +36,9 @@ export const Gallery: StoryObj = {
     return (
       <StoryLayout title="Checkbox">
         <StoryLayout.Section title="Checkbox">
-          <div className="flex flex-col gap-y-8">
-            <CheckboxGrid title="Master">
-              <CosCheckbox label={checkboxText} />
-            </CheckboxGrid>
-          </div>
+          <CheckboxGrid title="Master">
+            <CosCheckbox label={checkboxText} />
+          </CheckboxGrid>
         </StoryLayout.Section>
         <StoryLayout.Section title="Variants">
           <div className="flex flex-col gap-y-8">

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/index.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/index.stories.tsx
@@ -1,0 +1,131 @@
+import type { Meta, StoryObj } from '@storybook/react'
+import { ChangeEvent, useState } from 'react'
+import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
+import { CheckboxGrid } from './CheckboxGrid'
+import { CosCheckbox } from '../../../components/CosCheckbox/CosCheckbox'
+import { CosCheckboxGrid } from '../../../components/CosCheckbox/CosCheckboxGrid'
+
+const meta = {
+  component: CosCheckbox,
+} satisfies Meta<typeof CosCheckbox>
+
+export default meta
+
+const checkboxText = 'Checkbox item'
+const checkboxTextLonger = 'Checkbox item longer text'
+
+export const Gallery: StoryObj = {
+  args: {},
+  render: function Render() {
+    const [checked, setChecked] = useState<boolean | null>(true)
+    const [unchecked, setUnchecked] = useState<boolean | null>(null)
+    const [indeterminateChecked, setIndeterminateChecked] = useState<
+      boolean | null
+    >(null)
+
+    const handleChecked = (event: ChangeEvent<HTMLInputElement>) => {
+      setChecked(event.target.checked)
+    }
+
+    const handleUnchecked = (event: ChangeEvent<HTMLInputElement>) => {
+      setUnchecked(event.target.checked)
+    }
+    const handleIndeterminateChecked = (
+      event: ChangeEvent<HTMLInputElement>,
+    ) => {
+      setIndeterminateChecked(event.target.checked)
+    }
+
+    return (
+      <StoryLayout title="Checkbox">
+        <StoryLayout.Section title="Checkbox">
+          <div className="flex flex-col gap-y-8">
+            <CheckboxGrid title="Master">
+              <CosCheckbox label={checkboxText} />
+            </CheckboxGrid>
+          </div>
+        </StoryLayout.Section>
+        <StoryLayout.Section title="Variants">
+          <div className="flex flex-col gap-y-8">
+            <CheckboxGrid title="">
+              <div className="primary-body2">Default</div>
+              <div className="primary-body2">Disabled</div>
+            </CheckboxGrid>
+            <CheckboxGrid title="Unselect">
+              <CosCheckbox
+                label={checkboxText}
+                checked={unchecked}
+                onChange={handleUnchecked}
+              />
+              <CosCheckbox
+                label={checkboxText}
+                checked={false}
+                onChange={handleUnchecked}
+                disabled
+              />
+            </CheckboxGrid>
+            <CheckboxGrid title="Select">
+              <CosCheckbox
+                label={checkboxText}
+                checked={checked}
+                onChange={handleChecked}
+              />
+              <CosCheckbox
+                label={checkboxText}
+                checked={true}
+                onChange={handleChecked}
+                disabled
+              />
+            </CheckboxGrid>
+            <CheckboxGrid title="Indeterminate">
+              <CosCheckbox
+                label={checkboxText}
+                checked={indeterminateChecked}
+                onChange={handleIndeterminateChecked}
+                indeterminate
+              />
+              <CosCheckbox
+                label={checkboxText}
+                checked={null}
+                onChange={handleIndeterminateChecked}
+                disabled
+                indeterminate
+              />
+            </CheckboxGrid>
+          </div>
+        </StoryLayout.Section>
+        <StoryLayout.Section title="Layout">
+          <div className="flex flex-col gap-y-20">
+            <CheckboxGrid title="Vertical">
+              <CosCheckboxGrid direction="vertical">
+                <CosCheckbox label={checkboxTextLonger} />
+                <CosCheckbox label={checkboxTextLonger} />
+                <CosCheckbox label={checkboxText} />
+                <CosCheckbox label={checkboxText} />
+              </CosCheckboxGrid>
+            </CheckboxGrid>
+            <CheckboxGrid title="Wrap">
+              <CosCheckboxGrid direction="wrap" className="col-span-3">
+                <CosCheckbox label={checkboxTextLonger} />
+                <CosCheckbox label={checkboxTextLonger} />
+                <CosCheckbox label={checkboxText} />
+                <CosCheckbox label={checkboxText} />
+                <CosCheckbox label={checkboxTextLonger} />
+                <CosCheckbox label={checkboxTextLonger} />
+                <CosCheckbox label={checkboxText} />
+                <CosCheckbox label={checkboxText} />
+              </CosCheckboxGrid>
+            </CheckboxGrid>
+          </div>
+        </StoryLayout.Section>
+        <StoryLayout.Section title="Skeleton">
+          <div className="flex flex-col gap-y-8">
+            <CheckboxGrid title="Default">
+              <CosCheckbox label={checkboxText} isLoading />
+            </CheckboxGrid>
+          </div>
+        </StoryLayout.Section>
+      </StoryLayout>
+    )
+  },
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/index.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/index.stories.tsx
@@ -6,6 +6,7 @@ import { CosCheckbox } from '../../../components/CosCheckbox/CosCheckbox'
 import { CosCheckboxGrid } from '../../../components/CosCheckbox/CosCheckboxGrid'
 
 const meta = {
+  title: 'Molecules/Checkbox',
   component: CosCheckbox,
 } satisfies Meta<typeof CosCheckbox>
 
@@ -18,23 +19,19 @@ export const Gallery: StoryObj = {
   args: {},
   render: function Render() {
     const [checked, setChecked] = useState<boolean | null>(true)
-    const [unchecked, setUnchecked] = useState<boolean | null>(null)
+    const [unchecked, setUnchecked] = useState<boolean | null>(false)
     const [indeterminateChecked, setIndeterminateChecked] = useState<
       boolean | null
     >(null)
 
-    const handleChecked = (event: ChangeEvent<HTMLInputElement>) => {
+    const handleChecked = (event: ChangeEvent<HTMLInputElement>) =>
       setChecked(event.target.checked)
-    }
 
-    const handleUnchecked = (event: ChangeEvent<HTMLInputElement>) => {
+    const handleUnchecked = (event: ChangeEvent<HTMLInputElement>) =>
       setUnchecked(event.target.checked)
-    }
-    const handleIndeterminateChecked = (
-      event: ChangeEvent<HTMLInputElement>,
-    ) => {
+
+    const handleIndeterminateChecked = (event: ChangeEvent<HTMLInputElement>) =>
       setIndeterminateChecked(event.target.checked)
-    }
 
     return (
       <StoryLayout title="Checkbox">
@@ -82,14 +79,12 @@ export const Gallery: StoryObj = {
                 label={checkboxText}
                 checked={indeterminateChecked}
                 onChange={handleIndeterminateChecked}
-                indeterminate
               />
               <CosCheckbox
                 label={checkboxText}
                 checked={null}
                 onChange={handleIndeterminateChecked}
                 disabled
-                indeterminate
               />
             </CheckboxGrid>
           </div>


### PR DESCRIPTION
## Summary:
- close #15 
- create `CosCheckbox` and `CosCheckboxGrid`

## Screenshots:

https://github.com/user-attachments/assets/092d1d31-2d22-47fe-b436-9a679f4b7a0a

## Usage:
- To display an indeterminate status, use the `indeterminate` prop.
- When `indeterminate={true}`, the following conditions will display the indeterminate icon:
   - Controlled input: `value = null`
   - Uncontrolled input: `defaultValue = null`
- When `indeterminate={false}` or the indeterminate flag is not set, it will display an unselected icon if `value = null`.