### PR TITLE
feat: add medium-small icon size and update large icon size

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosHyperlink/CosHyperlink.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosHyperlink/CosHyperlink.tsx
@@ -1,7 +1,7 @@
-import { SvgComponent } from '../CosIcon/CosIcon'
+import { IconSize, SvgComponent } from '../CosIcon/CosIcon'
 import { createElement } from 'react'
 import { cva } from 'class-variance-authority'
-import { twMerge } from 'tailwind-merge'
+import { twJoin, twMerge } from 'tailwind-merge'
 import { getIconSizeClass } from '../CosIcon/utils'
 
 export type CosHyperlinkColor = 'primary' | 'secondary'
@@ -74,20 +74,30 @@ export const CosHyperlink = (props: CosHyperlinkProps) => {
     href,
   } = props
 
-  const renderLeftIcon = () => {
-    if (variant === 'icon-left') {
-      const { Icon } = props
-      return Icon && <Icon className={getIconSizeClass(size)} />
+  const renderIcon = (iconVariant: 'icon-left' | 'icon-right') => {
+    if (props.variant !== iconVariant) {
+      return null
     }
-    return undefined
-  }
 
-  const renderRightIcon = () => {
-    if (variant === 'icon-right') {
-      const { Icon } = props
-      return Icon && <Icon className={getIconSizeClass(size)} />
+    const { Icon } = props
+
+    const sizeMapping: Record<
+      CosHyperlinkSize,
+      { iconSize: IconSize; iconFrameSize: string }
+    > = {
+      sm: { iconSize: 'sm', iconFrameSize: twJoin('size-[15px]') },
+      md: { iconSize: 'md-sm', iconFrameSize: twJoin('size-[17px]') },
     }
-    return undefined
+    const { iconSize, iconFrameSize } = sizeMapping[size]
+    const iconSizeClass = getIconSizeClass(iconSize)
+
+    return (
+      <div
+        className={twMerge('flex items-center justify-center', iconFrameSize)}
+      >
+        <Icon className={iconSizeClass} />
+      </div>
+    )
   }
 
   const renderHyperlink = () => {
@@ -101,9 +111,9 @@ export const CosHyperlink = (props: CosHyperlinkProps) => {
         className: twMerge(hyperlink({ color, size, variant, disabled })),
         href: hrefAttribute,
       },
-      renderLeftIcon(),
+      renderIcon('icon-left'),
       children,
-      renderRightIcon(),
+      renderIcon('icon-right'),
     )
   }
 

--- a/packages/cube-frontend-ui-library/src/components/CosIcon/CosIcon.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosIcon/CosIcon.tsx
@@ -3,7 +3,7 @@ import { getContainerClasses, getIconClasses } from './utils'
 
 import type SvgComponentInstance from '*.svg?react'
 
-export type IconSize = 'xs' | 'sm' | 'md' | 'lg' | 'xl'
+export type IconSize = 'xs' | 'sm' | 'md-sm' | 'md' | 'lg' | 'xl'
 
 export type SvgComponent = typeof SvgComponentInstance
 

--- a/packages/cube-frontend-ui-library/src/components/CosIcon/utils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosIcon/utils.ts
@@ -10,6 +10,10 @@ const sizeClasses: Record<IconSize, Record<'container' | 'icon', string>> = {
     container: twMerge('icon-frame-sm'),
     icon: twMerge('icon-sm'),
   },
+  'md-sm': {
+    container: twMerge('icon-frame-md-sm'),
+    icon: twMerge('icon-md-sm'),
+  },
   md: {
     container: twMerge('icon-frame-md'),
     icon: twMerge('icon-md'),

--- a/packages/cube-frontend-ui-library/src/stories/designTokens/Icon/index.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/designTokens/Icon/index.stories.tsx
@@ -99,6 +99,13 @@ export const Size: Story = {
             />,
           )}
           {renderSizeRow(
+            'Medium-Small',
+            <Home01
+              className={twMerge('icon-md-sm', className)}
+              onClick={onClick}
+            />,
+          )}
+          {renderSizeRow(
             'Medium',
             <Home01
               className={twMerge('icon-md', className)}
@@ -130,6 +137,12 @@ export const Size: Story = {
           {renderSizeRow(
             'Small',
             <CosIconFrame size="sm" className={className} onClick={onClick}>
+              <Warning />
+            </CosIconFrame>,
+          )}
+          {renderSizeRow(
+            'Medium-Small',
+            <CosIconFrame size="md-sm" className={className} onClick={onClick}>
               <Warning />
             </CosIconFrame>,
           )}

--- a/packages/cube-frontend-ui-library/src/stories/designTokens/Icon/utils.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/designTokens/Icon/utils.tsx
@@ -31,7 +31,7 @@ export const coloredIcons = getIcons(coloredModule)
 
 export const renderSizeRow = (title: string, icon: React.ReactNode) => (
   <div className="flex h-16 items-center">
-    <h3 className="w-[120px] font-inter text-secondary-h5 text-functional-text">
+    <h3 className="min-w-[180px] font-inter text-secondary-h5 text-functional-text">
       {title}
     </h3>
     {icon}

--- a/packages/cube-frontend-ui-theme/src/plugins/iconPlugin.ts
+++ b/packages/cube-frontend-ui-theme/src/plugins/iconPlugin.ts
@@ -18,6 +18,14 @@ export const iconPlugin: PluginCreator = ({ addComponents }) => {
       width: '24px',
       height: '24px',
     },
+    '.icon-md-sm': {
+      width: '14px',
+      height: '14px',
+    },
+    '.icon-frame-md-sm': {
+      width: '28px',
+      height: '28px',
+    },
     '.icon-md': {
       width: '16px',
       height: '16px',
@@ -27,8 +35,8 @@ export const iconPlugin: PluginCreator = ({ addComponents }) => {
       height: '32px',
     },
     '.icon-lg': {
-      width: '20px',
-      height: '20px',
+      width: '18px',
+      height: '18px',
     },
     '.icon-frame-lg': {
       width: '40px',


### PR DESCRIPTION
1. feat: add medium-small icon size
2. feat: update large icon size: 20px -> 18px
3. fix: `CosHyperLink` icon incorrect size

Figma:
<img width="1263" alt="Screenshot 2025-02-03 at 10 41 08 AM" src="https://github.com/user-attachments/assets/dfee3b62-ff00-43f3-b24b-436c3760c52b" />

Storybook add icon size:
<img width="735" alt="Screenshot 2025-02-03 at 10 43 49 AM" src="https://github.com/user-attachments/assets/6cc00f8e-d478-495b-a154-fb15524d636f" />


