### PR TITLE
refactor(keycloak-login): use topdir macro & bump the version to force update images on helm

### DIFF
--- a/packages/cube-frontend-keycloak-login/cube-cos-login.spec
+++ b/packages/cube-frontend-keycloak-login/cube-cos-login.spec
@@ -14,7 +14,7 @@ The Login for CubeCOS.
 
 %prep
 rm -rf ./*
-cp ../SOURCES/"cube-cos-login-%{version}.tar.gz" .
+cp %{_topdir}/SOURCES/"cube-cos-login-%{version}.tar.gz" .
 tar -xzf "cube-cos-login-%{version}.tar.gz"
 rm "cube-cos-login-%{version}.tar.gz"
 mv ./source/* .

--- a/packages/cube-frontend-keycloak-login/cube-cos-login.spec
+++ b/packages/cube-frontend-keycloak-login/cube-cos-login.spec
@@ -29,10 +29,10 @@ rm -rf ./keycloak/themes/cos-ui/login/resources
 cp -r ./dist/resources ./keycloak/themes/cos-ui/login
 ctr=$(buildah from quay.io/keycloak/keycloak:%{keycloak_version})
 buildah copy $ctr ./keycloak/themes/ /opt/jboss/keycloak/themes/
-buildah commit $ctr localhost:5080/bigstack/keycloak:%{keycloak_version}
+buildah commit $ctr localhost:5080/bigstack/keycloak:%{version}
 buildah rm $ctr
 cd -
-podman save localhost:5080/bigstack/keycloak:%{keycloak_version} -o keycloak-image.tar
+podman save localhost:5080/bigstack/keycloak:%{version} -o keycloak-image.tar
 
 %install
 rm -rf $RPM_BUILD_ROOT

--- a/packages/cube-frontend-keycloak-login/docs/rpm.md
+++ b/packages/cube-frontend-keycloak-login/docs/rpm.md
@@ -118,7 +118,8 @@ skopeo delete --tls-verify=false --creds "username:password" docker://localhost:
 ```
 
 ```bash
-docker exec -it "<docker registry container id>" shrm -r /var/lib/registry/docker/registry/v2/repositories/bigstack/keycloak
+docker exec -it "<docker registry container id>" sh
+rm -r /var/lib/registry/docker/registry/v2/repositories/bigstack/keycloak
 ```
 
 4. Import the image

--- a/packages/cube-frontend-keycloak-login/package.json
+++ b/packages/cube-frontend-keycloak-login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cube-frontend/keycloak-login",
-  "version": "0.0.1",
+  "version": "17.1.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cube-frontend-web-app/cube-cos-ui.spec
+++ b/packages/cube-frontend-web-app/cube-cos-ui.spec
@@ -14,7 +14,7 @@ The UI for CubeCOS.
 
 %prep
 rm -rf ./*
-cp ../SOURCES/"cube-cos-ui-%{version}.tar.gz" .
+cp %{_topdir}/SOURCES/"cube-cos-ui-%{version}.tar.gz" .
 tar -xzf "cube-cos-ui-%{version}.tar.gz"
 rm "cube-cos-ui-%{version}.tar.gz"
 mv ./source/* .


### PR DESCRIPTION
#### What type of PR is this?

- refactor

#### What this PR does / why we need it

- Use `_topdir` macro to allow using a local rpm build directory in CubeCOS build process
- Bump the version to force update images on helm

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
