### PR TITLE
feat(web-app): set api response interceptor to perform SAML auth

### DIFF
--- a/packages/cube-frontend-web-app/src/api/cosApi.ts
+++ b/packages/cube-frontend-web-app/src/api/cosApi.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance, AxiosResponse } from 'axios'
+import axios, { AxiosInstance } from 'axios'
 import { BaseAPI } from '@cube-frontend/api/sdk/base'
 import {
   NodesApi,
@@ -13,29 +13,12 @@ import {
   ServicesApi,
 } from '@cube-frontend/api'
 import devAccessTokenInterceptor from './devAccessTokenInterceptor'
+import { samlAuthErrorInterceptor } from './samlAuthErrorInterceptor'
 import { config, validateStatus } from './utils'
 
 const cosApi = axios.create({
   baseURL: '/',
   validateStatus,
-})
-
-type UnauthorizedResponse = {
-  code?: string
-  msg?: string
-  status?: string
-}
-
-// redirect to perform SAML auth if HTTP status code 401 is received
-cosApi.interceptors.response.use((response: AxiosResponse): AxiosResponse => {
-  if (response.status === 401) {
-    const redirectUrl = (response.data as UnauthorizedResponse)?.msg ?? ''
-    if (redirectUrl !== '') {
-      window.location.replace(redirectUrl)
-    }
-  }
-
-  return response
 })
 
 /**
@@ -81,6 +64,8 @@ export const healthApi = createApiInstance(HealthApi)
 export const nodesApi = createApiInstance(NodesApi)
 export const eventsApi = createApiInstance(EventsApi)
 export const servicesApi = createApiInstance(ServicesApi)
+
+cosApi.interceptors.response.use(undefined, samlAuthErrorInterceptor)
 
 if (import.meta.env.DEV) {
   cosApi.interceptors.request.use(devAccessTokenInterceptor)

--- a/packages/cube-frontend-web-app/src/api/cosApi.ts
+++ b/packages/cube-frontend-web-app/src/api/cosApi.ts
@@ -1,4 +1,4 @@
-import axios, { AxiosInstance } from 'axios'
+import axios, { AxiosInstance, AxiosResponse } from 'axios'
 import { BaseAPI } from '@cube-frontend/api/sdk/base'
 import {
   NodesApi,
@@ -18,6 +18,24 @@ import { config, validateStatus } from './utils'
 const cosApi = axios.create({
   baseURL: '/',
   validateStatus,
+})
+
+type UnauthorizedResponse = {
+  code?: string
+  msg?: string
+  status?: string
+}
+
+// redirect to perform SAML auth if HTTP status code 401 is received
+cosApi.interceptors.response.use((response: AxiosResponse): AxiosResponse => {
+  if (response.status === 401) {
+    const redirectUrl = (response.data as UnauthorizedResponse)?.msg ?? ''
+    if (redirectUrl !== '') {
+      window.location.replace(redirectUrl)
+    }
+  }
+
+  return response
 })
 
 /**

--- a/packages/cube-frontend-web-app/src/api/samlAuthErrorInterceptor.ts
+++ b/packages/cube-frontend-web-app/src/api/samlAuthErrorInterceptor.ts
@@ -1,0 +1,24 @@
+import { HttpStatusCode, isAxiosError } from 'axios'
+import { CosApiInnerResponse } from '../hooks/useCosRequest/cosRequestUtils'
+
+// Redirect to perform SAML auth if HTTP status code 401 is received.
+export const samlAuthErrorInterceptor = (error: unknown): Promise<unknown> => {
+  if (
+    !isAxiosError(error) ||
+    error.response?.status !== HttpStatusCode.Unauthorized
+  ) {
+    return Promise.reject(error)
+  }
+
+  const data = error.response.data as
+    | Partial<CosApiInnerResponse<never>>
+    | undefined
+
+  const redirectUrl = data?.msg
+
+  if (redirectUrl) {
+    window.location.replace(redirectUrl)
+  }
+
+  return Promise.reject(error)
+}

--- a/packages/cube-frontend-web-app/src/api/utils.ts
+++ b/packages/cube-frontend-web-app/src/api/utils.ts
@@ -3,6 +3,6 @@ import { Configuration } from '@cube-frontend/api'
 export const config = new Configuration({ basePath: '.' })
 
 export const validateStatus = (status: number) => {
-  if (status >= 200 && status <= 300) return true
+  if ((status >= 200 && status <= 300) || status === 401) return true
   return false
 }

--- a/packages/cube-frontend-web-app/src/api/utils.ts
+++ b/packages/cube-frontend-web-app/src/api/utils.ts
@@ -3,6 +3,6 @@ import { Configuration } from '@cube-frontend/api'
 export const config = new Configuration({ basePath: '.' })
 
 export const validateStatus = (status: number) => {
-  if ((status >= 200 && status <= 300) || status === 401) return true
+  if (status >= 200 && status <= 300) return true
   return false
 }


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Connect the login process between UI and API
- 401 responses are now intercepted to trigger a redirect by reading the `msg` field from the payload
- The mechanism is added to tackle the CORS problem we now currently having during login, as mentioned in https://github.com/bigstack-oss/cube-cos-api/pull/133

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
