### PR TITLE
feat(web-app): bind onClick function to the FunctionBar

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosHeader/FunctionBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosHeader/FunctionBar.tsx
@@ -31,6 +31,7 @@ export const FunctionBar = (props: FunctionBarProps) => {
           type="ghost"
           usage="icon-only"
           Icon={button.Icon}
+          onClick={button.onClick}
         />
       ))}
     </div>


### PR DESCRIPTION
Close #150

It seems that redirection is already handled by Axios, but it's currently blocked by CORS.
We should test this feature only on staging.

<img width="269" alt="{8737D715-5256-4778-B54B-375AF3A8770C}" src="https://github.com/user-attachments/assets/55dadbdc-3f93-4ac4-afe2-b639011c666c" />
