### PR TITLE
43 UI library table basic

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/CosBasicTable.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/CosBasicTable.tsx
@@ -23,7 +23,7 @@ export type CosBasicTableProps<Row extends CosTableRow> = PropsWithChildren<{
   skeletonRowCount?: number
 }>
 
-const CosBasicTableComponent = <Row extends CosTableRow>(
+const CosBasicTable = <Row extends CosTableRow>(
   props: CosBasicTableProps<Row>,
 ) => {
   const {
@@ -102,10 +102,10 @@ const CosBasicTableComponent = <Row extends CosTableRow>(
   )
 }
 
-CosBasicTableComponent.Column = CreateCosTableColumn()
+CosBasicTable.Column = CreateCosTableColumn()
 
 type CosBasicTableWithColumn<Row extends CosTableRow> =
-  typeof CosBasicTableComponent<Row> & {
+  typeof CosBasicTable<Row> & {
     Column: ReturnType<typeof CreateCosTableColumn<Row>>
   }
 
@@ -113,5 +113,5 @@ type CosBasicTableWithColumn<Row extends CosTableRow> =
 export const GetCosBasicTable = <
   Row extends CosTableRow,
 >(): CosBasicTableWithColumn<Row> => {
-  return CosBasicTableComponent as CosBasicTableWithColumn<Row>
+  return CosBasicTable as CosBasicTableWithColumn<Row>
 }

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/cosTableUtils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/cosTableUtils.ts
@@ -1,0 +1,17 @@
+import { isValidElement, ReactElement, ReactNode } from 'react'
+import { CosTableColumnProps } from './rendering/CosTableColumn'
+
+export type CosTableRow = {
+  id: string
+}
+
+export const COS_TABLE_COLUMN_SYMBOL = Symbol('CosTableColumn')
+
+export const isCosTableColumn = <Row extends CosTableRow>(
+  node: ReactNode,
+): node is ReactElement<CosTableColumnProps<Row>> => {
+  if (!isValidElement(node)) {
+    return false
+  }
+  return typeof node.type === 'function' && COS_TABLE_COLUMN_SYMBOL in node.type
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableColumn.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableColumn.tsx
@@ -1,0 +1,54 @@
+import { ReactNode } from 'react'
+import { COS_TABLE_COLUMN_SYMBOL, CosTableRow } from '../cosTableUtils'
+import { ColumnCompareFnMap } from '../sorting/sortingUtils'
+
+export type CosTableColumnSkeletonVariant =
+  | 'regular'
+  | 'subtext-vertical'
+  | 'subtext-horizontal'
+  | 'icon-left'
+  | 'icon-right'
+  | 'icon-vertical'
+  | 'icon-only'
+  | 'with-barchart'
+  | 'status'
+
+export type CosTableColumnProps<
+  Row extends CosTableRow,
+  Property extends keyof Row = keyof Row,
+> = {
+  label?: string
+  property?: Property
+  emphasize?: boolean
+  isSortable?: boolean
+  /**
+   * Function that determines whether the two elements are sorted.
+   */
+  sortingCompareFnMap?: ColumnCompareFnMap<Row[Property]>
+  children?: ReactNode | ((propertyValue: Row[Property], row: Row) => ReactNode)
+  /**
+   * @default 'regular'
+   */
+  skeletonVariant?: CosTableColumnSkeletonVariant
+}
+
+// Wrapper function to help TypeScript correctly infer the type of `Row[Property]`.
+export const CreateCosTableColumn = <Row extends CosTableRow>() => {
+  type ColumnProps<Property extends keyof Row> = CosTableColumnProps<
+    Row,
+    Property
+  >
+
+  const CosTableColumn = <Property extends keyof Row>(
+    _props: ColumnProps<Property>,
+  ) => {
+    // The column component defines the schema for a table column, including its
+    // headers and body cells.
+    // The actual rendering logic is handled by the table component.
+    return undefined
+  }
+
+  CosTableColumn[COS_TABLE_COLUMN_SYMBOL] = true
+
+  return CosTableColumn
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTd.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTd.tsx
@@ -1,0 +1,61 @@
+import { cva } from 'class-variance-authority'
+import { CosTableRow } from '../cosTableUtils'
+import { CosTableColumnProps } from './CosTableColumn'
+import { CosTableTdSkeleton } from './CosTableTdSkeleton'
+
+export type CosTableTdProps<Row extends CosTableRow> = {
+  row?: Row
+  column: CosTableColumnProps<Row>
+  isLoading?: boolean
+}
+
+const td = cva(
+  [
+    'primary-body4 px-4 py-2.5 text-functional-text',
+    'border-b border-b-functional-border-divider bg-grey-0',
+    'first-of-type:border-l last-of-type:border-r',
+  ],
+  {
+    variants: {
+      emphasize: {
+        true: 'font-semibold',
+      },
+    },
+  },
+)
+
+export const CosTableTd = <Row extends CosTableRow>(
+  props: CosTableTdProps<Row>,
+) => {
+  const { row, column, isLoading } = props
+
+  const renderContent = () => {
+    if (!row) {
+      return undefined
+    }
+
+    const { children, property } = column
+
+    const propertyValue = property ? row[property] : undefined
+
+    if (typeof children === 'function') {
+      return children(propertyValue as Row[keyof Row], row)
+    }
+
+    return propertyValue?.toString()
+  }
+
+  return (
+    <td
+      className={td({
+        emphasize: column.emphasize,
+      })}
+    >
+      {isLoading ? (
+        <CosTableTdSkeleton variant={column.skeletonVariant ?? 'regular'} />
+      ) : (
+        renderContent()
+      )}
+    </td>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTd.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTd.tsx
@@ -39,7 +39,9 @@ export const CosTableTd = <Row extends CosTableRow>(
     const propertyValue = property ? row[property] : undefined
 
     if (typeof children === 'function') {
-      return children(propertyValue as Row[keyof Row], row)
+      return children(propertyValue!, row)
+    } else if (children) {
+      return children
     }
 
     return propertyValue?.toString()

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTdSkeleton.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTdSkeleton.tsx
@@ -1,0 +1,63 @@
+import { CosSkeleton } from '../../../internal/components/CosSkeleton/CosSkeleton'
+import { CosTableColumnSkeletonVariant } from './CosTableColumn'
+
+export type CosTableTdSkeletonProps = {
+  variant: CosTableColumnSkeletonVariant
+}
+
+export const CosTableTdSkeleton = (props: CosTableTdSkeletonProps) => {
+  const { variant } = props
+
+  switch (variant) {
+    case 'regular':
+      return <CosSkeleton className="h-4 w-[120px]" />
+    case 'subtext-vertical':
+      return (
+        <div className="flex w-[120px] flex-col gap-y-[6px]">
+          <CosSkeleton className="h-4 w-full" />
+          <CosSkeleton className="h-[13px] w-full" />
+        </div>
+      )
+    case 'subtext-horizontal':
+      return (
+        <div className="flex items-center gap-x-[6px]">
+          <CosSkeleton className="h-4 w-[30px]" />
+          <CosSkeleton className="h-4 w-[50px]" />
+        </div>
+      )
+    case 'icon-left':
+      return (
+        <div className="flex items-center gap-x-4">
+          <CosSkeleton className="size-4" />
+          <CosSkeleton className="h-4 w-[88px]" />
+        </div>
+      )
+    case 'icon-right':
+      return (
+        <div className="flex items-center gap-x-1">
+          <CosSkeleton className="h-4 w-[98px]" />
+          <CosSkeleton className="size-4" />
+        </div>
+      )
+    case 'icon-vertical':
+      return (
+        <div className="flex w-[85px] flex-col gap-y-[6px]">
+          <CosSkeleton className="h-4 w-full" />
+          <CosSkeleton className="h-[17px] w-full" />
+        </div>
+      )
+    case 'icon-only':
+      return <CosSkeleton className="size-4" />
+    case 'with-barchart':
+      return (
+        <div className="flex items-center gap-x-[6px]">
+          <CosSkeleton className="h-4 w-[60px]" />
+          <CosSkeleton className="h-4 w-[23px]" />
+        </div>
+      )
+    case 'status':
+      return <CosSkeleton className="h-[17px] w-[50px]" />
+    default:
+      throw new Error(`Unhandled CosTableTdSkeleton variant ${variant}`)
+  }
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTh.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTh.tsx
@@ -1,0 +1,42 @@
+import { cva } from 'class-variance-authority'
+import { CosTableRow } from '../cosTableUtils'
+import { SortingState } from '../sorting/sortingUtils'
+import { CosTableColumnProps } from './CosTableColumn'
+import { SortingArrow } from './SortingArrow'
+
+export type CosTableThProps<Row extends CosTableRow> = {
+  column: CosTableColumnProps<Row>
+  sortingState: SortingState<Row> | undefined
+  onSortClick: () => void
+}
+
+const th = cva([
+  'secondary-body3 px-4 py-2 text-left text-functional-text-light',
+  'border-y border-functional-border-divider bg-scene-background',
+  'first-of-type:rounded-tl-[5px] first-of-type:border-l',
+  'last-of-type:rounded-tr-[5px] last-of-type:border-r',
+])
+
+export const CosTableTh = <Row extends CosTableRow>(
+  props: CosTableThProps<Row>,
+) => {
+  const { column, sortingState, onSortClick } = props
+
+  return (
+    <th className={th()}>
+      <span className="flex items-center gap-x-2 whitespace-nowrap">
+        {column.label}
+        {column.isSortable && column.property && (
+          <SortingArrow
+            direction={
+              sortingState?.property === column.property
+                ? sortingState?.direction
+                : undefined
+            }
+            onClick={onSortClick}
+          />
+        )}
+      </span>
+    </th>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/SortingArrow.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/SortingArrow.tsx
@@ -1,0 +1,47 @@
+import ArrowDown from '@cube-frontend/ui-library/icons/monochrome/arrow_down.svg?react'
+import ArrowsSwitchVertical01 from '@cube-frontend/ui-library/icons/monochrome/arrows_switch_vertical_01.svg?react'
+import { cva } from 'class-variance-authority'
+import { ClassValue } from 'class-variance-authority/types'
+import { twMerge } from 'tailwind-merge'
+import { SortDirection } from '../sorting/sortingUtils'
+
+export type SortingArrowProps = {
+  direction: SortDirection
+  onClick: () => void
+}
+
+const arrow = cva(
+  [
+    'icon-md cursor-pointer',
+    'text-functional-text-light hover:text-functional-hover-primary',
+  ],
+  {
+    variants: {
+      direction: {
+        ascending: 'rotate-180',
+        descending: 'rotate-0',
+      } satisfies Record<NonNullable<SortDirection>, ClassValue>,
+      isSelected: {
+        true: 'text-functional-text transition-transform',
+      },
+    },
+  },
+)
+
+export const SortingArrow = (props: SortingArrowProps) => {
+  const { direction, onClick } = props
+
+  const Icon = !direction ? ArrowsSwitchVertical01 : ArrowDown
+
+  return (
+    <Icon
+      className={twMerge(
+        arrow({
+          direction,
+          isSelected: !!direction,
+        }),
+      )}
+      onClick={onClick}
+    />
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/sorting/sortingCompareFunctions.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/sorting/sortingCompareFunctions.ts
@@ -1,0 +1,88 @@
+import { CompareFn } from './sortingUtils'
+
+const primitiveTypes = new Set([
+  'string',
+  'number',
+  'bigint',
+  'boolean',
+  'undefined',
+  'null',
+])
+
+const defaultAscendingCompare = <T>(
+  preceding: T,
+  following: T,
+  property: string,
+): boolean => {
+  const type = ensureComparedValueType(preceding, following, property)
+  if (type === 'number') {
+    return (preceding as number) - (following as number) <= 0
+  }
+  return String(preceding).localeCompare(String(following)) <= 0
+}
+
+const ensureComparedValueType = <T>(
+  preceding: T,
+  following: T,
+  property: string,
+): string => {
+  if (typeof preceding !== typeof following) {
+    throw new Error('Values must have the same type')
+  }
+
+  const type = typeof preceding
+
+  if (!primitiveTypes.has(type)) {
+    throw new Error(
+      `Type ${type} is non-primitive. Please define a custom compare function for ${property}.`,
+    )
+  }
+
+  return type
+}
+
+const defaultDescendingCompare = <T>(
+  preceding: T,
+  following: T,
+  property: string,
+): boolean => {
+  const type = ensureComparedValueType(preceding, following, property)
+  if (type === 'number') {
+    return (preceding as number) - (following as number) >= 0
+  }
+  return String(preceding).localeCompare(String(following)) >= 0
+}
+
+export const ascendingCompare = <T>(
+  preceding: T,
+  following: T,
+  property: string,
+  customCompareFn: CompareFn<T> | undefined,
+): boolean => {
+  let isSorted = false
+
+  if (customCompareFn) {
+    isSorted = customCompareFn(preceding, following)
+  } else {
+    isSorted = defaultAscendingCompare(preceding, following, property)
+  }
+
+  return isSorted
+}
+
+export const descendingCompare = <T>(
+  preceding: T,
+  following: T,
+  property: string,
+  customCompareFn: CompareFn<T> | undefined,
+): boolean => {
+  let isSorted = false
+
+  if (customCompareFn) {
+    isSorted = customCompareFn(preceding, following)
+  } else {
+    isSorted = defaultDescendingCompare(preceding, following, property)
+  }
+
+  return isSorted
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/sorting/sortingUtils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/sorting/sortingUtils.ts
@@ -1,0 +1,42 @@
+import { CosTableRow } from '../cosTableUtils'
+
+export type SortingState<Row extends CosTableRow> = {
+  property: keyof Row
+  direction: SortDirection
+}
+
+export type SortDirectionMap<Row extends CosTableRow> = Partial<
+  Record<keyof Row, SortDirection>
+>
+
+export type SortDirection = 'ascending' | 'descending' | undefined
+
+export type RowCompareFnMap<Row extends CosTableRow> = {
+  [Property in keyof Row]?: ColumnCompareFnMap<Row[Property]>
+}
+
+export type ColumnCompareFnMap<T> = Record<
+  NonNullable<SortDirection>,
+  CompareFn<T>
+>
+
+/**
+ * Determines whether the two elements are sorted.
+ */
+export type CompareFn<T> = (preceding: T, following: T) => boolean
+
+//          <----------------<----------------<
+//          |                                 |
+//          v                                 ^
+// No sorting (undefined) -> descending -> ascending
+export const computeNextSortDirection = (
+  currentDirection: SortDirection | undefined,
+): SortDirection => {
+  if (currentDirection === undefined) {
+    return 'descending'
+  } else if (currentDirection === 'descending') {
+    return 'ascending'
+  } else {
+    return undefined
+  }
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/sorting/sortingUtils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/sorting/sortingUtils.ts
@@ -30,7 +30,7 @@ export type CompareFn<T> = (preceding: T, following: T) => boolean
 //          v                                 ^
 // No sorting (undefined) -> descending -> ascending
 export const computeNextSortDirection = (
-  currentDirection: SortDirection | undefined,
+  currentDirection: SortDirection,
 ): SortDirection => {
   if (currentDirection === undefined) {
     return 'descending'

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/sorting/useSortedRows.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/sorting/useSortedRows.ts
@@ -1,0 +1,101 @@
+import { RefObject, useEffect, useMemo, useState } from 'react'
+import { CosTableRow } from '../cosTableUtils'
+import { ascendingCompare, descendingCompare } from './sortingCompareFunctions'
+import {
+  computeNextSortDirection,
+  RowCompareFnMap,
+  SortDirection,
+  SortingState,
+} from './sortingUtils'
+import { CosTableColumnProps } from '../rendering/CosTableColumn'
+
+export type UseSortedRows<Row extends CosTableRow> = {
+  sortedRows: Row[]
+  sortingState: SortingState<Row> | undefined
+  onSortDirectionChange: (property: keyof Row) => void
+}
+
+export const useSortedRows = <Row extends CosTableRow>(
+  rows: Row[],
+  columns: CosTableColumnProps<Row>[],
+  defaultSortingState: SortingState<Row> | undefined,
+  rowCompareFnMapRef: RefObject<RowCompareFnMap<Row>>,
+): UseSortedRows<Row> => {
+  const [sortingState, setSortingState] = useState<
+    SortingState<Row> | undefined
+  >(defaultSortingState)
+
+  useEffect(() => {
+    const { property } = sortingState ?? {}
+    if (!property) {
+      return
+    }
+
+    const sortedColumn = columns.find((column) => column.property === property)
+    if (!sortedColumn) {
+      // This should not happen.
+      return
+    } else if (!sortedColumn.isSortable) {
+      console.warn(
+        `Column with property ${property.toString()} is sorted, but its isSortable prop is falsy. ` +
+          'Please set isSortable to true to enable sorting arrow.',
+      )
+    }
+  }, [sortingState, columns])
+
+  const sortedRows = useMemo(() => {
+    const { property, direction } = sortingState ?? {}
+
+    if (!property || !direction) {
+      return rows
+    }
+
+    return structuredClone(rows).sort((rowA, rowB) => {
+      const [preceding, following] = [rowA[property], rowB[property]]
+      const customCompareFn = rowCompareFnMapRef.current[property]?.[direction]
+
+      let isSorted = false
+
+      if (direction === 'ascending') {
+        isSorted = ascendingCompare(
+          preceding,
+          following,
+          property.toString(),
+          customCompareFn,
+        )
+      } else if (direction === 'descending') {
+        isSorted = descendingCompare(
+          preceding,
+          following,
+          property.toString(),
+          customCompareFn,
+        )
+      } else {
+        throw new Error(`Unhandled sort direction ${direction}`)
+      }
+
+      return isSorted ? -1 : 1
+    })
+  }, [rows, sortingState, rowCompareFnMapRef])
+
+  const onSortDirectionChange = (property: keyof Row) => {
+    let nextDirection: SortDirection
+
+    if (sortingState?.property === property) {
+      nextDirection = computeNextSortDirection(sortingState?.direction)
+    } else {
+      nextDirection = computeNextSortDirection(undefined)
+    }
+
+    setSortingState({
+      property,
+      direction: nextDirection,
+    })
+  }
+
+  return {
+    sortedRows,
+    sortingState,
+    onSortDirectionChange,
+  }
+}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/useColumnPayloads.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/useColumnPayloads.ts
@@ -18,9 +18,7 @@ export type ColumnPayloads<Row extends CosTableRow> = {
 export const useColumnPayloads = <Row extends CosTableRow>(
   children: ReactNode,
 ): ColumnPayloads<Row> => {
-  const [columns, setColumns] = useState<CosTableColumnProps<Row, keyof Row>[]>(
-    [],
-  )
+  const [columns, setColumns] = useState<CosTableColumnProps<Row>[]>([])
   const rowCompareFnMapRef = useRef<RowCompareFnMap<Row>>({})
 
   useEffect(() => {

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/useColumnPayloads.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/useColumnPayloads.ts
@@ -1,0 +1,57 @@
+import {
+  Children,
+  ReactNode,
+  RefObject,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import { CosTableColumnProps } from './rendering/CosTableColumn'
+import { CosTableRow, isCosTableColumn } from './cosTableUtils'
+import { RowCompareFnMap } from './sorting/sortingUtils'
+
+export type ColumnPayloads<Row extends CosTableRow> = {
+  columns: CosTableColumnProps<Row>[]
+  rowCompareFnMapRef: RefObject<RowCompareFnMap<Row>>
+}
+
+export const useColumnPayloads = <Row extends CosTableRow>(
+  children: ReactNode,
+): ColumnPayloads<Row> => {
+  const [columns, setColumns] = useState<CosTableColumnProps<Row, keyof Row>[]>(
+    [],
+  )
+  const rowCompareFnMapRef = useRef<RowCompareFnMap<Row>>({})
+
+  useEffect(() => {
+    const nextColumns: CosTableColumnProps<Row, keyof Row>[] = []
+    const nextRowCompareFnMap: RowCompareFnMap<Row> = {}
+
+    Children.toArray(children).forEach((child) => {
+      if (!isCosTableColumn(child)) {
+        console.warn(
+          'The children of CosTable can only be CosTableColumn, but found: ',
+          child,
+        )
+        return
+      }
+
+      const columnProps = child.props as CosTableColumnProps<Row>
+      nextColumns.push(columnProps)
+
+      const { property, sortingCompareFnMap } = columnProps
+
+      if (property) {
+        nextRowCompareFnMap[property] = sortingCompareFnMap
+      }
+    })
+
+    setColumns(nextColumns)
+    rowCompareFnMapRef.current = nextRowCompareFnMap
+  }, [children])
+
+  return {
+    columns,
+    rowCompareFnMapRef,
+  }
+}

--- a/packages/cube-frontend-ui-library/src/components/CosStatus/CosStatus.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosStatus/CosStatus.tsx
@@ -8,7 +8,7 @@ export type CosStatusProps = {
 
 const statusCva = cva(
   [
-    'flex h-[17px] cursor-default items-center rounded-[20px] border px-2.5',
+    'flex h-[17px] w-fit cursor-default items-center rounded-[20px] border px-2.5',
     'secondary-body6 font-semibold',
   ],
   {

--- a/packages/cube-frontend-ui-library/src/components/CosTag/CosTag.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosTag/CosTag.tsx
@@ -33,8 +33,8 @@ export type CosTagVariant = 'filled' | 'stroke'
 
 const tag = cva(
   [
-    'inline-flex items-center gap-x-[5px]',
-    'h-[21px] cursor-default rounded-[20px] px-2.5 py-1',
+    'inline-flex items-center gap-x-[5px] whitespace-nowrap',
+    'h-[21px] w-fit cursor-default rounded-[20px] px-2.5 py-1',
     'secondary-body5 font-semibold',
   ],
   {

--- a/packages/cube-frontend-ui-library/src/index.ts
+++ b/packages/cube-frontend-ui-library/src/index.ts
@@ -1,3 +1,5 @@
+export * from './components/CosBasicTable/CosBasicTable'
+export * from './components/CosBasicTable/rendering/CosTableTdSkeleton'
 export * from './components/CosButton/CosButton'
 export * from './components/CosButton/CosButtonSkeleton'
 export * from './components/CosCheckbox/CosCheckbox'

--- a/packages/cube-frontend-ui-library/src/index.ts
+++ b/packages/cube-frontend-ui-library/src/index.ts
@@ -1,5 +1,9 @@
 export * from './components/CosBasicTable/CosBasicTable'
 export * from './components/CosBasicTable/rendering/CosTableTdSkeleton'
+export type {
+  ColumnCompareFnMap,
+  CompareFn,
+} from './components/CosBasicTable/sorting/sortingUtils'
 export * from './components/CosButton/CosButton'
 export * from './components/CosButton/CosButtonSkeleton'
 export * from './components/CosCheckbox/CosCheckbox'

--- a/packages/cube-frontend-ui-library/src/internal/components/CosProgressBar/CosProgressBar.tsx
+++ b/packages/cube-frontend-ui-library/src/internal/components/CosProgressBar/CosProgressBar.tsx
@@ -1,0 +1,52 @@
+import { BackgroundColorClass } from '@cube-frontend/ui-theme'
+import { cva } from 'class-variance-authority'
+import { CSSProperties } from 'react'
+import { twMerge } from 'tailwind-merge'
+
+export type CosProgressBarProps = {
+  color: BackgroundColorClass
+  /**
+   * An integer between 0 and 100 indicating the progress (percentage).
+   */
+  progress: number
+}
+
+const progressCva = cva('absolute h-full', {
+  variants: {
+    isFull: {
+      true: 'rounded-full',
+      false: 'rounded-l-full',
+    },
+  },
+})
+
+export const CosProgressBar = (props: CosProgressBarProps) => {
+  const { color, progress } = props
+
+  // Use inline style because dynamic value is not supported in TailwindCSS.
+  const progressWidthStyle: CSSProperties = {
+    width: `${Math.min(progress, 100)}%`,
+  }
+
+  if (progress < 0) {
+    console.warn('progress value should not be less than 0')
+  }
+
+  return (
+    <div className="inline-flex items-center gap-x-[6px]">
+      <div className="relative h-[9px] w-[60px] rounded-full bg-functional-border-divider">
+        <div
+          className={twMerge(
+            progressCva({
+              isFull: progress >= 100,
+            }),
+            'absolute h-full',
+            color,
+          )}
+          style={progressWidthStyle}
+        />
+      </div>
+      <span className="primary-body5 text-functional-text">{`${progress}%`}</span>
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/internal/components/CosProgressBar/CosProgressBar.tsx
+++ b/packages/cube-frontend-ui-library/src/internal/components/CosProgressBar/CosProgressBar.tsx
@@ -40,7 +40,6 @@ export const CosProgressBar = (props: CosProgressBarProps) => {
             progressCva({
               isFull: progress >= 100,
             }),
-            'absolute h-full',
             color,
           )}
           style={progressWidthStyle}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTable/Basic/Basic.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTable/Basic/Basic.stories.tsx
@@ -1,0 +1,179 @@
+import { CosStatus, CosTag, GetCosBasicTable } from '@cube-frontend/ui-library'
+import { Meta, StoryObj } from '@storybook/react'
+import { CosProgressBar } from '../../../../internal/components/CosProgressBar/CosProgressBar'
+import { StoryLayout } from '../../../../internal/components/StoryLayout/StoryLayout'
+import { MockNode, mockNodes } from '../mockNodes'
+
+const NodeTable = GetCosBasicTable<MockNode>()
+
+const meta = {
+  component: NodeTable,
+} satisfies Meta
+
+export default meta
+
+export const Gallery: StoryObj = {
+  render: () => (
+    <StoryLayout title="Table - Basic">
+      <StoryLayout.Section title="Default">
+        <Default />
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Sortable">
+        <div className=""></div>
+        <Sortable />
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Sortable With Default State">
+        <SortableWithDefaultState />
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Skeleton">
+        <Skeleton />
+      </StoryLayout.Section>
+    </StoryLayout>
+  ),
+}
+
+const Default = () => (
+  <NodeTable rows={mockNodes}>
+    <NodeTable.Column label="Hostname" property="hostname" emphasize={true} />
+    <NodeTable.Column label="Management IP" property="managementIp" />
+    <NodeTable.Column label="Role" property="role">
+      {(role) => (
+        <CosTag color="blue" variant="filled">
+          {role}
+        </CosTag>
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="License Expire" property="licenseExpire">
+      {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
+    </NodeTable.Column>
+    <NodeTable.Column label="CPU" property="cpu">
+      {(cpu) => <CosProgressBar color="bg-chart-1" progress={cpu} />}
+    </NodeTable.Column>
+    <NodeTable.Column label="RAM" property="ram">
+      {(ram) => <CosProgressBar color="bg-chart-2" progress={ram} />}
+    </NodeTable.Column>
+    <NodeTable.Column label="Partition" property="partition">
+      {(partition) => (
+        <CosProgressBar color="bg-chart-3" progress={partition} />
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="Running" property="running">
+      {(running) => `${running.toLocaleString('en-US')} days`}
+    </NodeTable.Column>
+    <NodeTable.Column label="Status" property="status">
+      {(status) => <CosStatus status={status} />}
+    </NodeTable.Column>
+  </NodeTable>
+)
+
+const Sortable = () => (
+  <NodeTable rows={mockNodes}>
+    <NodeTable.Column
+      label="Hostname"
+      property="hostname"
+      emphasize={true}
+      isSortable={true}
+    />
+    <NodeTable.Column label="Management IP" property="managementIp" />
+    <NodeTable.Column label="Role" property="role">
+      {(role) => (
+        <CosTag color="blue" variant="filled">
+          {role}
+        </CosTag>
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="License Expire" property="licenseExpire">
+      {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
+    </NodeTable.Column>
+    <NodeTable.Column label="CPU" property="cpu">
+      {(cpu) => <CosProgressBar color="bg-chart-1" progress={cpu} />}
+    </NodeTable.Column>
+    <NodeTable.Column label="RAM" property="ram" isSortable={true}>
+      {(ram) => <CosProgressBar color="bg-chart-2" progress={ram} />}
+    </NodeTable.Column>
+    <NodeTable.Column label="Partition" property="partition">
+      {(partition) => (
+        <CosProgressBar color="bg-chart-3" progress={partition} />
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="Running" property="running">
+      {(running) => `${running.toLocaleString('en-US')} days`}
+    </NodeTable.Column>
+    <NodeTable.Column label="Status" property="status">
+      {(status) => <CosStatus status={status} />}
+    </NodeTable.Column>
+  </NodeTable>
+)
+
+const SortableWithDefaultState = () => (
+  <NodeTable
+    rows={mockNodes}
+    defaultSortingState={{
+      property: 'hostname',
+      direction: 'descending',
+    }}
+  >
+    <NodeTable.Column
+      label="Hostname"
+      property="hostname"
+      emphasize={true}
+      isSortable={true}
+    />
+    <NodeTable.Column label="Management IP" property="managementIp" />
+    <NodeTable.Column label="Role" property="role">
+      {(role) => (
+        <CosTag color="blue" variant="filled">
+          {role}
+        </CosTag>
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="License Expire" property="licenseExpire">
+      {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
+    </NodeTable.Column>
+    <NodeTable.Column label="CPU" property="cpu">
+      {(cpu) => <CosProgressBar color="bg-chart-1" progress={cpu} />}
+    </NodeTable.Column>
+    <NodeTable.Column label="RAM" property="ram" isSortable={true}>
+      {(ram) => <CosProgressBar color="bg-chart-2" progress={ram} />}
+    </NodeTable.Column>
+    <NodeTable.Column label="Partition" property="partition">
+      {(partition) => (
+        <CosProgressBar color="bg-chart-3" progress={partition} />
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="Running" property="running">
+      {(running) => `${running.toLocaleString('en-US')} days`}
+    </NodeTable.Column>
+    <NodeTable.Column label="Status" property="status">
+      {(status) => <CosStatus status={status} />}
+    </NodeTable.Column>
+  </NodeTable>
+)
+
+const Skeleton = () => (
+  <NodeTable rows={mockNodes} isLoading={true} skeletonRowCount={10}>
+    <NodeTable.Column label="Regular" />
+    <NodeTable.Column
+      label="Subtext Vertical"
+      skeletonVariant="subtext-vertical"
+    />
+    <NodeTable.Column
+      label="Subtext Horizontal"
+      property="role"
+      skeletonVariant="subtext-horizontal"
+    >
+      {/* Skeleton works with custom render function as well. */}
+      {(role) => (
+        <CosTag color="blue" variant="filled">
+          {role}
+        </CosTag>
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="Icon Left" skeletonVariant="icon-left" />
+    <NodeTable.Column label="Icon Right" skeletonVariant="icon-right" />
+    <NodeTable.Column label="Icon Vertical" skeletonVariant="icon-vertical" />
+    <NodeTable.Column label="Icon Only" skeletonVariant="icon-only" />
+    <NodeTable.Column label="With Barchart" skeletonVariant="with-barchart" />
+    <NodeTable.Column label="Status" skeletonVariant="status" />
+  </NodeTable>
+)

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTable/mockNodes.ts
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTable/mockNodes.ts
@@ -1,0 +1,63 @@
+export type MockNode = {
+  id: string
+  hostname: string
+  managementIp: string
+  role: string
+  licenseExpire: Date
+  cpu: number
+  ram: number
+  partition: number
+  running: number
+  status: string
+}
+
+export const mockNodes: MockNode[] = [
+  {
+    id: '5dcc8077-427a-4128-8fa2-470f6f87b451',
+    hostname: 'Dell03',
+    managementIp: '10.32.10.102',
+    role: 'control-converged',
+    licenseExpire: new Date('2025-01-22T01:23:45'),
+    cpu: 33,
+    ram: 34,
+    partition: 33,
+    running: 567,
+    status: 'error',
+  },
+  {
+    id: 'f8732267-4b0f-4976-bb92-20e763dc0f6a',
+    hostname: 'Dell01',
+    managementIp: '10.32.10.100',
+    role: 'control-converged',
+    licenseExpire: new Date('2025-01-20T01:23:45'),
+    cpu: 11,
+    ram: 78,
+    partition: 11,
+    running: 123,
+    status: 'success',
+  },
+  {
+    id: '4cd64b93-d59c-4ded-83ab-7d5c4f158e2e',
+    hostname: 'Dell04',
+    managementIp: '10.32.10.103',
+    role: 'control-converged',
+    licenseExpire: new Date('2025-01-23T01:23:45'),
+    cpu: 80,
+    ram: 125,
+    partition: 170,
+    running: 1357,
+    status: 'running',
+  },
+  {
+    id: 'cdf63e29-9a05-4c67-ab02-e07b7fb086fa',
+    hostname: 'Dell02',
+    managementIp: '10.32.10.101',
+    role: 'control-converged',
+    licenseExpire: new Date('2025-01-21T01:23:45'),
+    cpu: 22,
+    ram: 56,
+    partition: 22,
+    running: 234,
+    status: 'running',
+  },
+]

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/CosBasicTable.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/CosBasicTable.stories.tsx
@@ -1,12 +1,12 @@
-import { CosStatus, CosTag, GetCosBasicTable } from '@cube-frontend/ui-library'
+import { CosStatus, CosTag } from '@cube-frontend/ui-library'
 import { Meta, StoryObj } from '@storybook/react'
 import { CosProgressBar } from '../../../../internal/components/CosProgressBar/CosProgressBar'
 import { StoryLayout } from '../../../../internal/components/StoryLayout/StoryLayout'
-import { MockNode, mockNodes } from '../mockNodes'
-
-const NodeTable = GetCosBasicTable<MockNode>()
+import { CustomSortingRule } from './CustomSortingRule'
+import { mockNodes, NodeTable } from './utils'
 
 const meta = {
+  title: 'organisms/Tables/Basic',
   component: NodeTable,
 } satisfies Meta
 
@@ -19,11 +19,13 @@ export const Gallery: StoryObj = {
         <Default />
       </StoryLayout.Section>
       <StoryLayout.Section title="Sortable">
-        <div className=""></div>
         <Sortable />
       </StoryLayout.Section>
       <StoryLayout.Section title="Sortable With Default State">
         <SortableWithDefaultState />
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Custom Sorting Rule">
+        <CustomSortingRule />
       </StoryLayout.Section>
       <StoryLayout.Section title="Skeleton">
         <Skeleton />

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/CustomSortingRule.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/CustomSortingRule.tsx
@@ -1,0 +1,62 @@
+import {
+  ColumnCompareFnMap,
+  CosStatus,
+  CosTag,
+} from '@cube-frontend/ui-library'
+import { CosProgressBar } from '../../../../internal/components/CosProgressBar/CosProgressBar'
+import { mockNodes, NodeTable } from './utils'
+
+// Sorted in ascending order: running -> success -> error (descending is reversed).
+const statuses: string[] = ['running', 'success', 'error']
+
+const statusCompareFnMap: ColumnCompareFnMap<string> = {
+  ascending: (precedingStatus, followingStatus) => {
+    const precedingStatusIndex = statuses.indexOf(precedingStatus) ?? 100
+    const followingStatusIndex = statuses.indexOf(followingStatus) ?? 100
+    return precedingStatusIndex <= followingStatusIndex
+  },
+  descending: (precedingStatus, followingStatus) => {
+    const precedingStatusIndex = statuses.indexOf(precedingStatus) ?? 100
+    const followingStatusIndex = statuses.indexOf(followingStatus) ?? 100
+    return precedingStatusIndex >= followingStatusIndex
+  },
+}
+
+export const CustomSortingRule = () => (
+  <NodeTable rows={mockNodes}>
+    <NodeTable.Column label="Hostname" property="hostname" emphasize={true} />
+    <NodeTable.Column label="Management IP" property="managementIp" />
+    <NodeTable.Column label="Role" property="role">
+      {(role) => (
+        <CosTag color="blue" variant="filled">
+          {role}
+        </CosTag>
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="License Expire" property="licenseExpire">
+      {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
+    </NodeTable.Column>
+    <NodeTable.Column label="CPU" property="cpu">
+      {(cpu) => <CosProgressBar color="bg-chart-1" progress={cpu} />}
+    </NodeTable.Column>
+    <NodeTable.Column label="RAM" property="ram">
+      {(ram) => <CosProgressBar color="bg-chart-2" progress={ram} />}
+    </NodeTable.Column>
+    <NodeTable.Column label="Partition" property="partition">
+      {(partition) => (
+        <CosProgressBar color="bg-chart-3" progress={partition} />
+      )}
+    </NodeTable.Column>
+    <NodeTable.Column label="Running" property="running">
+      {(running) => `${running.toLocaleString('en-US')} days`}
+    </NodeTable.Column>
+    <NodeTable.Column
+      label="Status"
+      property="status"
+      isSortable={true}
+      sortingCompareFnMap={statusCompareFnMap}
+    >
+      {(status) => <CosStatus status={status} />}
+    </NodeTable.Column>
+  </NodeTable>
+)

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/utils.ts
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/utils.ts
@@ -1,3 +1,7 @@
+import { GetCosBasicTable } from '@cube-frontend/ui-library'
+
+export const NodeTable = GetCosBasicTable<MockNode>()
+
 export type MockNode = {
   id: string
   hostname: string

--- a/packages/cube-frontend-ui-theme/src/cubeTheme.ts
+++ b/packages/cube-frontend-ui-theme/src/cubeTheme.ts
@@ -272,3 +272,11 @@ export type BorderColorClass = `border-${FlattenedObjectKeys<
   // Excluded keys
   'DEFAULT'
 >}`
+
+export type BackgroundColorClass = `bg-${FlattenedObjectKeys<
+  typeof cubeTheme.colors,
+  // Separator
+  '-',
+  // Excluded keys
+  'DEFAULT'
+>}`

--- a/packages/cube-frontend-ui-theme/src/index.ts
+++ b/packages/cube-frontend-ui-theme/src/index.ts
@@ -1,5 +1,5 @@
 export * from './cubePreset'
-export type { BorderColorClass } from './cubeTheme'
+export type { BackgroundColorClass, BorderColorClass } from './cubeTheme'
 export type {
   FontAttributes,
   FontConfiguration,


### PR DESCRIPTION
Close #43 

https://github.com/user-attachments/assets/c60fa7de-98e8-45f1-81cf-0782e3601b9e

## Note

- Basic table covers only the **emphasize**, **hover**, **sort**, and **skeleton** functionalities.
- Currently, users can only sort the data by **1 column** at a time (same as [MUI](https://mui.com/material-ui/react-table/?srsltid=AfmBOoquioMNMoGeVrMrVEpMoIo9K3Ts4p8X0XB0gERtqTpGJg4PGmjK#sorting-amp-selecting)).

## Usage

### Basic

```tsx
type Node = {
  id: string
  name: string
  status: string
  otherAttribute: anything
}

const nodes: Node[] = [...]

const NodeTable = GetCosBasicTable<Node>()

<NodeTable rows={nodes}>
  <NodeTable.Column label="Name" property="name" emphasize={true} />
  <NodeTable.Column label="Status" property="status">
    {/* `status` is correctly inferred as string. */}
    {(status) => <CosStatus status={status} />}
  </>
</NodeTable>
```

### Skeleton

```tsx
export type CosTableColumnSkeletonVariant =
  | 'regular' // <- Default value
  | 'subtext-vertical'
  | 'subtext-horizontal'
  | 'icon-left'
  | 'icon-right'
  | 'icon-vertical'
  | 'icon-only'
  | 'with-barchart'
  | 'status'

<NodeTable rows={...} isLoading={true} skeletonRows={10}>
  <NodeTable.Column skeletonVariat="subtext-vertical" />
</NodeTable>
```