### PR TITLE
Feat/124 chart page usage panel

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBar.tsx
@@ -1,7 +1,9 @@
-import { BackgroundColorClass } from '@cube-frontend/ui-theme'
-import { cva } from 'class-variance-authority'
 import { CSSProperties } from 'react'
+import { cva } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
+import { BackgroundColorClass } from '@cube-frontend/ui-theme'
+import { PropsWithClassName } from '@cube-frontend/utils'
+import { CosProgressBarSkeleton } from './CosProgressBarSkeleton'
 
 export type CosProgressBarProps = {
   color: BackgroundColorClass
@@ -9,7 +11,7 @@ export type CosProgressBarProps = {
    * An integer between 0 and 100 indicating the progress (percentage).
    */
   progress: number
-}
+} & PropsWithClassName
 
 const progressCva = cva('absolute h-full', {
   variants: {
@@ -21,7 +23,7 @@ const progressCva = cva('absolute h-full', {
 })
 
 export const CosProgressBar = (props: CosProgressBarProps) => {
-  const { color, progress } = props
+  const { className: classNameProps, color, progress } = props
 
   // Use inline style because dynamic value is not supported in TailwindCSS.
   const progressWidthStyle: CSSProperties = {
@@ -32,9 +34,14 @@ export const CosProgressBar = (props: CosProgressBarProps) => {
     console.warn('progress value should not be less than 0')
   }
 
+  const className = twMerge(
+    'inline-flex w-full items-center gap-x-[6px]',
+    classNameProps,
+  )
+
   return (
-    <div className="inline-flex items-center gap-x-[6px]">
-      <div className="relative h-[9px] w-[60px] rounded-full bg-functional-border-divider">
+    <div className={className}>
+      <div className="relative h-[9px] w-full rounded-full bg-functional-border-divider">
         <div
           className={twMerge(
             progressCva({
@@ -49,3 +56,5 @@ export const CosProgressBar = (props: CosProgressBarProps) => {
     </div>
   )
 }
+
+CosProgressBar.Skeleton = CosProgressBarSkeleton

--- a/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBarSkeleton.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBarSkeleton.tsx
@@ -1,0 +1,16 @@
+import { PropsWithClassName } from '@cube-frontend/utils'
+import { CosSkeleton } from '../CosSkeleton/CosSkeleton'
+import { twMerge } from 'tailwind-merge'
+
+export const CosProgressBarSkeleton = (props: PropsWithClassName) => {
+  const { className: classNameProps } = props
+
+  const className = twMerge('flex w-full items-center gap-x-2', classNameProps)
+
+  return (
+    <div className={className}>
+      <CosSkeleton className="h-[9px] w-full" />
+      <CosSkeleton className="h-[15px] w-[23px]" />
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosProgressBarChart/CosProgressBarChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBarChart/CosProgressBarChart.tsx
@@ -1,0 +1,38 @@
+import {
+  CosProgressBar,
+  CosProgressBarProps,
+} from '../CosProgressBar/CosProgressBar'
+
+type CosProgressBarChart = {
+  title: string
+  subtext?: string
+  /**
+   * @default false
+   */
+  isLoading?: boolean
+  skeletonClassName?: string
+} & CosProgressBarProps
+
+export const CosProgressBarChart = (props: CosProgressBarChart) => {
+  const {
+    title,
+    subtext,
+    isLoading = false,
+    skeletonClassName,
+    ...restProps
+  } = props
+
+  return (
+    <div className="flex flex-1 flex-col items-stretch gap-y-[14px]">
+      <div className="flex items-center gap-x-3">
+        <span className="primary-body3 text-functional-text">{title}</span>
+        <span className="primary-body3 text-functional-text">{subtext}</span>
+      </div>
+      {isLoading ? (
+        <CosProgressBar.Skeleton className={skeletonClassName} />
+      ) : (
+        <CosProgressBar {...restProps} />
+      )}
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/index.ts
+++ b/packages/cube-frontend-ui-library/src/index.ts
@@ -1,5 +1,6 @@
 export * from './components/CosBackButton/CosBackButton'
 export * from './components/CosBackButton/CosBackButtonSkeleton'
+export * from './components/CosProgressBarChart/CosProgressBarChart'
 export * from './components/CosBasicTable/CosBasicTable'
 export * from './components/CosBasicTable/rendering/CosTableTdSkeleton'
 export type {

--- a/packages/cube-frontend-ui-library/src/stories/components/CosProgressBar/CosProgressBar.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosProgressBar/CosProgressBar.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from '@storybook/react'
 import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
 
 const meta = {
-  title: 'Molecules/Chart/Progress Bar',
+  title: 'Atoms/Progress Bar',
 } satisfies Meta
 
 export default meta
@@ -16,12 +16,33 @@ const ProgressBarGallery = () => {
   return (
     <StoryLayout title="Progress Bar">
       <StoryLayout.Section title="Progress">
-        <div className="flex items-center gap-x-4">
-          <CosProgressBar progress={0} color="bg-chart-1" />
-          <CosProgressBar progress={1} color="bg-chart-1" />
-          <CosProgressBar progress={50} color="bg-chart-2" />
-          <CosProgressBar progress={99} color="bg-chart-3" />
-          <CosProgressBar progress={100} color="bg-chart-4" />
+        <div className="flex flex-col gap-y-4">
+          <CosProgressBar
+            className="w-[90px]"
+            progress={50}
+            color="bg-chart-1"
+          />
+          <CosProgressBar progress={50} color="bg-chart-1" />
+          <div className="flex items-center gap-x-4">
+            <CosProgressBar progress={0} color="bg-chart-1" />
+            <CosProgressBar progress={1} color="bg-chart-1" />
+            <CosProgressBar progress={50} color="bg-chart-2" />
+            <CosProgressBar progress={99} color="bg-chart-3" />
+            <CosProgressBar progress={100} color="bg-chart-4" />
+          </div>
+        </div>
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Skeleton">
+        <div className="flex flex-col gap-y-4">
+          <CosProgressBar.Skeleton className="w-[90px]" />
+          <CosProgressBar.Skeleton />
+          <div className="flex items-center gap-x-4">
+            <CosProgressBar.Skeleton />
+            <CosProgressBar.Skeleton />
+            <CosProgressBar.Skeleton />
+            <CosProgressBar.Skeleton />
+            <CosProgressBar.Skeleton />
+          </div>
         </div>
       </StoryLayout.Section>
     </StoryLayout>

--- a/packages/cube-frontend-ui-library/src/stories/components/CosProgressBarChart/CosProgressBarChart.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosProgressBarChart/CosProgressBarChart.stories.tsx
@@ -1,0 +1,159 @@
+import { CosProgressBarChart } from '../../../components/CosProgressBarChart/CosProgressBarChart'
+import type { Meta, StoryObj } from '@storybook/react'
+import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
+
+const meta = {
+  title: 'Molecules/Chart/Progress Bar Chart',
+} satisfies Meta
+
+export default meta
+
+export const Gallery: StoryObj = {
+  render: () => <ProgressBarChartGallery />,
+}
+
+const ProgressBarChartGallery = () => {
+  return (
+    <StoryLayout title="Progress Bar Chart">
+      <StoryLayout.Section title="Title">
+        <div className="flex flex-col gap-y-4">
+          <CosProgressBarChart
+            className="w-[180px]"
+            title="Chart Title"
+            progress={50}
+            color="bg-chart-1"
+          />
+          <CosProgressBarChart
+            title="Chart Title"
+            progress={50}
+            color="bg-chart-1"
+          />
+          <div className="flex items-center gap-x-4">
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={0}
+              color="bg-chart-1"
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={1}
+              color="bg-chart-1"
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={50}
+              color="bg-chart-2"
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={99}
+              color="bg-chart-3"
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={100}
+              color="bg-chart-4"
+            />
+          </div>
+        </div>
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Title and Subtext">
+        <div className="flex flex-col gap-y-4">
+          <CosProgressBarChart
+            className="w-[180px]"
+            title="Chart Title"
+            progress={50}
+            color="bg-chart-1"
+          />
+          <CosProgressBarChart
+            title="Chart Title"
+            progress={50}
+            color="bg-chart-1"
+          />
+          <div className="flex items-center gap-x-4">
+            <CosProgressBarChart
+              title="Chart Title"
+              subtext="Subtext"
+              progress={0}
+              color="bg-chart-1"
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              subtext="Subtext"
+              progress={1}
+              color="bg-chart-1"
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              subtext="Subtext"
+              progress={50}
+              color="bg-chart-2"
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              subtext="Subtext"
+              progress={99}
+              color="bg-chart-3"
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              subtext="Subtext"
+              progress={100}
+              color="bg-chart-4"
+            />
+          </div>
+        </div>
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Skeleton">
+        <div className="flex flex-col gap-y-4">
+          <CosProgressBarChart
+            className="w-[180px]"
+            skeletonClassName="w-[180px]"
+            title="Chart Title"
+            progress={0}
+            color="bg-chart-1"
+            isLoading={true}
+          />
+          <CosProgressBarChart
+            title="Chart Title"
+            progress={0}
+            color="bg-chart-1"
+            isLoading={true}
+          />
+          <div className="flex items-center gap-x-4">
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={0}
+              color="bg-chart-1"
+              isLoading={true}
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={0}
+              color="bg-chart-1"
+              isLoading={true}
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={0}
+              color="bg-chart-2"
+              isLoading={true}
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={0}
+              color="bg-chart-3"
+              isLoading={true}
+            />
+            <CosProgressBarChart
+              title="Chart Title"
+              progress={100}
+              color="bg-chart-4"
+              isLoading={true}
+            />
+          </div>
+        </div>
+      </StoryLayout.Section>
+    </StoryLayout>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/home/chart/HomeChartPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/HomeChartPage.tsx
@@ -1,3 +1,4 @@
+import { UsagePanel } from './_components/UsagePanel/UsagePanel'
 import { ChartPanel } from './_components/ChartPanel/ChartPanel'
 import { useCosStreamRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosStreamRequest'
 import { defaultMetrics } from '../overview/_components/ChartPanel/utils'
@@ -18,6 +19,7 @@ export const HomeChartPage = () => {
 
   return (
     <div className="mt-6 flex flex-col gap-y-4">
+      <UsagePanel metrics={metrics} isLoading={isMetricsLoading} />
       <ChartPanel metrics={metrics} isLoading={isMetricsLoading} />
     </div>
   )

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/UsageMetricsItem.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/UsageMetricsItem.tsx
@@ -1,0 +1,48 @@
+import { CosSkeleton, CosProgressBarChart } from '@cube-frontend/ui-library'
+
+type UsageMetricsItemProps = {
+  name: string
+  nodeCount?: number
+  cpuUsedPercent: number
+  memoryUsedPercent: number
+  isLoading: boolean
+}
+
+export const UsageMetricsItem = (props: UsageMetricsItemProps) => {
+  const { name, nodeCount, cpuUsedPercent, memoryUsedPercent, isLoading } =
+    props
+
+  const renderNodeCount = () => {
+    if (nodeCount === undefined) return null
+    if (isLoading) return <CosSkeleton className="h-[18px] w-[48px]" />
+
+    return (
+      <span className="primary-body3 text-functional-text">{nodeCount}</span>
+    )
+  }
+
+  return (
+    <div className="flex flex-1 flex-col gap-y-3">
+      <div className="flex items-center gap-x-3">
+        <span className="primary-body2 font-medium text-functional-title">
+          {name}
+        </span>
+        {renderNodeCount()}
+      </div>
+      <div className="flex gap-x-6">
+        <CosProgressBarChart
+          isLoading={isLoading}
+          progress={Math.floor(cpuUsedPercent)}
+          color="bg-chart-1"
+          title="CPU"
+        />
+        <CosProgressBarChart
+          isLoading={isLoading}
+          progress={Math.floor(memoryUsedPercent)}
+          color="bg-chart-1"
+          title="Memory"
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/UsagePanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/UsagePanel.tsx
@@ -1,0 +1,78 @@
+import { GetMetricsResponseData, RoleUsage } from '@cube-frontend/api'
+import { CosGeneralPanel, CosStroke } from '@cube-frontend/ui-library'
+import { UsageMetricsItem } from './UsageMetricsItem'
+
+type RoleGroup = {
+  name: string
+  value: RoleUsage
+}[]
+
+export type UsagePanelProps = {
+  metrics: GetMetricsResponseData
+  isLoading: boolean
+}
+
+export const UsagePanel = (props: UsagePanelProps) => {
+  const { metrics, isLoading } = props
+
+  const roleGroups: RoleGroup[] = [
+    [
+      {
+        name: 'Control-converged Nodes',
+        value: metrics.host.role.controlConverged,
+      },
+      {
+        name: 'Control Nodes',
+        value: metrics.host.role.control,
+      },
+    ],
+    [
+      {
+        name: 'Compute Nodes',
+        value: metrics.host.role.compute,
+      },
+      {
+        name: 'Storage Nodes',
+        value: metrics.host.role.storage,
+      },
+    ],
+    [
+      {
+        name: 'Edge-core Nodes',
+        value: metrics.host.role.edgeCore,
+      },
+      {
+        name: 'Moderator Nodes',
+        value: metrics.host.role.moderator,
+      },
+    ],
+  ]
+
+  return (
+    <CosGeneralPanel topic="Usage">
+      <div className="flex flex-col gap-y-4">
+        <UsageMetricsItem
+          name="Data Center"
+          cpuUsedPercent={metrics.dataCenter.usage.cpu.usedPercent}
+          memoryUsedPercent={metrics.dataCenter.usage.memory.usedPercent}
+          isLoading={isLoading}
+        />
+        <CosStroke />
+        {roleGroups.map((roleGroup, index) => (
+          <div key={index} className="flex items-center gap-x-4">
+            {roleGroup.map((roleUsage) => (
+              <UsageMetricsItem
+                key={roleUsage.name}
+                nodeCount={roleUsage.value.count}
+                name={roleUsage.name}
+                cpuUsedPercent={roleUsage.value.cpu.usedPercent}
+                memoryUsedPercent={roleUsage.value.memory.usedPercent}
+                isLoading={isLoading}
+              />
+            ))}
+          </div>
+        ))}
+      </div>
+    </CosGeneralPanel>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel.tsx
@@ -95,6 +95,7 @@ export const NodePanel = () => {
         >
           {(cpu) => (
             <CosProgressBar
+              className="min-w-[90px]"
               color="bg-chart-1"
               progress={toPercentage(cpu.usedCores, cpu.totalCores)}
             />
@@ -107,6 +108,7 @@ export const NodePanel = () => {
         >
           {(memory) => (
             <CosProgressBar
+              className="min-w-[90px]"
               color="bg-chart-2"
               progress={toPercentage(memory.usedMiB, memory.totalMiB)}
             />
@@ -119,6 +121,7 @@ export const NodePanel = () => {
         >
           {(storage) => (
             <CosProgressBar
+              className="min-w-[90px]"
               color="bg-chart-3"
               progress={toPercentage(storage.usedMiB, storage.totalMiB)}
             />


### PR DESCRIPTION
⚠️ This PR is based on https://github.com/bigstack-oss/cube-cos-ui/pull/166. please check that PR before reviewing this one.

## Changes

## Main feature: Chart Page Usage Panel

https://github.com/user-attachments/assets/d0dceef3-c03f-4e25-9a73-7e4f3efb5ec0

## Components:

### 1. Implemented `CosProgressBarSkeleton`

<img width="1265" alt="Screenshot 2025-03-13 at 8 15 28 PM" src="https://github.com/user-attachments/assets/ce0a9057-c5ac-4f17-b17e-3d11b4231ec5" />

### 2. Enable customizing the `CosProgressBar` width via `className`, the default width is `w-full`

<img width="1507" alt="Screenshot 2025-03-13 at 8 16 44 PM" src="https://github.com/user-attachments/assets/b2ef9ded-e23d-47b7-8fbe-b19843dfff09" />

### 3. Implemented `CosProgressBarChart` component

<img width="1269" alt="image" src="https://github.com/user-attachments/assets/f1af9d95-f804-447a-8712-996292a540e0" />

<img width="1261" alt="image" src="https://github.com/user-attachments/assets/dcebc845-bf7d-41b9-a38c-68c1c807bae7" />


# TODO

Recently, the designers publisedh chart design guideline that defines all types of charts, variants and skeletons.
However, implementing all these components at this stage would take a lot of time, and many details are worth to discussing.

So I opened this ticket: https://github.com/bigstack-oss/cube-cos-ui/issues/168 to remind us to implement these components when we have time.
