### PR TITLE
feat(ui-library): cos icon text and its stories

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosIconText/CosIconText.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosIconText/CosIconText.tsx
@@ -1,0 +1,55 @@
+import { PropsWithClassName } from '@cube-frontend/utils'
+import { cva } from 'class-variance-authority'
+import { ClassValue } from 'class-variance-authority/types'
+import { twMerge } from 'tailwind-merge'
+
+export type CosIconTextProps = PropsWithClassName & {
+  type: CosIconTextType
+  children: string
+}
+
+export type CosIconTextType =
+  | 'primary'
+  | 'warning'
+  | 'error'
+  | 'functional'
+  | 'secondary'
+  | 'positive'
+  | 'primary-outline'
+
+const iconText = cva(
+  'secondary-body4 rounded px-1 py-0.5 text-center font-semibold text-grey-0',
+  {
+    variants: {
+      type: {
+        primary: 'bg-cosmos-primary',
+        warning: 'bg-status-paused',
+        error: 'bg-status-negative',
+        functional: 'bg-functional-text',
+        secondary: 'bg-cosmos-secondary text-functional-text',
+        positive: 'bg-status-positive',
+        'primary-outline': [
+          'secondary-body5 font-medium text-cosmos-primary',
+          'border border-cosmos-primary bg-grey-0 px-[5px]',
+        ],
+      } satisfies Record<CosIconTextType, ClassValue>,
+    },
+  },
+)
+
+export const CosIconText = (props: CosIconTextProps) => {
+  const { className, type, children } = props
+
+  return (
+    <span
+      className={twMerge(
+        iconText({
+          type,
+        }),
+        className,
+      )}
+    >
+      {children}
+    </span>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/designTokens/Color/Color.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/designTokens/Color/Color.stories.tsx
@@ -91,6 +91,7 @@ export const Color: StoryObj = {
             />
             <ColorBox colorName="Negative" bgClassName="bg-status-negative" />
             <ColorBox colorName="Warning" bgClassName="bg-status-warning" />
+            <ColorBox colorName="Paused" bgClassName="bg-status-paused" />
             <ColorBox
               colorName="Neutral/ Active"
               bgClassName="bg-status-neutral"

--- a/packages/cube-frontend-ui-library/src/stories/designTokens/Icon/Icon.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/designTokens/Icon/Icon.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { fn } from '@storybook/test'
 import { twMerge } from 'tailwind-merge'
 import { CosIconFrame } from '../../../components/CosIcon/CosIcon'
-import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
-import { coloredIcons, monochromeIcons, renderSizeRow } from './utils'
 import Home01 from '../../../components/CosIcon/monochrome/home_01.svg?react'
 import Warning from '../../../components/CosIcon/monochrome/warning.svg?react'
+import { CosIconText } from '../../../components/CosIconText/CosIconText'
+import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
 import { IconGallery } from './IconGallery'
-import { fn } from '@storybook/test'
+import { coloredIcons, monochromeIcons, renderSizeRow } from './utils'
 
 const meta = {
   title: 'Design Tokens/Icon',
@@ -169,4 +170,25 @@ export const Size: Story = {
       </StoryLayout>
     )
   },
+}
+
+export const Text: Story = {
+  render: () => (
+    <StoryLayout title="Text">
+      <StoryLayout.Section title="Master">
+        <div className="flex items-center gap-x-3">
+          <CosIconText type="primary">new</CosIconText>
+          <CosIconText type="warning">warning</CosIconText>
+          <CosIconText type="warning">expiring</CosIconText>
+          <CosIconText type="error">expired</CosIconText>
+          <CosIconText type="error">error</CosIconText>
+          <CosIconText type="error">NG</CosIconText>
+          <CosIconText type="functional">non-reserved</CosIconText>
+          <CosIconText type="secondary">reserved</CosIconText>
+          <CosIconText type="positive">OK</CosIconText>
+          <CosIconText type="primary-outline">Admin</CosIconText>
+        </div>
+      </StoryLayout.Section>
+    </StoryLayout>
+  ),
 }

--- a/packages/cube-frontend-ui-theme/src/cubeTheme.ts
+++ b/packages/cube-frontend-ui-theme/src/cubeTheme.ts
@@ -163,6 +163,7 @@ export const cubeTheme = {
       'positive-text': '#00BE90',
       negative: '#FF5D5D',
       warning: '#F9C300',
+      paused: '#FF9920',
       neutral: '#4C68F9',
     },
     chart: {


### PR DESCRIPTION
Close #174 

I’m not a big fan of the name "Icon Text." Something like "Badge" or "Chip" might be better. But since we don’t know if there will be components named `CosBadge` or `CosChip` in the future, I eventually named it `CosIconText` because it falls under the Icon category in the mockup. 🤷‍♂️ 

- Added a new status color "paused" according to the mockup:
   - <img width="1280" alt="{F7EEF373-D21F-4C23-AFA6-3EBB5173DA0D}" src="https://github.com/user-attachments/assets/1fefdad7-d50c-4fdf-9552-3a0620521dae" />
   - ![image](https://github.com/user-attachments/assets/7ad1d462-c58f-4f60-b623-90158b02539e)
- Component story
   - ![image](https://github.com/user-attachments/assets/24b9ab55-2756-470c-8679-5ccb7361d059)

## Known Issues

1. The font family used in the mockup (`Outfit`) is not presented in the typography tokens. I just went for `secondary-body` for now to save time.
   - <img width="736" alt="{B9B83854-0504-4B17-BD81-5B115ACA3B37}" src="https://github.com/user-attachments/assets/c276c49a-8b80-4f52-a84a-64266c0a0a99" />
2. The color hex of the `warning` type is actually `#FF9920`, but it's not listed in the color tokens. So I chose the closet color `status-paused`.
   - <img width="591" alt="{5A4F3A71-4FD6-40AD-B53B-CDBA7B393F20}" src="https://github.com/user-attachments/assets/811e0cf5-05e1-426a-a918-755806c5bc0b" />
