### PR TITLE
feat(ui-library): count segmented chart

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosCountSegmentedChart/ColorDot.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCountSegmentedChart/ColorDot.tsx
@@ -1,0 +1,18 @@
+import { FillColorClass } from '@cube-frontend/ui-theme'
+
+const SIZE = 6
+
+const radius = SIZE / 2
+
+type ColorDotProps = {
+  color: FillColorClass
+}
+export const ColorDot = (props: ColorDotProps) => {
+  const { color } = props
+
+  return (
+    <svg viewBox={`0 0 ${SIZE} ${SIZE}`} width={SIZE} height={SIZE}>
+      <circle className={color} cx={radius} cy={radius} r={radius} />
+    </svg>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosCountSegmentedChart/CosCountSegmentedChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCountSegmentedChart/CosCountSegmentedChart.tsx
@@ -1,0 +1,36 @@
+import { CosSegmentedBar } from '../CosSegmentedBar/CosSegmentedBar'
+import { useMemo } from 'react'
+import { Segment } from '../CosSegmentedBar/cosSegmentedBarUtils'
+import { CosCountSegmentedChartCountInfo, mapToSegment } from './utils'
+import { CountInfo } from './CountInfo'
+
+export type CosCountSegmentedChartOverview = Pick<
+  CosCountSegmentedChartCountInfo,
+  'name' | 'count'
+>
+
+export type CosCountSegmentedChartProps = {
+  overview?: CosCountSegmentedChartOverview
+  countInfos: CosCountSegmentedChartCountInfo[]
+}
+
+export const CosCountSegmentedChart = (props: CosCountSegmentedChartProps) => {
+  const { overview, countInfos } = props
+
+  const segments = useMemo<Segment[]>(
+    () => countInfos.map(mapToSegment),
+    [countInfos],
+  )
+
+  return (
+    <div className="flex flex-col gap-y-3">
+      <CosSegmentedBar rounded segments={segments} />
+      <div className="flex flex-row items-center justify-between">
+        {overview && <CountInfo {...overview}></CountInfo>}
+        {countInfos.map((segment) => (
+          <CountInfo key={segment.name} {...segment} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosCountSegmentedChart/CountInfo.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCountSegmentedChart/CountInfo.tsx
@@ -1,0 +1,21 @@
+import { Optional } from '@cube-frontend/utils'
+import { CosCountSegmentedChartCountInfo } from './utils'
+import { ColorDot } from './ColorDot'
+
+type CountInfoProps = Optional<CosCountSegmentedChartCountInfo, 'color'>
+
+export const CountInfo = (props: CountInfoProps) => {
+  const { name, color, count } = props
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <div className="flex items-center justify-between gap-x-1">
+        {color && <ColorDot color={color} />}
+        <span className="primary-body5 text-functional-text-light">{name}</span>
+      </div>
+      <span className="primary-body2 self-end text-functional-text">
+        {count}
+      </span>
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosCountSegmentedChart/utils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosCountSegmentedChart/utils.ts
@@ -1,0 +1,17 @@
+import { FillColorClass } from '@cube-frontend/ui-theme'
+import { Segment } from '../CosSegmentedBar/cosSegmentedBarUtils'
+
+export type CosCountSegmentedChartCountInfo = {
+  name: string
+  count: number
+  color: FillColorClass
+}
+
+export const mapToSegment = (
+  countInfo: CosCountSegmentedChartCountInfo,
+): Segment => {
+  return {
+    colCount: countInfo.count,
+    color: countInfo.color,
+  }
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCountSegmentedChart/CosCountSegmentedChart.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCountSegmentedChart/CosCountSegmentedChart.stories.tsx
@@ -1,0 +1,43 @@
+import { CosCountSegmentedChart } from '../../../components/CosCountSegmentedChart/CosCountSegmentedChart'
+import type { Meta, StoryObj } from '@storybook/react'
+import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
+import { vmSummary, roleSummary } from './mockCountInfos'
+
+const meta = {
+  title: 'Molecules/Chart/Count Segmented Chart',
+} satisfies Meta<typeof CosCountSegmentedChart>
+
+export default meta
+
+export const Gallery: StoryObj = {
+  render: () => <CountSegmentedChartGallery />,
+}
+
+const CountSegmentedChartGallery = () => {
+  const vmTotalCount = vmSummary.reduce((total, countInfo) => {
+    return total + countInfo.count
+  }, 0)
+
+  return (
+    <StoryLayout title="Count Segmented Chart">
+      <StoryLayout.Section title="With Overview">
+        <div className="flex flex-col gap-y-6">
+          <CosCountSegmentedChart
+            overview={{ name: 'Total VM', count: vmTotalCount }}
+            countInfos={vmSummary}
+          />
+          <CosCountSegmentedChart
+            overview={{ name: 'Control-convergerd', count: 2 }}
+            countInfos={roleSummary}
+          />
+        </div>
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Without Overview">
+        <div className="flex flex-col gap-y-6">
+          <CosCountSegmentedChart countInfos={vmSummary} />
+          <CosCountSegmentedChart countInfos={roleSummary} />
+        </div>
+      </StoryLayout.Section>
+    </StoryLayout>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCountSegmentedChart/mockCountInfos.ts
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCountSegmentedChart/mockCountInfos.ts
@@ -1,0 +1,47 @@
+import { CosCountSegmentedChartCountInfo } from '../../../components/CosCountSegmentedChart/utils'
+
+export const vmSummary = [
+  {
+    name: 'Running',
+    color: 'fill-chart-2',
+    count: 51,
+  },
+  {
+    name: 'Stopped',
+    color: 'fill-chart-4',
+    count: 1,
+  },
+  {
+    name: 'Suspended',
+    color: 'fill-chart-3',
+    count: 1,
+  },
+  {
+    name: 'Paused',
+    color: 'fill-chart-6',
+    count: 1,
+  },
+  {
+    name: 'Error',
+    color: 'fill-status-negative',
+    count: 1,
+  },
+] satisfies CosCountSegmentedChartCountInfo[]
+
+export const roleSummary = [
+  {
+    name: 'Control',
+    color: 'fill-chart-1',
+    count: 1,
+  },
+  {
+    name: 'Compute',
+    color: 'fill-chart-2',
+    count: 1,
+  },
+  {
+    name: 'Storage',
+    color: 'fill-chart-3',
+    count: 1,
+  },
+] satisfies CosCountSegmentedChartCountInfo[]

--- a/packages/cube-frontend-ui-library/src/stories/components/CosSegmentedBar/CosSegmentedBar.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosSegmentedBar/CosSegmentedBar.stories.tsx
@@ -10,7 +10,7 @@ import {
 } from './mockSegments'
 
 const meta = {
-  title: 'Molecules/Segmented Bar',
+  title: 'Atoms/Segmented Bar',
 } satisfies Meta<typeof CosSegmentedBar>
 
 export default meta

--- a/packages/cube-frontend-utils/src/generic-types.ts
+++ b/packages/cube-frontend-utils/src/generic-types.ts
@@ -18,3 +18,5 @@ export type FlattenedObjectKeys<
 > = FlattenObjectKeysInternal<T, Separator, ExcludedKeys>
 
 export type ValueOfSet<T> = T extends Set<infer Value> ? Value : never
+
+export type Optional<T, K extends keyof T> = Pick<Partial<T>, K> & Omit<T, K>


### PR DESCRIPTION
1. Implement the `CosCountSegmentedChart`, which is used on the Home and Chart pages.
2. Move `CosSegmented` to atom-level component.

<img width="1914" alt="image" src="https://github.com/user-attachments/assets/8543638e-aef8-4e3b-9995-70711f4546d9" />
