### PR TITLE
fix(ui-library): 133 rounded segmented bar incorrect display

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosSegmentedBar/CosSegmentedBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSegmentedBar/CosSegmentedBar.tsx
@@ -56,18 +56,27 @@ export const CosSegmentedBar = (props: CosSegmentedBarProps) => {
     throw new Error('width must be greater than 0')
   }
 
+  /**
+   * To ensure that the left-most and right-most rounded sides are display correctly,
+   * we need to filter out segments with 0 cols.
+   */
+  const displaySegments = useMemo<Segment[]>(
+    () => segments.filter((segment) => segment.colCount > 0),
+    [segments],
+  )
+
   const { svgRef, barWidth } = useSegmentedBarWidth(width)
 
   const totalColCount = useMemo<number>(
-    () => segments.reduce((sum, segment) => sum + segment.colCount, 0),
-    [segments],
+    () => displaySegments.reduce((sum, segment) => sum + segment.colCount, 0),
+    [displaySegments],
   )
 
   const rectDimensions = useMemo<RectDimensions[]>(() => {
     const result: RectDimensions[] = []
     let accumulatedLeft = 0
 
-    segments.forEach((segment) => {
+    displaySegments.forEach((segment) => {
       const width = barWidth * (segment.colCount / totalColCount)
 
       result.push({
@@ -79,11 +88,11 @@ export const CosSegmentedBar = (props: CosSegmentedBarProps) => {
     })
 
     return result
-  }, [segments, totalColCount, barWidth])
+  }, [displaySegments, totalColCount, barWidth])
 
   const computeRoundedSide = (index: number): RoundedSide => {
     const isFirst = index === 0
-    const isLast = index === segments.length - 1
+    const isLast = index === displaySegments.length - 1
 
     if (isFirst && isLast) {
       // There's only 1 segment.
@@ -118,7 +127,7 @@ export const CosSegmentedBar = (props: CosSegmentedBarProps) => {
       width={barWidth}
       height={svgHeight}
     >
-      {segments.map((segment, index) => (
+      {displaySegments.map((segment, index) => (
         <CosTooltip key={index} hoverContent={segment.hoverContent}>
           <SegmentedRect
             color={segment.color}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosSegmentedBar/mockSegments.ts
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosSegmentedBar/mockSegments.ts
@@ -2,6 +2,10 @@ import { Segment } from '@cube-frontend/ui-library'
 
 export const vmSummarySegments: Segment[] = [
   {
+    color: 'fill-chart-1',
+    colCount: 0,
+  },
+  {
     color: 'fill-chart-2',
     colCount: 51,
   },
@@ -20,6 +24,10 @@ export const vmSummarySegments: Segment[] = [
   {
     color: 'fill-status-negative',
     colCount: 1,
+  },
+  {
+    color: 'fill-chart-7',
+    colCount: 0,
   },
 ]
 


### PR DESCRIPTION
Closes #133

## Screenshots

### UI Library

I added 0-col segments to the first and last segment as a test case:

<img width="528" alt="Screenshot 2025-03-10 at 10 15 45 PM" src="https://github.com/user-attachments/assets/66263726-da96-4848-955c-3a3e843eee09" />

<img width="1512" alt="Screenshot 2025-03-10 at 10 17 23 PM" src="https://github.com/user-attachments/assets/dc863611-3b00-4261-a27e-367b78cb0e60" />


### Home Page

<img width="1502" alt="Screenshot 2025-03-10 at 10 14 40 PM" src="https://github.com/user-attachments/assets/b47f5b46-6c74-436a-9dfe-2fa1271e452d" />


