### PR TITLE
refactor: organize storybook by atoms molecules and organisms

### DIFF
--- a/packages/cube-frontend-ui-library/.storybook/preview.ts
+++ b/packages/cube-frontend-ui-library/.storybook/preview.ts
@@ -12,7 +12,13 @@ const preview: Preview = {
   parameters: {
     options: {
       storySort: {
-        order: ['designTokens', 'components'],
+        order: [
+          'Design Tokens',
+          ['Color', 'Typography', 'Icon'],
+          'Atoms',
+          'Molecules',
+          'Organisms',
+        ],
       },
     },
     controls: {

--- a/packages/cube-frontend-ui-library/src/stories/components/CosButton/CosButton.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosButton/CosButton.stories.tsx
@@ -3,6 +3,7 @@ import { Button, CubeButtonSize } from '../../../components/Button/Button'
 import ButtonSkeleton from '../../../components/Button/ButtonSkeleton'
 
 const meta = {
+  title: 'Atoms/Button',
   component: Button,
 } satisfies Meta<typeof Button>
 

--- a/packages/cube-frontend-ui-library/src/stories/components/CosHyperlink/CosHyperlink.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosHyperlink/CosHyperlink.stories.tsx
@@ -5,6 +5,7 @@ import Home01 from '../../../components/CosIcon/monochrome/home_01.svg?react'
 import { HyperlinkBox } from './HyperlinkBox'
 
 const meta = {
+  title: 'Atoms/Hyperlink',
   component: CosHyperlink,
 } satisfies Meta<typeof CosHyperlink>
 

--- a/packages/cube-frontend-ui-library/src/stories/components/CosInput/CosInput.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosInput/CosInput.stories.tsx
@@ -7,6 +7,7 @@ import { ChangeEventHandler, useState } from 'react'
 import { fn } from '@storybook/test'
 
 const meta = {
+  title: 'Molecules/Input',
   args: {
     onChange: fn(),
   },

--- a/packages/cube-frontend-ui-library/src/stories/components/CosLoadingSpinner/CosLoadingSpinner.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosLoadingSpinner/CosLoadingSpinner.stories.tsx
@@ -4,6 +4,7 @@ import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayou
 import { SpinnerRow } from './SpinnerRow'
 
 const meta = {
+  title: 'Atoms/LoadingSpinner',
   component: CosLoadingSpinner,
 } satisfies Meta<typeof CosLoadingSpinner>
 

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNagging/CosNagging.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNagging/CosNagging.stories.tsx
@@ -8,6 +8,7 @@ import {
 } from './NaggingBox'
 
 const meta = {
+  title: 'Molecules/Nagging',
   component: CosNagging,
 } satisfies Meta<typeof CosNagging>
 

--- a/packages/cube-frontend-ui-library/src/stories/components/CosStatus/CosStatus.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosStatus/CosStatus.stories.tsx
@@ -4,6 +4,7 @@ import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayou
 import { StatusRow } from './StatusRow'
 
 const meta = {
+  title: 'Atoms/Status',
   component: CosStatus,
 } satisfies Meta<typeof CosStatus>
 

--- a/packages/cube-frontend-ui-library/src/stories/components/CosStroke/CosStroke.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosStroke/CosStroke.stories.tsx
@@ -4,6 +4,7 @@ import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayou
 import { StrokeBox } from './StrokeBox'
 
 const meta = {
+  title: 'Atoms/Stroke',
   component: CosStroke,
 } satisfies Meta<typeof CosStroke>
 

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTableInput/CosTableInput.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTableInput/CosTableInput.stories.tsx
@@ -9,6 +9,7 @@ import { ChangeEventHandler, useState } from 'react'
 import { fn } from '@storybook/test'
 
 const meta = {
+  title: 'Molecules/TableInput',
   argTypes: {
     onChange: fn(),
   },

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTabs/CosTabs.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTabs/CosTabs.stories.tsx
@@ -5,12 +5,12 @@ import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayou
 import { TabsRow } from './TabsRow'
 
 const meta = {
-  title: 'components/Tabs',
+  title: 'Molecules/Tabs',
 } satisfies Meta<typeof CosTabs>
 
 export default meta
 
-export const Tabs: StoryObj = {
+export const Gallery: StoryObj = {
   render: () => <TabsGallery />,
 }
 

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTag/CosTag.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTag/CosTag.stories.tsx
@@ -4,16 +4,16 @@ import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayou
 import { TagLayout } from './TagLayout'
 
 const meta = {
-  title: 'components/Tags',
+  title: 'Atoms/Tags',
 } satisfies Meta<typeof CosTag>
 
 export default meta
 
-export const TagStory: StoryObj = {
-  render: () => <Gallery />,
+export const Gallery: StoryObj = {
+  render: () => <TagGallery />,
 }
 
-const Gallery = () => {
+const TagGallery = () => {
   return (
     <StoryLayout title="Tags">
       <StoryLayout.Section title="Default">

--- a/packages/cube-frontend-ui-library/src/stories/components/CosToggle/CosToggle.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosToggle/CosToggle.stories.tsx
@@ -6,12 +6,12 @@ import { ToggleRow } from './ToggleRow'
 import { ToggleRowHeader } from './ToggleRowHeader'
 
 const meta = {
-  title: 'components/Toggle',
+  title: 'Atoms/Toggle',
 } satisfies Meta
 
 export default meta
 
-export const Toggle: StoryObj = {
+export const Gallery: StoryObj = {
   render: () => <ToggleGallery />,
 }
 

--- a/packages/cube-frontend-ui-library/src/stories/designTokens/Color/Color.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/designTokens/Color/Color.stories.tsx
@@ -4,7 +4,9 @@ import { ColorBox } from './ColorBox'
 import { ColorPaletteRow } from './ColorPaletteRow'
 import { ColorScale } from './ColorScale'
 
-const meta = {} satisfies Meta
+const meta = {
+  title: 'Design Tokens/Color',
+} satisfies Meta
 
 export default meta
 

--- a/packages/cube-frontend-ui-library/src/stories/designTokens/Icon/Icon.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/designTokens/Icon/Icon.stories.tsx
@@ -9,6 +9,7 @@ import { IconGallery } from './IconGallery'
 import { fn } from '@storybook/test'
 
 const meta = {
+  title: 'Design Tokens/Icon',
   component: CosIconFrame,
   args: {
     onClick: fn(),

--- a/packages/cube-frontend-ui-library/src/stories/designTokens/Typography/Typography.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/designTokens/Typography/Typography.stories.tsx
@@ -5,7 +5,9 @@ import { BodyBoxHeader } from './BodyBoxHeader'
 import { HeadingBox } from './HeadingBox'
 import { Typeface } from './Typeface'
 
-const meta = {} satisfies Meta
+const meta = {
+  title: 'Design Tokens/Typography',
+} satisfies Meta
 
 export default meta
 


### PR DESCRIPTION
1. According to our design guidelines, split the components into `Atoms`, `Molecules` and `Organisms`.
2. Since our storybook is for developers and `designers`, we decided to remove `Cos` prefix to prevent confusion.
3. Rename `index.stories.tsx` to `{ComponentName}.stories.tsx` for a better VSCode file search experience for developers.
4. We decided not to use `route-based` Storybook hierarchy, so we need to define `title` in each stories meta.

<img width="734" alt="Screenshot 2025-02-03 at 11 14 00 AM" src="https://github.com/user-attachments/assets/9e182b56-4438-4fad-9220-9069b62d2604" />

<img width="316" alt="Screenshot 2025-02-03 at 11 22 38 AM" src="https://github.com/user-attachments/assets/2f3366da-549a-4994-a987-c0e93cc9c552" />

storybook reference: https://storybook.js.org/docs/writing-stories/naming-components-and-hierarchy


