### PR TITLE
feat(keycloak-login): pass login greeting messages onto Keycloak login page

### DIFF
--- a/packages/cube-frontend-keycloak-login/docker-compose.yaml
+++ b/packages/cube-frontend-keycloak-login/docker-compose.yaml
@@ -10,6 +10,7 @@ services:
       # The new `KC_DB_USERNAME` and `KC_DB_PASSWORD` won't work.
       KEYCLOAK_USER: admin
       KEYCLOAK_PASSWORD: admin
+      LOGIN_GREETING:
     volumes:
       - ./keycloak/themes/cos-ui:/opt/jboss/keycloak/themes/cos-ui:ro
     restart: unless-stopped

--- a/packages/cube-frontend-keycloak-login/keycloak/themes/cos-ui/login/login.ftl
+++ b/packages/cube-frontend-keycloak-login/keycloak/themes/cos-ui/login/login.ftl
@@ -6,8 +6,7 @@
                 resourcesPath: '${url.resourcesPath}',
                 incorrectCredentials: ${messagesPerField.existsError('username','password')?c},
                 sessionTimedOut: <#if message?has_content && message.type == 'error' && message.summary?contains('timed out')>true<#else>false</#if>,
-                // Remove all `amp;` because the `actionUrl` retrieved from FreeMarker has `amp;` after every `&` character.
-                formActionUrl: '${url.loginAction}'.replace(/amp;/g, ''),
+                formActionUrl: '${url.loginAction?js_string?no_esc}',
                 authSelectedCredentials: <#if auth.selectedCredential?has_content>"${auth.selectedCredential}"<#else>undefined</#if>,
                 loginGreeting: '${properties.loginGreeting?js_string?no_esc}',
             }

--- a/packages/cube-frontend-keycloak-login/keycloak/themes/cos-ui/login/login.ftl
+++ b/packages/cube-frontend-keycloak-login/keycloak/themes/cos-ui/login/login.ftl
@@ -9,6 +9,7 @@
                 // Remove all `amp;` because the `actionUrl` retrieved from FreeMarker has `amp;` after every `&` character.
                 formActionUrl: '${url.loginAction}'.replace(/amp;/g, ''),
                 authSelectedCredentials: <#if auth.selectedCredential?has_content>"${auth.selectedCredential}"<#else>undefined</#if>,
+                loginGreeting: '${properties.loginGreeting?js_string?no_esc}',
             }
         </script>
         <div id="kc-form-wrapper" style="height: 100%;"></div>

--- a/packages/cube-frontend-keycloak-login/keycloak/themes/cos-ui/login/theme.properties
+++ b/packages/cube-frontend-keycloak-login/keycloak/themes/cos-ui/login/theme.properties
@@ -3,3 +3,5 @@ import=common/keycloak
 
 styles=css/index.css
 scripts=js/index.js
+
+loginGreeting=${env.LOGIN_GREETING:}

--- a/packages/cube-frontend-keycloak-login/src/components/LoginForm/LoginHeader.tsx
+++ b/packages/cube-frontend-keycloak-login/src/components/LoginForm/LoginHeader.tsx
@@ -1,6 +1,8 @@
 import CubeCOSLogo from '@cube-frontend/ui-library/assets/cubecos_full_logo.svg?react'
 
 export const LoginHeader = () => {
+  const { loginGreeting } = window.keycloakLoginContext
+
   return (
     <header className="flex flex-col gap-y-4">
       <CubeCOSLogo className="w-[133px]" />
@@ -8,7 +10,9 @@ export const LoginHeader = () => {
         Log in to the Data Center
       </h1>
       <p className="primary-body2 text-functional-text">
-        Welcome to COS cloud service platform!
+        {loginGreeting.length > 0
+          ? loginGreeting
+          : 'Welcome to COS cloud service platform!'}
       </p>
     </header>
   )

--- a/packages/cube-frontend-keycloak-login/src/components/LoginForm/LoginHeader.tsx
+++ b/packages/cube-frontend-keycloak-login/src/components/LoginForm/LoginHeader.tsx
@@ -10,9 +10,7 @@ export const LoginHeader = () => {
         Log in to the Data Center
       </h1>
       <p className="primary-body2 text-functional-text">
-        {loginGreeting.length > 0
-          ? loginGreeting
-          : 'Welcome to COS cloud service platform!'}
+        {loginGreeting || 'Welcome to COS cloud service platform!'}
       </p>
     </header>
   )

--- a/packages/cube-frontend-keycloak-login/src/keycloakLoginContext.d.ts
+++ b/packages/cube-frontend-keycloak-login/src/keycloakLoginContext.d.ts
@@ -15,5 +15,6 @@ interface Window {
     sessionTimedOut: boolean
     formActionUrl: string
     authSelectedCredentials: string | undefined
+    loginGreeting: string
   }
 }

--- a/packages/cube-frontend-keycloak-login/src/keycloakLoginContextSetupDev.ts
+++ b/packages/cube-frontend-keycloak-login/src/keycloakLoginContextSetupDev.ts
@@ -6,5 +6,6 @@ if (import.meta.env.DEV) {
     formActionUrl:
       'http://localhost:8642/auth/realms/master/login-actions/authenticate?session_code=a6ESSp_K4BexArNGC3-vShOEDcO79tvomSu8SJrN8_k&execution=336de572-f999-43b8-af68-961e86711af7&client_id=security-admin-console&tab_id=AQCFEittHgs',
     authSelectedCredentials: undefined,
+    loginGreeting: '',
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

feature

#### What this PR does / why we need it

- Pull the login greeting message from env, and display it on LoginHeader.
- Escape apostrophe (single quote, ') using `?js_string` directive, and use `?no_esc` directive to prevent auto-escaping mechanism of FreeMarker to escape apostrophe as `&#39;`.

#### Which issue(s) this PR fixes

Close #92 
Close https://github.com/bigstack-oss/cube-cos-api/issues/15 

#### Special notes for your reviewer

#### Additional documentation
