### PR TITLE
126 settings page email recipients

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/EmailSettings.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/EmailSettings.tsx
@@ -23,7 +23,11 @@ export const EmailSettings = (props: EmailSettingsProps) => {
 
   return (
     <div className="flex flex-col gap-y-6">
-      <EmailRecipients hasVerifiedSender={hasVerifiedSender} />
+      <EmailRecipients
+        isLoading={isLoading}
+        initialRecipients={initialData?.recipients}
+        hasVerifiedSender={hasVerifiedSender}
+      />
       <EmailSenders
         isLoading={isLoading}
         rows={emailSenderRows}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/EmailRecipients.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/EmailRecipients.tsx
@@ -1,15 +1,123 @@
-import { noop } from 'lodash'
+import { EmailRecipientResponse } from '@cube-frontend/api'
+import {
+  CosModal,
+  CosTableInput,
+  GetCosBasicTable,
+} from '@cube-frontend/ui-library'
 import { EmailRecipientsHeader } from './EmailRecipientsHeader'
+import { EmailRecipientRow } from './emailRecipientsUtils'
+import { ActionCell } from './tableCells/ActionCell'
+import { useDeleteEmailRecipientModal } from './useDeleteEmailRecipientModal'
+import { useEmailRecipientRows } from './useEmailRecipientRows'
+import { useEmailRecipientRowsErrorMap } from './useEmailRecipientRowsErrorMap'
 
-type EmailRecipientProps = {
+type EmailRecipientsProps = {
+  isLoading: boolean
+  initialRecipients?: EmailRecipientResponse[] | undefined
   hasVerifiedSender: boolean
 }
 
-export const EmailRecipients = (_props: EmailRecipientProps) => {
+const EmailRecipientTable = GetCosBasicTable<EmailRecipientRow>()
+
+export const EmailRecipients = (props: EmailRecipientsProps) => {
+  const { isLoading, initialRecipients, hasVerifiedSender } = props
+
+  const {
+    rows,
+    onAddClick,
+    onEditClick,
+    onCancelEditClick,
+    onChange,
+    onTryClick,
+    onSaveClick,
+    deleteEmailRecipient,
+  } = useEmailRecipientRows(initialRecipients)
+
+  const rowsErrorMap = useEmailRecipientRowsErrorMap(rows)
+
+  const {
+    isDeleteModalOpen,
+    toBeDeletedRowId,
+    onDeleteClick,
+    onCloseDeleteModal,
+  } = useDeleteEmailRecipientModal()
+
+  const onConfirmDelete = async (): Promise<void> => {
+    if (toBeDeletedRowId) {
+      onCloseDeleteModal()
+      await deleteEmailRecipient(toBeDeletedRowId)
+    }
+  }
+
   return (
     <div className="flex flex-col gap-y-2">
-      <EmailRecipientsHeader onAddButtonClick={noop} />
-      <p>🚧WIP🚧</p>
+      <EmailRecipientsHeader
+        isCountLimitReached={rows.length >= 10}
+        isRowsLoading={isLoading}
+        onAddButtonClick={onAddClick}
+      />
+      <EmailRecipientTable isLoading={isLoading} rows={rows}>
+        <EmailRecipientTable.Column property="address" label="Email">
+          {(address, row) =>
+            row.isEditing ? (
+              <CosTableInput
+                name="address"
+                placeholder="Email"
+                value={address}
+                errorMessage={rowsErrorMap.get(row.id)?.address}
+                disabled={row.isSaving}
+                onChange={(e) => onChange(row.id, e)}
+              />
+            ) : (
+              address
+            )
+          }
+        </EmailRecipientTable.Column>
+        <EmailRecipientTable.Column property="note" label="Note">
+          {(note, row) =>
+            row.isEditing ? (
+              <CosTableInput
+                name="note"
+                placeholder="Note"
+                value={note}
+                errorMessage={rowsErrorMap.get(row.id)?.note}
+                disabled={row.isSaving}
+                onChange={(e) => onChange(row.id, e)}
+              />
+            ) : (
+              note
+            )
+          }
+        </EmailRecipientTable.Column>
+        <EmailRecipientTable.Column>
+          {(_, row) => (
+            <ActionCell
+              row={row}
+              rowError={rowsErrorMap.get(row.id)}
+              hasVerifiedSender={hasVerifiedSender}
+              nonEditingActions={{
+                onEditClick,
+                onTryClick,
+                onDeleteClick,
+              }}
+              editingActions={{
+                onSaveClick,
+                onCancelEditClick,
+              }}
+            />
+          )}
+        </EmailRecipientTable.Column>
+      </EmailRecipientTable>
+      <CosModal
+        title="Delete Email Recipient"
+        size="sm"
+        isOpen={isDeleteModalOpen}
+        actionText="Delete"
+        onActionClick={onConfirmDelete}
+        onCloseClick={onCloseDeleteModal}
+      >
+        Are you sure you want to delete this email recipient?
+      </CosModal>
     </div>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/EmailRecipientsHeader.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/EmailRecipientsHeader.tsx
@@ -1,13 +1,28 @@
-import { CosButton, CosTooltip } from '@cube-frontend/ui-library'
+import {
+  CosButton,
+  CosTooltip,
+  CosTooltipInformation,
+} from '@cube-frontend/ui-library'
 import InformationCircleFilled from '@cube-frontend/ui-library/icons/monochrome/information_circle_filled.svg?react'
 import Plus from '@cube-frontend/ui-library/icons/monochrome/plus.svg?react'
 
 export type EmailRecipientsHeaderProps = {
+  isCountLimitReached: boolean
+  isRowsLoading: boolean
   onAddButtonClick: () => void
 }
 
 export const EmailRecipientsHeader = (props: EmailRecipientsHeaderProps) => {
-  const { onAddButtonClick } = props
+  const { isCountLimitReached, isRowsLoading, onAddButtonClick } = props
+
+  const getAddButtonHoverInfo = (): CosTooltipInformation | undefined => {
+    if (!isCountLimitReached) {
+      return undefined
+    }
+    return {
+      message: 'You have reached the limit of 10 email recipients.',
+    }
+  }
 
   return (
     <div className="flex items-center justify-between">
@@ -22,15 +37,22 @@ export const EmailRecipientsHeader = (props: EmailRecipientsHeaderProps) => {
           <InformationCircleFilled className="icon-md text-functional-border-divider" />
         </CosTooltip>
       </div>
-      <CosButton
-        type="secondary"
-        usage="icon-left"
-        Icon={Plus}
-        size="sm"
-        onClick={onAddButtonClick}
-      >
-        Add Email Recipient
-      </CosButton>
+      <CosTooltip hoverContent={getAddButtonHoverInfo()}>
+        {/* Wrap the button with a <span> because the hover event doesn't work
+        when the button is disabled, but we still need it for the tooltip. */}
+        <span>
+          <CosButton
+            type="secondary"
+            usage="icon-left"
+            Icon={Plus}
+            size="sm"
+            disabled={isCountLimitReached || isRowsLoading}
+            onClick={onAddButtonClick}
+          >
+            Add Email Recipient
+          </CosButton>
+        </span>
+      </CosTooltip>
     </div>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/createEmailRecipient.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/createEmailRecipient.ts
@@ -1,0 +1,32 @@
+import { settingsApi } from '@cube-frontend/web-app/api/cosApi'
+import { rowToEmailPostRequest } from '../emailRecipientMappers'
+import { getRowId } from '../emailRecipientsUtils'
+import { ActionOptions } from './utils'
+
+export const createEmailRecipient = async (
+  options: ActionOptions,
+): Promise<void> => {
+  const { dataCenter, row, patchRow, onSuccess } = options
+
+  patchRow(row.id, { isSaving: true })
+
+  const newEmailRecipient = rowToEmailPostRequest(row)
+
+  try {
+    await settingsApi.createEmailRecipient({
+      dataCenter,
+      emailRecipientPostRequest: newEmailRecipient,
+    })
+    patchRow(row.id, {
+      id: getRowId(),
+      originalState: newEmailRecipient,
+      isNew: false,
+      isEditing: false,
+      isSaving: false,
+    })
+    onSuccess?.()
+  } catch (error) {
+    console.error('Create email recipient error: ', error)
+    patchRow(row.id, { isSaving: false })
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/deleteEmailRecipient.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/deleteEmailRecipient.ts
@@ -1,0 +1,21 @@
+import { settingsApi } from '@cube-frontend/web-app/api/cosApi'
+import { ActionOptions } from './utils'
+
+export const deleteEmailRecipient = async (
+  options: ActionOptions,
+): Promise<void> => {
+  const { dataCenter, row, patchRow, onSuccess } = options
+
+  patchRow(row.id, { isDeleting: true })
+
+  try {
+    await settingsApi.deleteEmailRecipient({
+      dataCenter,
+      recipientEmail: row.originalState.address,
+    })
+    onSuccess?.()
+  } catch (error) {
+    console.error('Delete email recipient error: ', error)
+    patchRow(row.id, { isDeleting: false })
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/tryEmailRecipient.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/tryEmailRecipient.ts
@@ -1,0 +1,22 @@
+import { settingsApi } from '@cube-frontend/web-app/api/cosApi'
+import { ActionOptions } from './utils'
+
+export const tryEmailRecipient = async (
+  options: ActionOptions,
+): Promise<void> => {
+  const { dataCenter, row, patchRow, onSuccess } = options
+
+  patchRow(row.id, { isTrying: true })
+
+  try {
+    await settingsApi.tryEmailRecipient({
+      dataCenter,
+      recipientEmail: row.originalState.address,
+    })
+    onSuccess?.()
+  } catch (error) {
+    console.error('Try email recipient error: ', error)
+  } finally {
+    patchRow(row.id, { isTrying: false })
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/updateEmailRecipient.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/updateEmailRecipient.ts
@@ -1,0 +1,33 @@
+import { settingsApi } from '@cube-frontend/web-app/api/cosApi'
+import { rowToEmailPutRequest } from '../emailRecipientMappers'
+import { ActionOptions } from './utils'
+
+export const updateEmailRecipient = async (
+  options: ActionOptions,
+): Promise<void> => {
+  const { dataCenter, row, patchRow, onSuccess } = options
+
+  patchRow(row.id, { isSaving: true })
+
+  const updatedEmailRecipient = rowToEmailPutRequest(row)
+
+  try {
+    await settingsApi.updateEmailRecipient({
+      dataCenter,
+      recipientEmail: row.originalState.address,
+      emailRecipientPutRequest: updatedEmailRecipient,
+    })
+    patchRow(row.id, {
+      originalState: {
+        address: row.address,
+        note: row.note,
+      },
+      isEditing: false,
+      isSaving: false,
+    })
+    onSuccess?.()
+  } catch (error) {
+    console.error('Update email recipient error: ', error)
+    patchRow(row.id, { isSaving: false })
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/utils.ts
@@ -1,0 +1,8 @@
+import { EmailRecipientRow } from '../emailRecipientsUtils'
+
+export type ActionOptions = {
+  dataCenter: string
+  row: EmailRecipientRow
+  patchRow: (id: string, payload: Partial<EmailRecipientRow>) => void
+  onSuccess?: () => void
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/emailRecipientMappers.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/emailRecipientMappers.ts
@@ -1,0 +1,34 @@
+import {
+  EmailRecipientPostRequest,
+  EmailRecipientPutRequest,
+  EmailRecipientResponse,
+} from '@cube-frontend/api'
+import { EmailRecipientRow, getRowId } from './emailRecipientsUtils'
+
+export const emailRecipientToRow = (
+  emailRecipient: EmailRecipientResponse,
+): EmailRecipientRow => ({
+  address: emailRecipient.address,
+  note: emailRecipient.note,
+  id: getRowId(),
+  originalState: { ...emailRecipient },
+  isNew: false,
+  isEditing: false,
+  isTrying: false,
+  isSaving: false,
+  isDeleting: false,
+})
+
+export const rowToEmailPostRequest = (
+  row: EmailRecipientRow,
+): EmailRecipientPostRequest => ({
+  address: row.address,
+  note: row.note,
+})
+
+export const rowToEmailPutRequest = (
+  row: EmailRecipientRow,
+): EmailRecipientPutRequest => ({
+  address: row.address,
+  note: row.note,
+})

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/emailRecipientsUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/emailRecipientsUtils.ts
@@ -1,0 +1,38 @@
+import { EmailRecipientResponse } from '@cube-frontend/api'
+import { CosTableRow } from '@cube-frontend/ui-library'
+import { uniqueId } from 'lodash'
+import { z } from 'zod'
+
+export type EmailRecipientRow = EmailRecipientResponse &
+  CosTableRow & {
+    originalState: EmailRecipientResponse
+    isNew: boolean
+    isEditing: boolean
+    isTrying: boolean
+    isSaving: boolean
+    isDeleting: boolean
+  }
+
+export const getRowId = (): string => uniqueId('email-recipient')
+
+const createEmailRecipient = (): EmailRecipientResponse => ({
+  address: '',
+  note: '',
+})
+
+export const createNewRow = (): EmailRecipientRow => ({
+  ...createEmailRecipient(),
+  id: getRowId(),
+  originalState: createEmailRecipient(),
+  isNew: true,
+  isEditing: true,
+  isTrying: false,
+  isSaving: false,
+  isDeleting: false,
+})
+
+// TODO: Replace error messages with i18n keys.
+export const emailRecipientSchema = z.object({
+  address: z.string().email('Invalid email'),
+  note: z.string().optional(),
+})

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/tableCells/ActionCell.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/tableCells/ActionCell.tsx
@@ -1,0 +1,44 @@
+import { isEmpty } from 'lodash'
+import { EmailRecipientRow } from '../emailRecipientsUtils'
+import { EmailRecipientRowError } from '../useEmailRecipientRowsErrorMap'
+import { EditingActionCallbacks, EditingActions } from './EditingActions'
+import {
+  NonEditingActionCallbacks,
+  NonEditingActions,
+} from './NonEditingActions'
+
+export type ActionCellProps = {
+  row: EmailRecipientRow
+  rowError: EmailRecipientRowError | undefined
+  hasVerifiedSender: boolean
+  nonEditingActions: NonEditingActionCallbacks
+  editingActions: EditingActionCallbacks
+}
+
+export const ActionCell = (props: ActionCellProps) => {
+  const {
+    row,
+    rowError,
+    hasVerifiedSender,
+    nonEditingActions,
+    editingActions,
+  } = props
+
+  if (row.isEditing) {
+    return (
+      <EditingActions
+        row={row}
+        canSave={isEmpty(rowError)}
+        callbacks={editingActions}
+      />
+    )
+  }
+
+  return (
+    <NonEditingActions
+      row={row}
+      hasVerifiedSender={hasVerifiedSender}
+      callbacks={nonEditingActions}
+    />
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/tableCells/EditingActions.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/tableCells/EditingActions.tsx
@@ -1,0 +1,45 @@
+import { CosButton } from '@cube-frontend/ui-library'
+import Close from '@cube-frontend/ui-library/icons/monochrome/x.svg?react'
+import { EmailRecipientRow } from '../emailRecipientsUtils'
+
+type EditingActionsProps = {
+  row: EmailRecipientRow
+  canSave: boolean
+  callbacks: EditingActionCallbacks
+}
+
+export type EditingActionCallbacks = {
+  onSaveClick: (rowId: string) => Promise<void>
+  onCancelEditClick: (rowId: string) => void
+}
+
+export const EditingActions = (props: EditingActionsProps) => {
+  const {
+    row,
+    canSave,
+    callbacks: { onSaveClick, onCancelEditClick },
+  } = props
+
+  const { isSaving } = row
+
+  return (
+    <div className="flex items-center justify-end gap-x-2">
+      <CosButton
+        usage="text-only"
+        loading={isSaving}
+        disabled={!canSave}
+        onClick={() => onSaveClick(row.id)}
+      >
+        Save
+      </CosButton>
+      <CosButton
+        className="rounded-full text-functional-text"
+        type="ghost"
+        usage="icon-only"
+        Icon={Close}
+        disabled={isSaving}
+        onClick={() => onCancelEditClick(row.id)}
+      />
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/tableCells/NonEditingActions.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/tableCells/NonEditingActions.tsx
@@ -1,0 +1,54 @@
+import Delete from '@cube-frontend/ui-library/icons/monochrome/delete.svg?react'
+import Edit from '@cube-frontend/ui-library/icons/monochrome/edit.svg?react'
+import Send from '@cube-frontend/ui-library/icons/monochrome/send.svg?react'
+import { IconActionButton } from '../../../IconActionButton'
+import { EmailRecipientRow } from '../emailRecipientsUtils'
+
+type NonEditingActionsProps = {
+  row: EmailRecipientRow
+  hasVerifiedSender: boolean
+  callbacks: NonEditingActionCallbacks
+}
+
+export type NonEditingActionCallbacks = {
+  onEditClick: (rowId: string) => void
+  onTryClick: (rowId: string) => Promise<void>
+  onDeleteClick: (rowId: string) => void
+}
+
+export const NonEditingActions = (props: NonEditingActionsProps) => {
+  const {
+    row,
+    hasVerifiedSender,
+    callbacks: { onEditClick, onTryClick, onDeleteClick },
+  } = props
+
+  const { isTrying, isDeleting } = row
+
+  return (
+    <div className="flex items-center justify-end gap-x-4">
+      <IconActionButton
+        Icon={Edit}
+        disabled={isTrying || isDeleting}
+        onClick={() => onEditClick(row.id)}
+      />
+      <IconActionButton
+        Icon={Send}
+        isLoading={isTrying}
+        hoverMessage={
+          hasVerifiedSender
+            ? 'Send test message'
+            : 'A verified sender email is required to send the test message.'
+        }
+        disabled={!hasVerifiedSender || isDeleting}
+        onClick={() => onTryClick(row.id)}
+      />
+      <IconActionButton
+        Icon={Delete}
+        isLoading={isDeleting}
+        disabled={isTrying}
+        onClick={() => onDeleteClick(row.id)}
+      />
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useDeleteEmailRecipientModal.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useDeleteEmailRecipientModal.ts
@@ -1,0 +1,30 @@
+import { useState } from 'react'
+
+type UseDeleteEmailRecipientModal = {
+  isDeleteModalOpen: boolean
+  toBeDeletedRowId: string | undefined
+  onDeleteClick: (rowId: string) => void
+  onCloseDeleteModal: () => void
+}
+
+export const useDeleteEmailRecipientModal =
+  (): UseDeleteEmailRecipientModal => {
+    const [toBeDeletedRowId, setToBeDeletedRowId] = useState<
+      string | undefined
+    >(undefined)
+
+    const onDeleteClick = (rowId: string): void => {
+      setToBeDeletedRowId(rowId)
+    }
+
+    const onCloseDeleteModal = (): void => {
+      setToBeDeletedRowId(undefined)
+    }
+
+    return {
+      isDeleteModalOpen: !!toBeDeletedRowId,
+      toBeDeletedRowId,
+      onDeleteClick,
+      onCloseDeleteModal,
+    }
+  }

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useEmailRecipientRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useEmailRecipientRows.ts
@@ -1,0 +1,137 @@
+import { EmailRecipientResponse } from '@cube-frontend/api'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { ChangeEvent, useContext, useEffect, useState } from 'react'
+import { createEmailRecipient } from './actions/createEmailRecipient'
+import { deleteEmailRecipient as deleteEmailRecipientAction } from './actions/deleteEmailRecipient'
+import { tryEmailRecipient } from './actions/tryEmailRecipient'
+import { updateEmailRecipient } from './actions/updateEmailRecipient'
+import { emailRecipientToRow } from './emailRecipientMappers'
+import { createNewRow, EmailRecipientRow } from './emailRecipientsUtils'
+
+type UseEmailRecipientRows = {
+  rows: EmailRecipientRow[]
+  onAddClick: () => void
+  onEditClick: (rowId: string) => void
+  onCancelEditClick: (rowId: string) => void
+  onChange: (rowId: string, e: ChangeEvent<HTMLInputElement>) => void
+  onTryClick: (rowId: string) => Promise<void>
+  onSaveClick: (rowId: string) => Promise<void>
+  deleteEmailRecipient: (rowId: string) => Promise<void>
+}
+
+export const useEmailRecipientRows = (
+  initialRecipients?: EmailRecipientResponse[] | undefined,
+): UseEmailRecipientRows => {
+  const { name: dataCenter } = useContext(DataCenterContext)
+
+  const [rows, setRows] = useState<EmailRecipientRow[]>([])
+
+  useEffect(() => {
+    if (initialRecipients) {
+      setRows(initialRecipients.map(emailRecipientToRow))
+    }
+  }, [initialRecipients])
+
+  const onAddClick = (): void => {
+    setRows((prevRows) => [createNewRow(), ...prevRows])
+  }
+
+  const patchRow = (id: string, payload: Partial<EmailRecipientRow>): void => {
+    setRows((prevRows) => {
+      const rowIndex = prevRows.findIndex((row) => row.id === id)
+      if (rowIndex < 0) {
+        return prevRows
+      }
+      const nextRows = [...prevRows]
+      Object.assign(nextRows[rowIndex], payload)
+      return nextRows
+    })
+  }
+
+  const onEditClick = (rowId: string): void => {
+    patchRow(rowId, { isEditing: true })
+  }
+
+  const onCancelEditClick = (rowId: string): void => {
+    const targetRow = rows.find((row) => row.id === rowId)
+    if (!targetRow) {
+      return
+    }
+
+    if (targetRow.isNew) {
+      // Remove the new row.
+      setRows((prevRows) => prevRows.filter((row) => row.id !== targetRow.id))
+    } else {
+      // Reset the target row to the original state and exit editing state.
+      patchRow(targetRow.id, {
+        ...targetRow.originalState,
+        isEditing: false,
+      })
+    }
+  }
+
+  const onChange = (rowId: string, e: ChangeEvent<HTMLInputElement>): void => {
+    const { name, value } = e.target
+    patchRow(rowId, {
+      [name as keyof EmailRecipientResponse]: value,
+    })
+  }
+
+  const onTryClick = async (rowId: string): Promise<void> => {
+    const row = rows.find((row) => row.id === rowId)
+    if (!row) {
+      return
+    }
+    await tryEmailRecipient({
+      dataCenter,
+      row,
+      patchRow,
+    })
+  }
+
+  const onSaveClick = async (rowId: string): Promise<void> => {
+    const row = rows.find((row) => row.id === rowId)
+    if (!row) {
+      return
+    }
+    if (row.isNew) {
+      await createEmailRecipient({
+        dataCenter,
+        row,
+        patchRow,
+      })
+    } else {
+      await updateEmailRecipient({
+        dataCenter,
+        row,
+        patchRow,
+      })
+    }
+  }
+
+  const deleteEmailRecipient = async (rowId: string): Promise<void> => {
+    const row = rows.find((row) => row.id === rowId)
+    if (!row) {
+      return
+    }
+    await deleteEmailRecipientAction({
+      dataCenter,
+      row,
+      patchRow,
+      onSuccess: () => {
+        setRows((prevRows) => prevRows.filter((row) => row.id !== rowId))
+      },
+    })
+  }
+
+  return {
+    rows,
+    onAddClick,
+    onEditClick,
+    onCancelEditClick,
+    onChange,
+    onTryClick,
+    onSaveClick,
+    deleteEmailRecipient,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useEmailRecipientRowsErrorMap.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useEmailRecipientRowsErrorMap.ts
@@ -1,0 +1,49 @@
+import { EmailRecipientResponse } from '@cube-frontend/api'
+import { useMemo } from 'react'
+import { ErrorRecord, validateBySchema } from '../../validateBySchema'
+import { EmailRecipientRow, emailRecipientSchema } from './emailRecipientsUtils'
+
+export type EmailRecipientRowError = ErrorRecord<EmailRecipientResponse>
+
+const computeEmailCountMap = (
+  rows: EmailRecipientRow[],
+): Map<string, number> => {
+  const map = new Map<string, number>()
+  rows.forEach((row) => {
+    const count = map.get(row.address) ?? 0
+    map.set(row.address, count + 1)
+  })
+  return map
+}
+
+export const useEmailRecipientRowsErrorMap = (
+  rows: EmailRecipientRow[],
+): Map<string, EmailRecipientRowError> => {
+  const errorMap = useMemo<Map<string, EmailRecipientRowError>>(() => {
+    const emailCountMap = computeEmailCountMap(rows)
+    const errorMap = new Map<string, EmailRecipientRowError>()
+
+    rows.forEach((row) => {
+      const errorRecord = validateBySchema<EmailRecipientResponse>(
+        emailRecipientSchema,
+        row,
+      )
+
+      const isEmailFormatValid = !errorRecord.address
+      if (isEmailFormatValid) {
+        // Email format is valid. Proceeding to check for duplicates.
+        const sameEmailCount = emailCountMap.get(row.address) ?? 0
+        if (sameEmailCount > 1) {
+          // TODO: Replace this with i18n key.
+          errorRecord.address = 'Duplicate email'
+        }
+      }
+
+      errorMap.set(row.id, errorRecord)
+    })
+
+    return errorMap
+  }, [rows])
+
+  return errorMap
+}


### PR DESCRIPTION
# ⚠️This PR is based on #191⚠️

#126 is a huge feature, so it's implemented in multiple stages.
This PR is for the Slack Channels section in the page.

The implementation is a little bit complicated because users can create, edit, try, and delete any row simultaneously. We can't reload the table after mutation as usual because that'll interrupt/erase users' inputs in the table.

## Sleletons

https://github.com/user-attachments/assets/e2108846-f17e-4143-93d8-c53148ef877d

## Create (up to 10)

https://github.com/user-attachments/assets/c34821f0-5afa-4527-a1b9-e681ff00e50d

## Try

https://github.com/user-attachments/assets/bb787418-d605-43c4-9dd4-90bd0165b79f

## Update

https://github.com/user-attachments/assets/2ab16a8d-2c80-4c43-aa34-5d837934a266

## Delete

https://github.com/user-attachments/assets/d910aea0-a98d-498f-a2dc-d9aa29189415
