### PR TITLE
fix: cos stream request loading state incorrect

### DIFF
--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosStreamRequest.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosStreamRequest.ts
@@ -124,6 +124,7 @@ export const useCosStreamRequest: UseCosStreamRequestHook = <
   }, [])
 
   const unsubscribe = useCallback(() => {
+    setIsLoading(false)
     isFirstStreamResponseRef.current = true
     abortControllerRef.current?.abort()
     abortControllerRef.current = null


### PR DESCRIPTION
When the unsubscribe occurs before the first loading is complete, the loading should be set to false.

Demo:

![Screen Recording 2025-02-22 at 6 46 05 PM](https://github.com/user-attachments/assets/b763df2c-bc0e-4782-a2e2-60575f907190)

reference: https://github.com/bigstack-oss/cube-cos-ui/pull/103#pullrequestreview-2631560568
