### PR TITLE
fix(ui-library): table show double border in panel

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosPanel/CosPanel.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPanel/CosPanel.tsx
@@ -9,10 +9,20 @@ import { CosPanelContentItem } from './CosPanelContentItem'
 
 export type CosPanelProps = PropsWithChildren &
   PropsWithClassName &
-  CosPanelHeaderProps
+  CosPanelHeaderProps & {
+    /**
+     * @default true
+     */
+    useContentWrapper?: boolean
+  }
 
 export const CosPanel = (props: CosPanelProps) => {
-  const { className: classNameProp, children, ...restProps } = props
+  const {
+    className: classNameProp,
+    useContentWrapper = true,
+    children,
+    ...headerProps
+  } = props
 
   const className = twMerge(
     'flex w-full flex-col gap-y-3 rounded-[5px] bg-grey-0 p-4',
@@ -24,8 +34,12 @@ export const CosPanel = (props: CosPanelProps) => {
       className={className}
       style={{ boxShadow: '0px 0px 2px 0px rgba(0, 0, 0, 0.20)' }}
     >
-      <CosPanelHeader {...restProps} />
-      <CosPanelContentBox>{children}</CosPanelContentBox>
+      <CosPanelHeader {...headerProps} />
+      {useContentWrapper ? (
+        <CosPanelContentBox>{children}</CosPanelContentBox>
+      ) : (
+        children
+      )}
     </div>
   )
 }

--- a/packages/cube-frontend-ui-library/src/stories/components/CosPanel/UsageSection.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosPanel/UsageSection.tsx
@@ -89,6 +89,7 @@ export const UsageSection = () => {
             title="Events"
             time="yyyy/mm/dd 00:00"
             hyperLinkProps={{ onClick: noop }}
+            useContentWrapper={false}
           >
             <EventTable rows={events}>
               <EventTable.Column property="type" label="Type" />


### PR DESCRIPTION
fix(ui-library): table show double border in panel.

https://github.com/bigstack-oss/cube-cos-ui/pull/112#discussion_r1977134880

Screenshot:

<img width="1566" alt="image" src="https://github.com/user-attachments/assets/23c8a142-e210-4f93-9d5b-474de0c6139b" />
