### PR TITLE
ci(rpm): set up the rpm spec file

### DIFF
--- a/packages/cube-frontend-web-app/cube-cos-ui.spec
+++ b/packages/cube-frontend-web-app/cube-cos-ui.spec
@@ -1,0 +1,36 @@
+Name:           cube-cos-ui
+Version:        %{version}
+Release:        1%{?dist}.%{build_number}
+Summary:        UI for CubeCOS
+
+License:        Apache License 2.0
+URL:            https://github.com/bigstack-oss/cube-cos-ui
+Source0:        https://github.com/bigstack-oss/cube-cos-ui/tree/%{build_number}
+
+BuildRequires:  nodejs
+
+%description
+The UI for CubeCOS.
+
+%prep
+rm -rf ./*
+cp ../SOURCES/"cube-cos-ui-%{version}.tar.gz" .
+tar -xzf "cube-cos-ui-%{version}.tar.gz"
+rm "cube-cos-ui-%{version}.tar.gz"
+mv ./source/* .
+rmdir source
+
+%build
+npm list -g pnpm
+pnpm install
+cd ./packages/cube-frontend-web-app
+pnpm run build
+
+%install
+rm -rf $RPM_BUILD_ROOT
+mkdir -p $RPM_BUILD_ROOT/%{_datadir}/cube/ui
+cp LICENSE $RPM_BUILD_ROOT/%{_datadir}/cube/ui
+cp -r ./packages/cube-frontend-web-app/dist/. $RPM_BUILD_ROOT/%{_datadir}/cube/ui
+
+%files
+%{_datadir}/cube/ui

--- a/packages/cube-frontend-web-app/docs/rpm.md
+++ b/packages/cube-frontend-web-app/docs/rpm.md
@@ -1,0 +1,98 @@
+# Build RPM
+
+## Env
+
+```bash
+VERSION=$(node -p -e "require('./packages/cube-frontend-web-app/package.json').version")
+BUILD_NUMBER=$(git rev-parse --short HEAD)
+```
+
+## Install Dependencies
+
+- Node.js
+- npm
+- pnpm
+
+```bash
+dnf module install nodejs:22/common
+npm install -g pnpm@latest-10
+```
+
+## Prepare Environment
+
+### Dev Tools
+
+```bash
+sudo dnf install -y rpmdevtools rpmlint
+```
+
+### Directory
+
+```bash
+rm -rf ~/rpmbuild
+pushd ~
+mkdir rpmbuild
+cd rpmbuild
+mkdir BUILD RPMS SOURCES SPECS SRPMS
+popd
+```
+
+## Build
+
+### Tarball Source Code
+
+```bash
+mkdir ~/source
+mkdir -p ~/source/packages/cube-frontend-api
+pushd ./packages/cube-frontend-api
+cp -r package.json tsconfig.json ~/source/packages/cube-frontend-api
+mkdir -p ~/source/packages/cube-frontend-api/sdk
+cd ./sdk
+cp api.ts base.ts common.ts configuration.ts index.ts ~/source/packages/cube-frontend-api/sdk
+popd
+mkdir -p ~/source/packages/cube-frontend-ui-library
+pushd ./packages/cube-frontend-ui-library
+cp -r ./src package.json postcss.config.js tailwind.config.js tsconfig.json vite.config.ts ~/source/packages/cube-frontend-ui-library
+popd
+mkdir -p ~/source/packages/cube-frontend-ui-theme
+pushd ./packages/cube-frontend-ui-theme
+cp -r ./src package.json tsconfig.json ~/source/packages/cube-frontend-ui-theme
+popd
+mkdir -p ~/source/packages/cube-frontend-utils
+pushd ./packages/cube-frontend-utils
+cp -r ./src package.json tsconfig.json ~/source/packages/cube-frontend-utils
+popd
+mkdir -p ~/source/packages/cube-frontend-web-app
+pushd ./packages/cube-frontend-web-app
+cp -r ./public ./src index.html package.json postcss.config.js tailwind.config.js tsconfig.app.json tsconfig.json tsconfig.node.json vite.config.ts ~/source/packages/cube-frontend-web-app
+popd
+cp -r LICENSE package.json pnpm-lock.yaml pnpm-workspace.yaml tsconfig.json ~/source
+pushd ~
+tar -cvzf "cube-cos-ui-${VERSION}.tar.gz" source
+mv "cube-cos-ui-${VERSION}.tar.gz" ~/rpmbuild/SOURCES
+rm -r source/
+popd
+```
+
+### Spec file
+
+- [cube-cos-ui.spec](../cube-cos-ui.spec)
+
+```bash
+cp ./packages/cube-frontend-web-app/cube-cos-ui.spec ~/rpmbuild/SPECS
+rpmlint ~/rpmbuild/SPECS/cube-cos-ui.spec
+```
+
+### Build
+
+```bash
+rpmbuild -bb --nodeps --define "version $VERSION" --define "build_number $BUILD_NUMBER" ~/rpmbuild/SPECS/cube-cos-ui.spec
+```
+
+### Upload
+
+- upload the rpm under ~/rpmbuild/RPMS/x86_64
+
+```bash
+ls -ahl ~/rpmbuild/RPMS/x86_64/cube-cos-ui-$VERSION-1.el9.$BUILD_NUMBER.x86_64.rpm
+```

--- a/packages/cube-frontend-web-app/package.json
+++ b/packages/cube-frontend-web-app/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@cube-frontend/web-app",
+  "version": "0.0.1",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

- Add rpm build spec file the related documents
- We could use the commands listed in `./packages/cube-frontend-web-app/docs/rpm.md` to build an rpm locally, on an amd64 (x86_64) based Linux machine, and install the rpm on a running COS 3.0.0 to easily swap out the old version of cube-cos-ui and test the new version
- `"version": "0.0.1"` field in `packages/cube-frontend-web-app/package.json` is temporary. We could switch to other places to hold the version infos, like git branch, git tag, or other kinds of text files.

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
