### PR TITLE
[ ✅ ready for review ] 147 implement Create Trigger page

### DIFF
--- a/packages/cube-frontend-api/sdk/api.ts
+++ b/packages/cube-frontend-api/sdk/api.ts
@@ -669,37 +669,6 @@ export interface GetAbstractedEventsResponseDataLimit {
 /**
  * 
  * @export
- * @interface GetCpuUsageHistoryOfHostResponse
- */
-export interface GetCpuUsageHistoryOfHostResponse {
-    /**
-     * 
-     * @type {number}
-     * @memberof GetCpuUsageHistoryOfHostResponse
-     */
-    'code': number;
-    /**
-     * 
-     * @type {TimeValuePair}
-     * @memberof GetCpuUsageHistoryOfHostResponse
-     */
-    'data': TimeValuePair;
-    /**
-     * 
-     * @type {string}
-     * @memberof GetCpuUsageHistoryOfHostResponse
-     */
-    'msg': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof GetCpuUsageHistoryOfHostResponse
-     */
-    'status': string;
-}
-/**
- * 
- * @export
  * @interface GetCpuUsageRankOfHostsResponse
  */
 export interface GetCpuUsageRankOfHostsResponse {
@@ -2612,37 +2581,6 @@ export interface GetMeResponseData {
 /**
  * 
  * @export
- * @interface GetMemoryUsageHistoryOfHostResponse
- */
-export interface GetMemoryUsageHistoryOfHostResponse {
-    /**
-     * 
-     * @type {number}
-     * @memberof GetMemoryUsageHistoryOfHostResponse
-     */
-    'code': number;
-    /**
-     * 
-     * @type {TimeValuePair}
-     * @memberof GetMemoryUsageHistoryOfHostResponse
-     */
-    'data': TimeValuePair;
-    /**
-     * 
-     * @type {string}
-     * @memberof GetMemoryUsageHistoryOfHostResponse
-     */
-    'msg': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof GetMemoryUsageHistoryOfHostResponse
-     */
-    'status': string;
-}
-/**
- * 
- * @export
  * @interface GetMemoryUsageRankOfHostsResponse
  */
 export interface GetMemoryUsageRankOfHostsResponse {
@@ -2764,12 +2702,6 @@ export interface GetMemoryUsageSummaryOfVmsResponse {
      */
     'status': string;
 }
-/**
- * @type GetMetricByHostOrVm200Response
- * @export
- */
-export type GetMetricByHostOrVm200Response = GetCpuUsageHistoryOfHostResponse | GetMemoryUsageHistoryOfHostResponse;
-
 /**
  * 
  * @export
@@ -4557,6 +4489,12 @@ export interface GetTriggerResponseDataResponseEmailsInner {
      * @memberof GetTriggerResponseDataResponseEmailsInner
      */
     'note': string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof GetTriggerResponseDataResponseEmailsInner
+     */
+    'enabled': boolean;
 }
 /**
  * 
@@ -4731,6 +4669,12 @@ export interface GetTriggersResponseDataInnerResponseEmailsInner {
      * @memberof GetTriggersResponseDataInnerResponseEmailsInner
      */
     'note': string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof GetTriggersResponseDataInnerResponseEmailsInner
+     */
+    'enabled': boolean;
 }
 /**
  * 
@@ -4756,6 +4700,12 @@ export interface GetTriggersResponseDataInnerResponseSlacksInner {
      * @memberof GetTriggersResponseDataInnerResponseSlacksInner
      */
     'description': string;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof GetTriggersResponseDataInnerResponseSlacksInner
+     */
+    'enabled': boolean;
 }
 /**
  * 
@@ -4775,6 +4725,56 @@ export interface GetTriggersResponseDataInnerStatus {
      * @memberof GetTriggersResponseDataInnerStatus
      */
     'isUpdating': boolean;
+}
+/**
+ * 
+ * @export
+ * @interface HostMetricHistoryResponse
+ */
+export interface HostMetricHistoryResponse {
+    /**
+     * 
+     * @type {number}
+     * @memberof HostMetricHistoryResponse
+     */
+    'code': number;
+    /**
+     * 
+     * @type {HostMetricHistoryResponseData}
+     * @memberof HostMetricHistoryResponse
+     */
+    'data': HostMetricHistoryResponseData;
+    /**
+     * 
+     * @type {string}
+     * @memberof HostMetricHistoryResponse
+     */
+    'msg': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof HostMetricHistoryResponse
+     */
+    'status': string;
+}
+/**
+ * 
+ * @export
+ * @interface HostMetricHistoryResponseData
+ */
+export interface HostMetricHistoryResponseData {
+    /**
+     * 
+     * @type {string}
+     * @memberof HostMetricHistoryResponseData
+     */
+    'unit': string;
+    /**
+     * 
+     * @type {Array<TimeValuePair>}
+     * @memberof HostMetricHistoryResponseData
+     */
+    'history': Array<TimeValuePair>;
 }
 /**
  * 
@@ -6643,10 +6643,10 @@ export interface UpdateTrigger500Response {
 export interface UpdateTriggerRequest {
     /**
      * 
-     * @type {Array<GetTriggersResponseDataInnerAttributes>}
+     * @type {Array<UpdateTriggerRequestAttributesInner>}
      * @memberof UpdateTriggerRequest
      */
-    'attributes': Array<GetTriggersResponseDataInnerAttributes>;
+    'attributes': Array<UpdateTriggerRequestAttributesInner>;
     /**
      * 
      * @type {UpdateTriggerRequestResponse}
@@ -6655,10 +6655,35 @@ export interface UpdateTriggerRequest {
     'response': UpdateTriggerRequestResponse;
     /**
      * 
-     * @type {boolean}
+     * @type {string}
      * @memberof UpdateTriggerRequest
      */
-    'enabled': boolean;
+    'description': string;
+}
+/**
+ * 
+ * @export
+ * @interface UpdateTriggerRequestAttributesInner
+ */
+export interface UpdateTriggerRequestAttributesInner {
+    /**
+     * 
+     * @type {string}
+     * @memberof UpdateTriggerRequestAttributesInner
+     */
+    'name': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof UpdateTriggerRequestAttributesInner
+     */
+    'type': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof UpdateTriggerRequestAttributesInner
+     */
+    'value': string;
 }
 /**
  * 
@@ -10518,7 +10543,7 @@ export const MetricsApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getMetricByHostOrVm(dataCenter: string, metricType: GetMetricByHostOrVmMetricTypeEnum, viewType: GetMetricByHostOrVmViewTypeEnum, entityType: GetMetricByHostOrVmEntityTypeEnum, entityIdOrName: string, past?: GetMetricByHostOrVmPastEnum, start?: string, stop?: string, watch?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetMetricByHostOrVm200Response>> {
+        async getMetricByHostOrVm(dataCenter: string, metricType: GetMetricByHostOrVmMetricTypeEnum, viewType: GetMetricByHostOrVmViewTypeEnum, entityType: GetMetricByHostOrVmEntityTypeEnum, entityIdOrName: string, past?: GetMetricByHostOrVmPastEnum, start?: string, stop?: string, watch?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<HostMetricHistoryResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getMetricByHostOrVm(dataCenter, metricType, viewType, entityType, entityIdOrName, past, start, stop, watch, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['MetricsApi.getMetricByHostOrVm']?.[localVarOperationServerIndex]?.url;
@@ -10574,7 +10599,7 @@ export const MetricsApiFactory = function (configuration?: Configuration, basePa
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getMetricByHostOrVm(requestParameters: MetricsApiGetMetricByHostOrVmRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetMetricByHostOrVm200Response> {
+        getMetricByHostOrVm(requestParameters: MetricsApiGetMetricByHostOrVmRequest, options?: RawAxiosRequestConfig): AxiosPromise<HostMetricHistoryResponse> {
             return localVarFp.getMetricByHostOrVm(requestParameters.dataCenter, requestParameters.metricType, requestParameters.viewType, requestParameters.entityType, requestParameters.entityIdOrName, requestParameters.past, requestParameters.start, requestParameters.stop, requestParameters.watch, options).then((request) => request(axios, basePath));
         },
         /**

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/CosBasicTable.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/CosBasicTable.tsx
@@ -112,6 +112,7 @@ export const CosBasicTable = <Row extends CosTableRow>(
       <table className="w-full border-separate border-spacing-0">
         <thead>
           <tr>
+            {/*  */}
             {columns.map((column, index) => (
               <CosTableTh
                 key={`${column.property?.toString() ?? ''}-${index}`}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/CosBasicTable.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/CosBasicTable.tsx
@@ -4,6 +4,7 @@ import {
   PropsWithChildren,
   useMemo,
 } from 'react'
+import { cva } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
 import {
   computeRowClassName,
@@ -22,6 +23,20 @@ const tdBorderRadiusClass = twMerge(
   '[&:last-of-type>td:first-of-type]:rounded-bl-[5px]',
   '[&:last-of-type>td:last-of-type]:rounded-br-[5px]',
 )
+
+const tableRow = cva(['[&>td]:hover:bg-functional-hover-grey'], {
+  variants: {
+    isChecked: {
+      true: '[&>td]:bg-functional-hover-secondary [&>td]:hover:bg-[#ECF1FF]',
+    },
+    isDisabled: {
+      true: [
+        '[&>td]:bg-white [&>td]:hover:bg-white',
+        '[&>td]:text-functional-disable-text',
+      ],
+    },
+  },
+})
 
 export type CosBasicTableProps<Row extends CosTableRow> = PropsWithChildren<{
   rows: Row[]
@@ -89,9 +104,9 @@ export const CosBasicTable = <Row extends CosTableRow>(
       <tr
         key={row.id}
         className={twMerge(
-          '[&>td]:hover:bg-functional-hover-grey',
           tdBorderRadiusClass,
           computeRowClassName(rowClassName, row),
+          tableRow({ isChecked: !!row.checked, isDisabled: !!row.disabled }),
         )}
         onClick={() => onRowClick?.(row)}
       >
@@ -112,7 +127,6 @@ export const CosBasicTable = <Row extends CosTableRow>(
       <table className="w-full border-separate border-spacing-0">
         <thead>
           <tr>
-            {/*  */}
             {columns.map((column, index) => (
               <CosTableTh
                 key={`${column.property?.toString() ?? ''}-${index}`}

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/cosTableUtils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/cosTableUtils.ts
@@ -4,6 +4,8 @@ import { CosTableColumnProps } from './rendering/CosTableColumn'
 
 export type CosTableRow = {
   id: string
+  checked?: boolean
+  disabled?: boolean
 }
 
 export type CosBatchActionTableRow = CosTableRow & {

--- a/packages/cube-frontend-ui-library/src/components/CosBatchActionTable/useCheckboxStatus.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBatchActionTable/useCheckboxStatus.ts
@@ -10,7 +10,8 @@ export const useCheckboxStatus = <Row extends CosTableRow>(
     if (selectedRowIds.length === 0) return false
 
     // If all rows' `id` are selected, return true
-    if (rows.every((row) => selectedRowIds.includes(row.id))) return true
+    const enabledRows = rows.filter((row) => !row.disabled)
+    if (enabledRows.every((row) => selectedRowIds.includes(row.id))) return true
 
     // If some rows are selected, return null (indeterminate state)
     return null

--- a/packages/cube-frontend-ui-library/src/components/CosBatchActionTable/useCheckboxStatus.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBatchActionTable/useCheckboxStatus.ts
@@ -1,0 +1,18 @@
+import { useMemo } from 'react'
+import { CosTableRow } from '../CosBasicTable/cosTableUtils'
+
+export const useCheckboxStatus = <Row extends CosTableRow>(
+  rows: Row[],
+  selectedRowIds: string[],
+): boolean | null => {
+  return useMemo(() => {
+    // If no rows are selected, return false
+    if (selectedRowIds.length === 0) return false
+
+    // If all rows' `id` are selected, return true
+    if (rows.every((row) => selectedRowIds.includes(row.id))) return true
+
+    // If some rows are selected, return null (indeterminate state)
+    return null
+  }, [rows, selectedRowIds])
+}

--- a/packages/cube-frontend-web-app/src/CosRoutes.tsx
+++ b/packages/cube-frontend-web-app/src/CosRoutes.tsx
@@ -13,6 +13,7 @@ import { IntegrationsPage } from './pages/integrations/IntegrationsPage'
 import { EventsLayout } from './pages/events/EventsLayout'
 import { EventsIndexPage } from './pages/events/index/EventsIndexPage'
 import { EventsTriggersPage } from './pages/events/triggers/EventsTriggersPage'
+import { TriggersCreatePage } from './pages/events/triggers/[create]/TriggersCreatePage'
 import { EventsTuningsPage } from './pages/events/tunings/EventsTuningsPage'
 import { CreateTuningsPage } from './pages/events/tunings/create/CreateTuningsPage'
 import { EditTuningsPage } from './pages/events/tunings/edit/EditTuningsPage'
@@ -78,6 +79,10 @@ export const CosRoutes = () => {
         />
       </Route>
       <Route path="/settings" element={<SettingsPage />} />
+      <Route
+        path={CosRoutesEnum.EVENTS_TRIGGERS_CREATE_PAGE}
+        element={<TriggersCreatePage />}
+      />
       <Route path="*" element={<div>TODO: Not Found Page</div>} />
     </Routes>
   )

--- a/packages/cube-frontend-web-app/src/enum/routes.ts
+++ b/packages/cube-frontend-web-app/src/enum/routes.ts
@@ -11,6 +11,7 @@ export enum Routes {
   EVENTS_INDEX_INSTANCE = '/events/instance',
 
   EVENTS_TRIGGERS_PAGE = '/events/triggers',
+  EVENTS_TRIGGERS_CREATE_PAGE = '/events/triggers/create',
   EVENTS_TUNINGS_PAGE = '/events/tunings',
   EVENTS_CHART_PAGE = '/events/chart',
 }

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/TriggersUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/TriggersUtils.ts
@@ -1,0 +1,27 @@
+import { GetTriggersResponseDataInner } from '@cube-frontend/api'
+import { CosTableRow } from '@cube-frontend/ui-library'
+
+export type TriggerRow = GetTriggersResponseDataInner & CosTableRow
+
+export const mapToTriggerTableRows = (
+  triggers: GetTriggersResponseDataInner[],
+): TriggerRow[] =>
+  triggers.map((trigger) => ({
+    ...trigger,
+    /**
+     * We use the trigger name as the row ID since it is unique.
+     * This is a workaround for the fact that the API does not return an ID field.
+     */
+    id: trigger.name,
+  }))
+
+export const getTriggerResponse = (res: string[]): string => {
+  const hasSlack = res.includes('slack')
+  const hasEmail = res.includes('email')
+
+  if (hasSlack && hasEmail) return 'Slack / Emails'
+  if (hasSlack) return 'Slack'
+  if (hasEmail) return 'Emails'
+
+  return 'None'
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/TriggersCreatePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/TriggersCreatePage.tsx
@@ -29,7 +29,6 @@ export const TriggersCreatePage = () => {
   })
 
   const {
-    enabled,
     attributes,
     selectedEmails,
     selectedSlacks,
@@ -56,7 +55,6 @@ export const TriggersCreatePage = () => {
         // The Rest Form Fields
         trigger,
         isTriggerLoading,
-        enabled,
         attributes,
         selectedEmails,
         selectedSlacks,

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/TriggersCreatePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/TriggersCreatePage.tsx
@@ -1,0 +1,66 @@
+import { useState } from 'react'
+import { CosStroke } from '@cube-frontend/ui-library'
+import { TriggersCreateGoBackButton } from './_components/TriggersCreateGoBackButton'
+import { TriggersCreateSteps } from './_components/TriggersCreateSteps'
+import { TriggersCreateForm } from './_components/TriggersCreateForm'
+import { useTrigger } from './_components/useTrigger'
+import { useTriggerCreateForm } from './_components/useCreateTriggerForm'
+import { TriggersCreateContext } from './_components/context'
+import { TriggersCreateStep, triggersCreateSteps } from './_components/utils'
+
+export const TriggersCreatePage = () => {
+  const [activeStep, setActiveStep] = useState<TriggersCreateStep>(
+    triggersCreateSteps[0],
+  )
+
+  const { trigger, isTriggerLoading } = useTrigger()
+
+  const {
+    enabled,
+    selectedTemplate,
+    attributes,
+    selectedEmails,
+    selectedSlacks,
+    description,
+    handleTemplateSelect,
+    handleTemplateSelectAll,
+    handleEmailSelect,
+    handleEmailSelectAll,
+    handleSlackSelect,
+    handleSlackSelectAll,
+    handleDescriptionChange,
+  } = useTriggerCreateForm({ trigger, isTriggerLoading })
+
+  return (
+    <TriggersCreateContext.Provider
+      value={{
+        activeStep,
+        setActiveStep,
+        trigger,
+        isTriggerLoading,
+        enabled,
+        selectedTemplate,
+        attributes,
+        selectedEmails,
+        selectedSlacks,
+        description,
+        handleTemplateSelect,
+        handleTemplateSelectAll,
+        handleEmailSelect,
+        handleEmailSelectAll,
+        handleSlackSelect,
+        handleSlackSelectAll,
+        handleDescriptionChange,
+      }}
+    >
+      <div className="flex flex-col gap-4">
+        <div className="flex flex-col gap-px">
+          <TriggersCreateGoBackButton />
+          <TriggersCreateSteps />
+        </div>
+        <CosStroke />
+        <TriggersCreateForm />
+      </div>
+    </TriggersCreateContext.Provider>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/TriggersCreatePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/TriggersCreatePage.tsx
@@ -5,47 +5,63 @@ import { TriggersCreateSteps } from './_components/TriggersCreateSteps'
 import { TriggersCreateForm } from './_components/TriggersCreateForm'
 import { useTrigger } from './_components/useTrigger'
 import { useTriggerCreateForm } from './_components/useCreateTriggerForm'
-import { TriggersCreateContext } from './_components/context'
+import { useTemplateTable } from './_components/useTemplateTable'
 import { TriggersCreateStep, triggersCreateSteps } from './_components/utils'
+import { TriggersCreateContext } from './_components/context'
 
 export const TriggersCreatePage = () => {
   const [activeStep, setActiveStep] = useState<TriggersCreateStep>(
     triggersCreateSteps[0],
   )
 
-  const { trigger, isTriggerLoading } = useTrigger()
+  const {
+    dataCenter,
+    isTemplateLoading,
+    templateRows,
+    disabledRowsId,
+    selectedTemplateName,
+    handleTemplateSelect,
+  } = useTemplateTable()
+
+  const { isTriggerLoading, trigger } = useTrigger({
+    dataCenter,
+    selectedTemplateName,
+  })
 
   const {
     enabled,
-    selectedTemplate,
     attributes,
     selectedEmails,
     selectedSlacks,
     description,
-    handleTemplateSelect,
-    handleTemplateSelectAll,
     handleEmailSelect,
     handleEmailSelectAll,
     handleSlackSelect,
     handleSlackSelectAll,
     handleDescriptionChange,
-  } = useTriggerCreateForm({ trigger, isTriggerLoading })
+  } = useTriggerCreateForm({ isTriggerLoading, trigger })
 
   return (
     <TriggersCreateContext.Provider
       value={{
+        // Step Params
         activeStep,
         setActiveStep,
+        // Template Table
+        isTemplateLoading,
+        templateRows,
+        disabledRowsId,
+        selectedTemplateName,
+        handleTemplateSelect,
+        // The Rest Form Fields
         trigger,
         isTriggerLoading,
         enabled,
-        selectedTemplate,
         attributes,
         selectedEmails,
         selectedSlacks,
         description,
-        handleTemplateSelect,
-        handleTemplateSelectAll,
+        // Form Field Handlers
         handleEmailSelect,
         handleEmailSelectAll,
         handleSlackSelect,

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersAddButton.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersAddButton.tsx
@@ -1,0 +1,15 @@
+import { CosButton, CosButtonProps } from '@cube-frontend/ui-library'
+import AddSquare from '@cube-frontend/ui-library/icons/monochrome/add_square.svg?react'
+
+type ButtonProps = Omit<CosButtonProps, 'usage' | 'Icon'> & {
+  children: string
+}
+
+export const TriggersAddButton = (props: ButtonProps) => {
+  const { children, ...restProps } = props
+  return (
+    <CosButton {...restProps} usage="icon-left" Icon={AddSquare}>
+      {children}
+    </CosButton>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateActionButton.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateActionButton.tsx
@@ -9,32 +9,46 @@ export const TriggersCreateActionButton = () => {
   const {
     activeStep,
     setActiveStep,
+    isTemplateLoading,
+    selectedTemplateName,
     isTriggerLoading,
     enabled,
     attributes,
-    selectedTemplate,
     selectedEmails,
     selectedSlacks,
   } = useContext(TriggersCreateContext)
 
-  const { isUpdateLoading, handleTriggerUpdate, errorState } = useUpdateTrigger(
-    { enabled, attributes, selectedTemplate, selectedEmails, selectedSlacks },
-  )
-
-  const isLastStep = activeStep.serialNumber === 4
-
   const { isValid, errorMessage } = isFormValueValid(
     activeStep,
-    selectedTemplate,
+    selectedTemplateName,
     selectedEmails,
     selectedSlacks,
   )
 
+  const { isUpdateLoading, handleTriggerUpdate, errorState } = useUpdateTrigger(
+    {
+      isValid,
+      enabled,
+      attributes,
+      selectedTemplateName,
+      selectedEmails,
+      selectedSlacks,
+    },
+  )
+
+  const isLastStep = activeStep.serialNumber === 4
+
+  const isLoading = isTemplateLoading || isTriggerLoading
+
   const renderErrorMessage = () => {
-    const message =
-      errorMessage || errorState?.api?.msg || errorState?.native?.message
-    if (isTriggerLoading || !message) return null
-    return <div className="primary-body3 text-status-negative">{message}</div>
+    if (errorMessage || errorState?.api?.msg || errorState?.native?.message)
+      return (
+        <div className="primary-body3 text-status-negative">
+          {errorMessage || errorState?.api?.msg || errorState?.native?.message}
+        </div>
+      )
+
+    return null
   }
 
   const handleGoToNextStep = () => {
@@ -54,7 +68,7 @@ export const TriggersCreateActionButton = () => {
         size="md"
         type="primary"
         loading={isUpdateLoading}
-        disabled={!isValid || isTriggerLoading}
+        disabled={!!errorState}
         onClick={handleTriggerUpdate}
       >
         Update
@@ -70,7 +84,7 @@ export const TriggersCreateActionButton = () => {
         type="primary"
         usage="icon-right"
         Icon={ChevronRight}
-        loading={isTriggerLoading}
+        loading={isLoading}
         disabled={!isValid}
         onClick={handleGoToNextStep}
       >

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateActionButton.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateActionButton.tsx
@@ -12,10 +12,10 @@ export const TriggersCreateActionButton = () => {
     isTemplateLoading,
     selectedTemplateName,
     isTriggerLoading,
-    enabled,
     attributes,
     selectedEmails,
     selectedSlacks,
+    description,
   } = useContext(TriggersCreateContext)
 
   const { isValid, errorMessage } = isFormValueValid(
@@ -28,11 +28,11 @@ export const TriggersCreateActionButton = () => {
   const { isUpdateLoading, handleTriggerUpdate, errorState } = useUpdateTrigger(
     {
       isValid,
-      enabled,
       attributes,
       selectedTemplateName,
       selectedEmails,
       selectedSlacks,
+      description,
     },
   )
 

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateActionButton.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateActionButton.tsx
@@ -1,0 +1,91 @@
+import { useContext } from 'react'
+import ChevronRight from '@cube-frontend/ui-library/icons/monochrome/chevron_right.svg?react'
+import { CosButton } from '@cube-frontend/ui-library'
+import { useUpdateTrigger } from './useUpdateTrigger'
+import { isFormValueValid, triggersCreateSteps } from './utils'
+import { TriggersCreateContext } from './context'
+
+export const TriggersCreateActionButton = () => {
+  const {
+    activeStep,
+    setActiveStep,
+    isTriggerLoading,
+    enabled,
+    attributes,
+    selectedTemplate,
+    selectedEmails,
+    selectedSlacks,
+  } = useContext(TriggersCreateContext)
+
+  const { isUpdateLoading, handleTriggerUpdate, errorState } = useUpdateTrigger(
+    { enabled, attributes, selectedTemplate, selectedEmails, selectedSlacks },
+  )
+
+  const isLastStep = activeStep.serialNumber === 4
+
+  const { isValid, errorMessage } = isFormValueValid(
+    activeStep,
+    selectedTemplate,
+    selectedEmails,
+    selectedSlacks,
+  )
+
+  const renderErrorMessage = () => {
+    const message =
+      errorMessage || errorState?.api?.msg || errorState?.native?.message
+    if (isTriggerLoading || !message) return null
+    return <div className="primary-body3 text-status-negative">{message}</div>
+  }
+
+  const handleGoToNextStep = () => {
+    const nextStepSerialNumber = activeStep.serialNumber + 1
+    const nextStep = triggersCreateSteps.find(
+      (step) => step.serialNumber === nextStepSerialNumber,
+    )
+
+    if (!nextStep) return
+    setActiveStep(nextStep)
+  }
+
+  const renderUpdateButton = () => {
+    if (!isLastStep) return
+    return (
+      <CosButton
+        size="md"
+        type="primary"
+        loading={isUpdateLoading}
+        disabled={!isValid || isTriggerLoading}
+        onClick={handleTriggerUpdate}
+      >
+        Update
+      </CosButton>
+    )
+  }
+
+  const renderGoToNextButton = () => {
+    if (isLastStep) return
+    return (
+      <CosButton
+        size="md"
+        type="primary"
+        usage="icon-right"
+        Icon={ChevronRight}
+        loading={isTriggerLoading}
+        disabled={!isValid}
+        onClick={handleGoToNextStep}
+      >
+        Next
+      </CosButton>
+    )
+  }
+
+  return (
+    <div className="flex flex-col gap-2">
+      {renderErrorMessage()}
+      <div>
+        {renderUpdateButton()}
+        {renderGoToNextButton()}
+      </div>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateForm.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateForm.tsx
@@ -1,0 +1,40 @@
+import { useContext } from 'react'
+import { CosStroke } from '@cube-frontend/ui-library'
+import { TriggersStepDescription } from './TriggersStepDescription/TriggersStepDescription'
+import { TriggersStepResponse } from './TriggersStepResponse/TriggersStepResponse'
+import { TriggersStepTemplate } from './TriggersStepTemplate/TriggersStepTemplate'
+import { TriggersStepEvent } from './TriggersStepEvents/TriggersStepEvents'
+import { TriggersCreateActionButton } from './TriggersCreateActionButton'
+import { TriggersCreateContext } from './context'
+
+export const TriggersCreateForm = () => {
+  const { activeStep } = useContext(TriggersCreateContext)
+
+  const renderContent = () => {
+    if (activeStep.label === 'Select Template') {
+      return <TriggersStepTemplate />
+    }
+
+    if (activeStep.label === 'Select Events') {
+      return <TriggersStepEvent />
+    }
+
+    if (activeStep.label === 'Set Response') {
+      return <TriggersStepResponse />
+    }
+
+    if (activeStep.label === 'Add Description') {
+      return <TriggersStepDescription />
+    }
+
+    throw new Error(`Unhandled step ${activeStep}`)
+  }
+
+  return (
+    <div className="flex flex-col gap-4">
+      {renderContent()}
+      <CosStroke type="dot" />
+      <TriggersCreateActionButton />
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateGoBackButton.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateGoBackButton.tsx
@@ -1,0 +1,34 @@
+import { useContext } from 'react'
+import { CosBackButton } from '@cube-frontend/ui-library'
+import { TriggersCreateContext } from './context'
+import { triggersCreateSteps } from './utils'
+import { useNavigate } from 'react-router'
+
+export const TriggersCreateGoBackButton = () => {
+  const navigate = useNavigate()
+
+  const { activeStep, setActiveStep } = useContext(TriggersCreateContext)
+
+  const handleGoToPrevStep = () => {
+    const prevStepSerialNumber = activeStep.serialNumber - 1
+    const prevStep = triggersCreateSteps.find(
+      (step) => step.serialNumber === prevStepSerialNumber,
+    )
+
+    if (!prevStep) {
+      setActiveStep(triggersCreateSteps[0])
+      navigate('/events/triggers')
+      return
+    }
+
+    setActiveStep(prevStep)
+  }
+
+  return (
+    <div className="flex h-8 items-center">
+      <CosBackButton onClick={handleGoToPrevStep}>
+        Create from Template
+      </CosBackButton>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateSteps.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersCreateSteps.tsx
@@ -1,0 +1,21 @@
+import { useContext } from 'react'
+import { CosStepProcess } from '@cube-frontend/ui-library'
+import { triggersCreateSteps } from './utils'
+import { TriggersCreateContext } from './context'
+
+export const TriggersCreateSteps = () => {
+  const { activeStep } = useContext(TriggersCreateContext)
+
+  return (
+    <CosStepProcess isLoading={false}>
+      {triggersCreateSteps.map((step) => (
+        <CosStepProcess.Item
+          key={`create-${step.label}`}
+          serialNumber={step.serialNumber}
+          label={step.label}
+          isActive={step.label === activeStep.label}
+        />
+      ))}
+    </CosStepProcess>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepDescription/TriggersStepDescription.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepDescription/TriggersStepDescription.tsx
@@ -1,0 +1,20 @@
+import { useContext } from 'react'
+import { CosTextArea } from '@cube-frontend/ui-library'
+import { TriggersCreateContext } from '../context'
+
+export const TriggersStepDescription = () => {
+  const { description, handleDescriptionChange } = useContext(
+    TriggersCreateContext,
+  )
+
+  return (
+    <div className="flex flex-col gap-2 rounded-[5px] bg-white px-6 py-4">
+      <CosTextArea
+        label="Description"
+        maxLength={1000}
+        value={description}
+        onChange={handleDescriptionChange}
+      />
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepEvents/TriggersStepEvents.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepEvents/TriggersStepEvents.tsx
@@ -1,0 +1,42 @@
+import { useContext } from 'react'
+import { upperFirst } from 'lodash'
+import { CosButton, CosStackCard, CosTag } from '@cube-frontend/ui-library'
+import { TriggersAddButton } from '../TriggersAddButton'
+import { TriggersSubtractButton } from '../TriggersSubtractButton'
+import { groupAttributeByName } from '../utils'
+import { TriggersCreateContext } from '../context'
+
+export const TriggersStepEvent = () => {
+  const { attributes } = useContext(TriggersCreateContext)
+
+  const groupedAttributes = groupAttributeByName(attributes) || {}
+
+  return (
+    <div className="flex flex-col gap-6 rounded-[5px] bg-white px-6 py-4">
+      <div className="flex items-center justify-between">
+        <TriggersAddButton disabled={true} type="ghost">
+          Add Attribute
+        </TriggersAddButton>
+        <CosButton disabled={true} type="ghost">
+          Reset
+        </CosButton>
+      </div>
+      {Object.entries(groupedAttributes).map(([groupName, groupAttributes]) => (
+        <div key={groupName} className="flex items-center justify-between">
+          <CosStackCard title={upperFirst(groupName)}>
+            <div className="flex flex-wrap gap-2">
+              {groupAttributes.map((attr) => (
+                <CosTag key={attr.value} color="blue" variant="stroke">
+                  {attr.value}
+                </CosTag>
+              ))}
+            </div>
+          </CosStackCard>
+          <TriggersSubtractButton disabled={true} type="ghost">
+            Remove
+          </TriggersSubtractButton>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseEmailFilter.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseEmailFilter.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import { CosDropdown } from '@cube-frontend/ui-library'
+
+/**
+ * The filters are temporarily disabled for phase 1
+ * The implementation will be completed in the next phase
+ */
+export const ResponseEmailFilter = () => {
+  const [filter] = useState<string>('Send Notifications')
+  const [email] = useState<string>('Email')
+
+  return (
+    <div className="mb-6 flex w-fit items-center gap-3">
+      <CosDropdown
+        type="regular"
+        variant="in-table"
+        selectedItems={[filter]}
+        disabled={true}
+      >
+        <CosDropdown.Trigger>{filter}</CosDropdown.Trigger>
+      </CosDropdown>
+      <CosDropdown
+        type="regular"
+        variant="in-table"
+        selectedItems={[email]}
+        disabled={true}
+      >
+        <CosDropdown.Trigger>{email}</CosDropdown.Trigger>
+      </CosDropdown>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseEmailTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseEmailTable.tsx
@@ -12,10 +12,7 @@ const mapToEmailTable = (
   email: GetTriggerResponseDataResponseEmailsInner,
 ): EmailTableType => ({
   ...email,
-  /**
-   * Replace email with correct email address (waiting for API update)
-   */
-  id: email.note,
+  id: email.email,
 })
 
 export const ResponseEmailTable = () => {
@@ -39,9 +36,6 @@ export const ResponseEmailTable = () => {
         showHeaderCheckbox={true}
         onAllCheckChange={handleEmailSelectAll}
       >
-        {/**
-         * TODO: update the property of email (waiting for API update)
-         */}
         <EmailTable.Column label="Email" property="email" />
         <EmailTable.Column label="Note" property="note" />
       </EmailTable>

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseEmailTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseEmailTable.tsx
@@ -1,0 +1,49 @@
+import { useContext, useMemo } from 'react'
+import { GetTriggerResponseDataResponseEmailsInner } from '@cube-frontend/api'
+import { GetCosBatchActionTable } from '@cube-frontend/ui-library'
+import { ResponseEmailFilter } from './ResponseEmailFilter'
+import { TriggersCreateContext } from '../context'
+
+type EmailTableType = GetTriggerResponseDataResponseEmailsInner & { id: string }
+
+const EmailTable = GetCosBatchActionTable<EmailTableType>()
+
+const mapToEmailTable = (
+  email: GetTriggerResponseDataResponseEmailsInner,
+): EmailTableType => ({
+  ...email,
+  /**
+   * Replace email with correct email address (waiting for API update)
+   */
+  id: email.note,
+})
+
+export const ResponseEmailTable = () => {
+  const { trigger, selectedEmails, handleEmailSelect, handleEmailSelectAll } =
+    useContext(TriggersCreateContext)
+
+  const emailRows = useMemo<EmailTableType[]>(() => {
+    return trigger?.response.emails.map(mapToEmailTable) || []
+  }, [trigger])
+
+  return (
+    <div className="flex flex-col rounded-[5px] bg-white px-6 py-4">
+      <ResponseEmailFilter />
+      <div className="primary-body2 mb-2 font-semibold text-functional-text">
+        Select Emails
+      </div>
+      <EmailTable
+        rows={emailRows}
+        selectedRowIds={selectedEmails}
+        onCheckChange={handleEmailSelect}
+        onAllCheckChange={handleEmailSelectAll}
+      >
+        {/**
+         * TODO: update the property of email (waiting for API update)
+         */}
+        <EmailTable.Column label="Email" property="email" />
+        <EmailTable.Column label="Note" property="note" />
+      </EmailTable>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseEmailTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseEmailTable.tsx
@@ -36,6 +36,7 @@ export const ResponseEmailTable = () => {
         rows={emailRows}
         selectedRowIds={selectedEmails}
         onCheckChange={handleEmailSelect}
+        showHeaderCheckbox={true}
         onAllCheckChange={handleEmailSelectAll}
       >
         {/**

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseSlackFilter.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseSlackFilter.tsx
@@ -1,0 +1,32 @@
+import { useState } from 'react'
+import { CosDropdown } from '@cube-frontend/ui-library'
+
+/**
+ * The filters are temporarily disabled for phase 1
+ * The implementation will be completed in the next phase
+ */
+export const ResponseSlackFilter = () => {
+  const [filter] = useState<string>('Send Notifications')
+  const [slackChannel] = useState<string>('Slack Channel')
+
+  return (
+    <div className="mb-6 flex w-fit items-center gap-3">
+      <CosDropdown
+        type="regular"
+        variant="in-table"
+        selectedItems={[filter]}
+        disabled={true}
+      >
+        <CosDropdown.Trigger>{filter}</CosDropdown.Trigger>
+      </CosDropdown>
+      <CosDropdown
+        type="regular"
+        variant="in-table"
+        selectedItems={[slackChannel]}
+        disabled={true}
+      >
+        <CosDropdown.Trigger>{slackChannel}</CosDropdown.Trigger>
+      </CosDropdown>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseSlackTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseSlackTable.tsx
@@ -35,6 +35,7 @@ export const ResponseSlackTable = () => {
         rows={slackRows}
         selectedRowIds={selectedSlacks}
         onCheckChange={handleSlackSelect}
+        showHeaderCheckbox={true}
         onAllCheckChange={handleSlackSelectAll}
       >
         <SlackTable.Column label="Slack channels" property="name" />

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseSlackTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/ResponseSlackTable.tsx
@@ -1,0 +1,46 @@
+import { useContext, useMemo } from 'react'
+import { GetTriggersResponseDataInnerResponseSlacksInner } from '@cube-frontend/api'
+import { GetCosBatchActionTable } from '@cube-frontend/ui-library'
+import { ResponseSlackFilter } from './ResponseSlackFilter'
+import { TriggersCreateContext } from '../context'
+
+type SlackTableType = GetTriggersResponseDataInnerResponseSlacksInner & {
+  id: string
+}
+
+const SlackTable = GetCosBatchActionTable<SlackTableType>()
+
+const mapToSlackTable = (
+  slack: GetTriggersResponseDataInnerResponseSlacksInner,
+): SlackTableType => ({
+  ...slack,
+  id: slack.url,
+})
+
+export const ResponseSlackTable = () => {
+  const { trigger, selectedSlacks, handleSlackSelect, handleSlackSelectAll } =
+    useContext(TriggersCreateContext)
+
+  const slackRows = useMemo<SlackTableType[]>(() => {
+    return trigger?.response.slacks.map(mapToSlackTable) || []
+  }, [trigger])
+
+  return (
+    <div className="flex flex-col rounded-[5px] bg-white px-6 py-4">
+      <ResponseSlackFilter />
+      <div className="primary-body2 mb-2 font-semibold text-functional-text">
+        Select Slack channels
+      </div>
+      <SlackTable
+        rows={slackRows}
+        selectedRowIds={selectedSlacks}
+        onCheckChange={handleSlackSelect}
+        onAllCheckChange={handleSlackSelectAll}
+      >
+        <SlackTable.Column label="Slack channels" property="name" />
+        <SlackTable.Column label="URL" property="url" />
+        <SlackTable.Column label="Description" property="description" />
+      </SlackTable>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/TriggersStepResponse.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepResponse/TriggersStepResponse.tsx
@@ -1,0 +1,21 @@
+import { CosButton } from '@cube-frontend/ui-library'
+import { TriggersAddButton } from '../TriggersAddButton'
+import { ResponseEmailTable } from './ResponseEmailTable'
+import { ResponseSlackTable } from './ResponseSlackTable'
+
+export const TriggersStepResponse = () => {
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="flex items-center justify-between">
+        <TriggersAddButton disabled={true} type="ghost">
+          Set Responses
+        </TriggersAddButton>
+        <CosButton disabled={true} type="ghost">
+          Reset
+        </CosButton>
+      </div>
+      <ResponseEmailTable />
+      <ResponseSlackTable />
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepTemplate/TriggersStepTemplate.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepTemplate/TriggersStepTemplate.tsx
@@ -1,48 +1,29 @@
-import { useContext, useMemo } from 'react'
-import { CosTableRow, GetCosBatchActionTable } from '@cube-frontend/ui-library'
-import { GetTriggerResponseData } from '@cube-frontend/api'
+import { useContext } from 'react'
+import { GetCosBatchActionTable } from '@cube-frontend/ui-library'
 import { TriggersCreateContext } from '../context'
-
-type TemplateRow = Pick<GetTriggerResponseData, 'name' | 'description'> &
-  CosTableRow
-
-const mapToTemplateTableRows = (
-  trigger: GetTriggerResponseData | undefined,
-): TemplateRow[] => {
-  if (!trigger) return []
-  return [
-    {
-      name: trigger.name,
-      description: trigger.description,
-      id: trigger.name,
-    },
-  ]
-}
+import { TemplateRow } from '../useTemplateTable'
 
 const TemplateTable = GetCosBatchActionTable<TemplateRow>()
 
 export const TriggersStepTemplate = () => {
   const {
-    trigger,
-    isTriggerLoading,
-    selectedTemplate,
+    isTemplateLoading,
+    templateRows,
+    selectedTemplateName,
+    disabledRowsId,
     handleTemplateSelect,
-    handleTemplateSelectAll,
   } = useContext(TriggersCreateContext)
-
-  const rows = useMemo(() => {
-    return mapToTemplateTableRows(trigger)
-  }, [trigger])
 
   return (
     <div className="flex flex-col gap-2 rounded-[5px] bg-white px-6 py-4">
       <div className="primary-h5 text-functional-text">Templates</div>
       <TemplateTable
-        rows={rows}
-        isLoading={isTriggerLoading}
-        selectedRowIds={selectedTemplate ? [selectedTemplate] : []}
+        rows={templateRows}
+        isLoading={isTemplateLoading}
+        selectedRowIds={selectedTemplateName ? [selectedTemplateName] : []}
+        disabledRowIds={disabledRowsId}
         onCheckChange={handleTemplateSelect}
-        onAllCheckChange={handleTemplateSelectAll}
+        showHeaderCheckbox={false}
       >
         <TemplateTable.Column label="Templates" property="name" />
         <TemplateTable.Column label="Description" property="description" />

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepTemplate/TriggersStepTemplate.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersStepTemplate/TriggersStepTemplate.tsx
@@ -1,0 +1,52 @@
+import { useContext, useMemo } from 'react'
+import { CosTableRow, GetCosBatchActionTable } from '@cube-frontend/ui-library'
+import { GetTriggerResponseData } from '@cube-frontend/api'
+import { TriggersCreateContext } from '../context'
+
+type TemplateRow = Pick<GetTriggerResponseData, 'name' | 'description'> &
+  CosTableRow
+
+const mapToTemplateTableRows = (
+  trigger: GetTriggerResponseData | undefined,
+): TemplateRow[] => {
+  if (!trigger) return []
+  return [
+    {
+      name: trigger.name,
+      description: trigger.description,
+      id: trigger.name,
+    },
+  ]
+}
+
+const TemplateTable = GetCosBatchActionTable<TemplateRow>()
+
+export const TriggersStepTemplate = () => {
+  const {
+    trigger,
+    isTriggerLoading,
+    selectedTemplate,
+    handleTemplateSelect,
+    handleTemplateSelectAll,
+  } = useContext(TriggersCreateContext)
+
+  const rows = useMemo(() => {
+    return mapToTemplateTableRows(trigger)
+  }, [trigger])
+
+  return (
+    <div className="flex flex-col gap-2 rounded-[5px] bg-white px-6 py-4">
+      <div className="primary-h5 text-functional-text">Templates</div>
+      <TemplateTable
+        rows={rows}
+        isLoading={isTriggerLoading}
+        selectedRowIds={selectedTemplate ? [selectedTemplate] : []}
+        onCheckChange={handleTemplateSelect}
+        onAllCheckChange={handleTemplateSelectAll}
+      >
+        <TemplateTable.Column label="Templates" property="name" />
+        <TemplateTable.Column label="Description" property="description" />
+      </TemplateTable>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersSubtractButton.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/TriggersSubtractButton.tsx
@@ -1,0 +1,15 @@
+import { CosButton, CosButtonProps } from '@cube-frontend/ui-library'
+import SubtractSquare from '@cube-frontend/ui-library/icons/monochrome/subtract_square.svg?react'
+
+type ButtonProps = Omit<CosButtonProps, 'usage' | 'Icon'> & {
+  children: string
+}
+
+export const TriggersSubtractButton = (props: ButtonProps) => {
+  const { children, ...restProps } = props
+  return (
+    <CosButton {...restProps} usage="icon-left" Icon={SubtractSquare}>
+      {children}
+    </CosButton>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/context.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/context.ts
@@ -4,20 +4,27 @@ import {
   GetTriggersResponseDataInnerAttributes,
 } from '@cube-frontend/api'
 import { TriggersCreateStep, triggersCreateSteps } from './utils'
+import { TemplateRow } from './useTemplateTable'
 
 export type TriggersCreateContextValue = {
+  // Step Params
   activeStep: TriggersCreateStep
   setActiveStep: React.Dispatch<SetStateAction<TriggersCreateStep>>
+  // Template Table
+  isTemplateLoading: boolean
+  templateRows: TemplateRow[]
+  disabledRowsId: string[]
+  selectedTemplateName: string | null
+  handleTemplateSelect: (selectedId: string) => void
+  // The Rest Form Fields
   trigger: GetTriggerResponseData | undefined
   isTriggerLoading: boolean
   enabled: boolean
-  selectedTemplate: string | undefined
   attributes: GetTriggersResponseDataInnerAttributes[]
   selectedEmails: string[]
   selectedSlacks: string[]
   description: string
-  handleTemplateSelect: (id: string) => void
-  handleTemplateSelectAll: () => void
+  // Form Field Handlers
   handleEmailSelect: (id: string) => void
   handleEmailSelectAll: () => void
   handleSlackSelect: (id: string) => void
@@ -26,18 +33,24 @@ export type TriggersCreateContextValue = {
 }
 
 export const TriggersCreateContext = createContext<TriggersCreateContextValue>({
+  // Step Params
   activeStep: triggersCreateSteps[0],
   setActiveStep: () => {},
+  // Template Table
+  isTemplateLoading: false,
+  templateRows: [],
+  disabledRowsId: [],
+  selectedTemplateName: null,
+  handleTemplateSelect: () => {},
+  // The Rest Form Fields
   trigger: undefined,
   isTriggerLoading: false,
   enabled: true,
-  selectedTemplate: undefined,
   attributes: [],
   selectedEmails: [],
   selectedSlacks: [],
   description: '',
-  handleTemplateSelect: () => {},
-  handleTemplateSelectAll: () => {},
+  // Form Field Handlers
   handleEmailSelect: () => {},
   handleEmailSelectAll: () => {},
   handleSlackSelect: () => {},

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/context.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/context.ts
@@ -1,0 +1,46 @@
+import { ChangeEvent, createContext, SetStateAction } from 'react'
+import {
+  GetTriggerResponseData,
+  GetTriggersResponseDataInnerAttributes,
+} from '@cube-frontend/api'
+import { TriggersCreateStep, triggersCreateSteps } from './utils'
+
+export type TriggersCreateContextValue = {
+  activeStep: TriggersCreateStep
+  setActiveStep: React.Dispatch<SetStateAction<TriggersCreateStep>>
+  trigger: GetTriggerResponseData | undefined
+  isTriggerLoading: boolean
+  enabled: boolean
+  selectedTemplate: string | undefined
+  attributes: GetTriggersResponseDataInnerAttributes[]
+  selectedEmails: string[]
+  selectedSlacks: string[]
+  description: string
+  handleTemplateSelect: (id: string) => void
+  handleTemplateSelectAll: () => void
+  handleEmailSelect: (id: string) => void
+  handleEmailSelectAll: () => void
+  handleSlackSelect: (id: string) => void
+  handleSlackSelectAll: () => void
+  handleDescriptionChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
+}
+
+export const TriggersCreateContext = createContext<TriggersCreateContextValue>({
+  activeStep: triggersCreateSteps[0],
+  setActiveStep: () => {},
+  trigger: undefined,
+  isTriggerLoading: false,
+  enabled: true,
+  selectedTemplate: undefined,
+  attributes: [],
+  selectedEmails: [],
+  selectedSlacks: [],
+  description: '',
+  handleTemplateSelect: () => {},
+  handleTemplateSelectAll: () => {},
+  handleEmailSelect: () => {},
+  handleEmailSelectAll: () => {},
+  handleSlackSelect: () => {},
+  handleSlackSelectAll: () => {},
+  handleDescriptionChange: () => {},
+})

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/context.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/context.ts
@@ -19,7 +19,6 @@ export type TriggersCreateContextValue = {
   // The Rest Form Fields
   trigger: GetTriggerResponseData | undefined
   isTriggerLoading: boolean
-  enabled: boolean
   attributes: GetTriggersResponseDataInnerAttributes[]
   selectedEmails: string[]
   selectedSlacks: string[]
@@ -45,7 +44,6 @@ export const TriggersCreateContext = createContext<TriggersCreateContextValue>({
   // The Rest Form Fields
   trigger: undefined,
   isTriggerLoading: false,
-  enabled: true,
   attributes: [],
   selectedEmails: [],
   selectedSlacks: [],

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/mockData.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/mockData.ts
@@ -1,0 +1,14 @@
+import { GetTriggersResponseDataInnerAttributes } from '@cube-frontend/api'
+
+export const mockAttributes: GetTriggersResponseDataInnerAttributes[] = [
+  { name: 'severity', type: 'string', value: 'W', enabled: true },
+  { name: 'severity', type: 'string', value: 'E', enabled: true },
+  { name: 'severity', type: 'string', value: 'C', enabled: true },
+  { name: 'category', type: 'string', value: 'DEV', enabled: false },
+  { name: 'category', type: 'string', value: 'CPU', enabled: false },
+  { name: 'category', type: 'string', value: 'DSK', enabled: false },
+  { name: 'category', type: 'string', value: 'MEM', enabled: false },
+  { name: 'category', type: 'string', value: 'NET', enabled: false },
+  { name: 'category', type: 'string', value: 'SRV', enabled: false },
+  { name: 'category', type: 'string', value: 'VRT', enabled: false },
+]

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/mockData.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/mockData.ts
@@ -1,4 +1,7 @@
-import { GetTriggersResponseDataInnerAttributes } from '@cube-frontend/api'
+import {
+  GetTriggerResponseDataResponse,
+  GetTriggersResponseDataInnerAttributes,
+} from '@cube-frontend/api'
 
 export const mockAttributes: GetTriggersResponseDataInnerAttributes[] = [
   { name: 'severity', type: 'string', value: 'W', enabled: true },
@@ -12,3 +15,28 @@ export const mockAttributes: GetTriggersResponseDataInnerAttributes[] = [
   { name: 'category', type: 'string', value: 'SRV', enabled: false },
   { name: 'category', type: 'string', value: 'VRT', enabled: false },
 ]
+
+export const mockResponse: GetTriggerResponseDataResponse = {
+  types: ['email', 'slack'],
+  slacks: [
+    {
+      name: 'amqp-alert-p1',
+      url: 'https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>',
+      description: 'example slack channel 1',
+      enabled: false,
+    },
+    {
+      name: '#test-cos-300-notification',
+      url: 'https://hooks.slack.com/services/<hookHash>/<hookHash>/<hookHash>',
+      description: 'example slack channel 2',
+      enabled: false,
+    },
+  ],
+  emails: [
+    {
+      email: 'example.user@example.com',
+      note: 'example email recipient',
+      enabled: false,
+    },
+  ],
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useCreateTriggerForm.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useCreateTriggerForm.ts
@@ -44,7 +44,7 @@ export const useTriggerCreateForm = (
     [trigger],
   )
   const allEmails = useMemo(
-    () => trigger?.response?.emails?.map((email) => email.note) ?? [],
+    () => trigger?.response?.emails?.map((email) => email.email) ?? [],
     [trigger],
   )
   const allSlacks = useMemo(
@@ -58,8 +58,34 @@ export const useTriggerCreateForm = (
    */
   useEffect(() => {
     if (!isTriggerLoading && trigger) {
-      setSelectedEmails(allEmails.length > 0 ? [allEmails[0]] : [])
-      setSelectedSlacks(allSlacks.length > 0 ? [allSlacks[0]] : [])
+      const enabledEmails = trigger?.response.emails
+        .filter((email) => email.enabled)
+        .map((email) => email.email)
+
+      const enabledSlacks = trigger?.response.slacks
+        .filter((slack) => slack.enabled)
+        .map((slack) => slack.url)
+
+      setSelectedEmails(() => {
+        if (enabledEmails.length > 0) {
+          return enabledEmails
+        } else if (trigger?.response?.emails?.length > 0) {
+          return [allEmails[0]]
+        } else {
+          return []
+        }
+      })
+
+      setSelectedSlacks(() => {
+        if (enabledSlacks.length > 0) {
+          return enabledEmails
+        } else if (trigger?.response?.slacks.length > 0) {
+          return [allSlacks[0]]
+        } else {
+          return []
+        }
+      })
+
       setDescription(trigger.description)
     }
   }, [trigger, isTriggerLoading, allEmails, allSlacks])

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useCreateTriggerForm.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useCreateTriggerForm.ts
@@ -1,0 +1,129 @@
+import { ChangeEvent, useEffect, useMemo, useState } from 'react'
+import {
+  GetTriggerResponseData,
+  GetTriggersResponseDataInnerAttributes,
+} from '@cube-frontend/api'
+import { isAllSelected, isRowSelected } from './utils'
+
+type UseTriggerCreateFormOption = {
+  trigger: GetTriggerResponseData | undefined
+  isTriggerLoading: boolean
+}
+
+type UseTriggerCreateForm = {
+  enabled: boolean
+  selectedTemplate: string | undefined
+  attributes: GetTriggersResponseDataInnerAttributes[]
+  selectedEmails: string[]
+  selectedSlacks: string[]
+  description: string
+  handleTemplateSelect: (id: string) => void
+  handleTemplateSelectAll: () => void
+  handleEmailSelect: (id: string) => void
+  handleEmailSelectAll: () => void
+  handleSlackSelect: (id: string) => void
+  handleSlackSelectAll: () => void
+  handleDescriptionChange: (e: ChangeEvent<HTMLTextAreaElement>) => void
+}
+
+export const useTriggerCreateForm = (
+  option: UseTriggerCreateFormOption,
+): UseTriggerCreateForm => {
+  const { trigger, isTriggerLoading } = option
+
+  /**
+   * Form States
+   */
+  const [selectedTemplate, setSelectedTemplate] = useState<string>()
+  const [selectedEmails, setSelectedEmails] = useState<string[]>([])
+  const [selectedSlacks, setSelectedSlacks] = useState<string[]>([])
+  const [description, setDescription] = useState<string>('')
+
+  /**
+   * Compute attributes – this field is temporarily non-editable in Phase 1.
+   */
+  const attributes = useMemo(
+    () =>
+      (trigger?.attributes ?? []) as GetTriggersResponseDataInnerAttributes[],
+    [trigger],
+  )
+  const allEmails = useMemo(
+    () => trigger?.response?.emails?.map((email) => email.note) ?? [],
+    [trigger],
+  )
+  const allSlacks = useMemo(
+    () => trigger?.response?.slacks?.map((slack) => slack.url) ?? [],
+    [trigger],
+  )
+  const enabled = useMemo(() => trigger?.enabled ?? true, [trigger])
+
+  /**
+   * Sync form state with trigger data when it is available.
+   */
+  useEffect(() => {
+    if (!isTriggerLoading && trigger) {
+      setSelectedTemplate(trigger.name)
+      setSelectedEmails(allEmails.length > 0 ? [allEmails[0]] : [])
+      setSelectedSlacks(allSlacks.length > 0 ? [allSlacks[0]] : [])
+      setDescription(trigger.description)
+    }
+  }, [trigger, isTriggerLoading, allEmails, allSlacks])
+
+  const handleTemplateSelect = (id: string) => {
+    setSelectedTemplate(id)
+  }
+
+  /**
+   * By default, only one template is displayed and multiple selections are not expected,
+   * so the `handleTemplateSelectAll` has no effect here and it will always checked.
+   */
+  const handleTemplateSelectAll = () => {}
+
+  const handleEmailSelect = (id: string) => {
+    setSelectedEmails((prev) =>
+      isRowSelected(id, prev)
+        ? prev.filter((email) => email !== id)
+        : [...prev, id],
+    )
+  }
+
+  const handleEmailSelectAll = () => {
+    setSelectedEmails((prev) =>
+      isAllSelected(allEmails, prev) ? [] : allEmails,
+    )
+  }
+
+  const handleSlackSelect = (id: string) => {
+    setSelectedSlacks((prev) =>
+      isRowSelected(id, prev)
+        ? prev.filter((slack) => slack !== id)
+        : [...prev, id],
+    )
+  }
+
+  const handleSlackSelectAll = () => {
+    setSelectedSlacks((prev) =>
+      isAllSelected(allSlacks, prev) ? [] : allSlacks,
+    )
+  }
+
+  const handleDescriptionChange = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setDescription(e.target.value)
+  }
+
+  return {
+    enabled,
+    selectedTemplate,
+    attributes,
+    selectedEmails,
+    selectedSlacks,
+    description,
+    handleTemplateSelect,
+    handleTemplateSelectAll,
+    handleEmailSelect,
+    handleEmailSelectAll,
+    handleSlackSelect,
+    handleSlackSelectAll,
+    handleDescriptionChange,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useCreateTriggerForm.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useCreateTriggerForm.ts
@@ -12,13 +12,10 @@ type UseTriggerCreateFormOption = {
 
 type UseTriggerCreateForm = {
   enabled: boolean
-  selectedTemplate: string | undefined
   attributes: GetTriggersResponseDataInnerAttributes[]
   selectedEmails: string[]
   selectedSlacks: string[]
   description: string
-  handleTemplateSelect: (id: string) => void
-  handleTemplateSelectAll: () => void
   handleEmailSelect: (id: string) => void
   handleEmailSelectAll: () => void
   handleSlackSelect: (id: string) => void
@@ -34,7 +31,6 @@ export const useTriggerCreateForm = (
   /**
    * Form States
    */
-  const [selectedTemplate, setSelectedTemplate] = useState<string>()
   const [selectedEmails, setSelectedEmails] = useState<string[]>([])
   const [selectedSlacks, setSelectedSlacks] = useState<string[]>([])
   const [description, setDescription] = useState<string>('')
@@ -62,22 +58,11 @@ export const useTriggerCreateForm = (
    */
   useEffect(() => {
     if (!isTriggerLoading && trigger) {
-      setSelectedTemplate(trigger.name)
       setSelectedEmails(allEmails.length > 0 ? [allEmails[0]] : [])
       setSelectedSlacks(allSlacks.length > 0 ? [allSlacks[0]] : [])
       setDescription(trigger.description)
     }
   }, [trigger, isTriggerLoading, allEmails, allSlacks])
-
-  const handleTemplateSelect = (id: string) => {
-    setSelectedTemplate(id)
-  }
-
-  /**
-   * By default, only one template is displayed and multiple selections are not expected,
-   * so the `handleTemplateSelectAll` has no effect here and it will always checked.
-   */
-  const handleTemplateSelectAll = () => {}
 
   const handleEmailSelect = (id: string) => {
     setSelectedEmails((prev) =>
@@ -113,13 +98,10 @@ export const useTriggerCreateForm = (
 
   return {
     enabled,
-    selectedTemplate,
     attributes,
     selectedEmails,
     selectedSlacks,
     description,
-    handleTemplateSelect,
-    handleTemplateSelectAll,
     handleEmailSelect,
     handleEmailSelectAll,
     handleSlackSelect,

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useTemplateTable.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useTemplateTable.ts
@@ -1,0 +1,82 @@
+import { useContext, useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router'
+import { CosTableRow } from '@cube-frontend/ui-library'
+import { triggersApi } from '@cube-frontend/web-app/api/cosApi'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
+
+export type TemplateRow = {
+  name: string
+  description: string
+} & CosTableRow
+
+type UseTemplateTable = {
+  dataCenter: string
+  isTemplateLoading: boolean
+  templateRows: TemplateRow[]
+  disabledRowsId: string[]
+  selectedTemplateName: string | null
+  handleTemplateSelect: (selectedId: string) => void
+}
+
+export const useTemplateTable = (): UseTemplateTable => {
+  const [searchParams, _] = useSearchParams()
+
+  const urlTemplateName = searchParams.get('name')
+
+  const { name: dataCenter } = useContext(DataCenterContext)
+
+  /**
+   * When editing a trigger, the URL will include a name corresponding to the default `selectedTemplateName`.
+   * In this case, the template table will automatically select the matching template name,
+   * while other template rows will be disabled.
+   *
+   * In Phase 2, a `Create a new trigger from template` feature will be implemented.
+   * At that time, there will be no query string in the URL, meaning no default `selectedTemplateName`.
+   * As a result, all rows in the table will be selectable, adn no rows will be pre-selected.
+   *
+   */
+  const [selectedTemplateName, setSelectedTemplateName] = useState<
+    string | null
+  >(urlTemplateName)
+
+  const { isLoading, data } = useCosGetRequest(triggersApi.getTriggers, () => {
+    if (!dataCenter) return
+    return {
+      dataCenter,
+    }
+  })
+
+  const templateRows: TemplateRow[] = useMemo(() => {
+    if (!data) return []
+    return data.map((template) => ({
+      name: template.name,
+      description: template.description,
+      id: template.name,
+    }))
+  }, [data])
+
+  const disabledRowsId = urlTemplateName
+    ? templateRows
+        .filter((template) => template.name !== selectedTemplateName)
+        .map((template) => template.id)
+    : []
+
+  const handleTemplateSelect = (selectedId: string) => {
+    const selectedTemplate = templateRows.find(
+      (template) => template.id === selectedId,
+    )
+    setSelectedTemplateName((prev) => {
+      return selectedTemplate ? selectedTemplate.name : prev
+    })
+  }
+
+  return {
+    dataCenter,
+    isTemplateLoading: isLoading,
+    templateRows,
+    disabledRowsId,
+    selectedTemplateName,
+    handleTemplateSelect,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useTrigger.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useTrigger.ts
@@ -1,0 +1,32 @@
+import { useContext } from 'react'
+import { useSearchParams } from 'react-router'
+import { GetTriggerResponseData } from '@cube-frontend/api'
+import { triggersApi } from '@cube-frontend/web-app/api/cosApi'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
+
+type UseTrigger = {
+  isTriggerLoading: boolean
+  trigger: GetTriggerResponseData | undefined
+}
+
+export const useTrigger = (): UseTrigger => {
+  const [searchParams, _] = useSearchParams()
+
+  const triggerName = searchParams.get('name')
+
+  const { name: dataCenter } = useContext(DataCenterContext)
+
+  const { data, isLoading } = useCosGetRequest(triggersApi.getTrigger, () => {
+    if (!dataCenter || !triggerName) return null
+    return {
+      dataCenter,
+      triggerName,
+    }
+  })
+
+  return {
+    isTriggerLoading: isLoading,
+    trigger: data,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useTrigger.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useTrigger.ts
@@ -1,27 +1,25 @@
-import { useContext } from 'react'
-import { useSearchParams } from 'react-router'
 import { GetTriggerResponseData } from '@cube-frontend/api'
 import { triggersApi } from '@cube-frontend/web-app/api/cosApi'
-import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
+
+type UseTriggerOption = {
+  dataCenter: string
+  selectedTemplateName: string | null
+}
 
 type UseTrigger = {
   isTriggerLoading: boolean
   trigger: GetTriggerResponseData | undefined
 }
 
-export const useTrigger = (): UseTrigger => {
-  const [searchParams, _] = useSearchParams()
-
-  const triggerName = searchParams.get('name')
-
-  const { name: dataCenter } = useContext(DataCenterContext)
+export const useTrigger = (option: UseTriggerOption): UseTrigger => {
+  const { dataCenter, selectedTemplateName } = option
 
   const { data, isLoading } = useCosGetRequest(triggersApi.getTrigger, () => {
-    if (!dataCenter || !triggerName) return null
+    if (!dataCenter || !selectedTemplateName) return
     return {
       dataCenter,
-      triggerName,
+      triggerName: selectedTemplateName,
     }
   })
 

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useUpdateTrigger.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useUpdateTrigger.ts
@@ -15,9 +15,10 @@ import {
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 
 type UseUpdateTriggerOption = {
+  isValid: boolean
   enabled: boolean
   attributes: GetTriggersResponseDataInnerAttributes[]
-  selectedTemplate: string | undefined
+  selectedTemplateName: string | null
   selectedEmails: string[]
   selectedSlacks: string[]
 }
@@ -32,9 +33,10 @@ export const useUpdateTrigger = (
   option: UseUpdateTriggerOption,
 ): UseUpdateTrigger => {
   const {
+    isValid,
     enabled,
     attributes,
-    selectedTemplate,
+    selectedTemplateName,
     selectedEmails,
     selectedSlacks,
   } = option
@@ -58,10 +60,11 @@ export const useUpdateTrigger = (
     clearError()
 
     try {
-      if (!dataCenter || !selectedTemplate) return
+      if (!dataCenter || !selectedTemplateName || !isValid) return
+
       await updateTrigger({
         dataCenter,
-        triggerName: selectedTemplate,
+        triggerName: selectedTemplateName,
         updateTriggerRequest: {
           attributes: attributes.map(
             ({ name, type, value, enabled }) =>

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useUpdateTrigger.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useUpdateTrigger.ts
@@ -16,11 +16,11 @@ import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosReques
 
 type UseUpdateTriggerOption = {
   isValid: boolean
-  enabled: boolean
   attributes: GetTriggersResponseDataInnerAttributes[]
   selectedTemplateName: string | null
   selectedEmails: string[]
   selectedSlacks: string[]
+  description: string
 }
 
 type UseUpdateTrigger = {
@@ -34,11 +34,11 @@ export const useUpdateTrigger = (
 ): UseUpdateTrigger => {
   const {
     isValid,
-    enabled,
     attributes,
     selectedTemplateName,
     selectedEmails,
     selectedSlacks,
+    description,
   } = option
 
   const navigate = useNavigate()
@@ -87,7 +87,7 @@ export const useUpdateTrigger = (
                 }) satisfies UpdateTriggerRequestResponseEmailsInner,
             ),
           },
-          enabled,
+          description,
         },
       })
       navigate('/events/triggers')

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useUpdateTrigger.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/useUpdateTrigger.ts
@@ -1,0 +1,101 @@
+import { useContext } from 'react'
+import { useNavigate } from 'react-router'
+import {
+  GetTriggersResponseDataInnerAttributes,
+  TriggersApiUpdateTriggerRequest,
+  UpdateTriggerRequestResponseEmailsInner,
+  UpdateTriggerRequestResponseSlacksInner,
+} from '@cube-frontend/api'
+import { triggersApi } from '@cube-frontend/web-app/api/cosApi'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import {
+  CosApiResponse,
+  CosRequestError,
+} from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
+import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
+
+type UseUpdateTriggerOption = {
+  enabled: boolean
+  attributes: GetTriggersResponseDataInnerAttributes[]
+  selectedTemplate: string | undefined
+  selectedEmails: string[]
+  selectedSlacks: string[]
+}
+
+type UseUpdateTrigger = {
+  isUpdateLoading: boolean
+  handleTriggerUpdate: () => Promise<void>
+  errorState: CosRequestError | undefined
+}
+
+export const useUpdateTrigger = (
+  option: UseUpdateTriggerOption,
+): UseUpdateTrigger => {
+  const {
+    enabled,
+    attributes,
+    selectedTemplate,
+    selectedEmails,
+    selectedSlacks,
+  } = option
+
+  const navigate = useNavigate()
+
+  const { name: dataCenter } = useContext(DataCenterContext)
+
+  const {
+    isLoading: isUpdateLoading,
+    mutateResource: updateTrigger,
+    errorState,
+    clearError,
+  } = useCosMutationRequest(
+    triggersApi.updateTrigger as (
+      params: TriggersApiUpdateTriggerRequest,
+    ) => Promise<CosApiResponse<undefined>>,
+  )
+
+  const handleTriggerUpdate = async () => {
+    clearError()
+
+    try {
+      if (!dataCenter || !selectedTemplate) return
+      await updateTrigger({
+        dataCenter,
+        triggerName: selectedTemplate,
+        updateTriggerRequest: {
+          attributes: attributes.map(
+            ({ name, type, value, enabled }) =>
+              ({
+                name,
+                type,
+                value,
+                enabled,
+              }) satisfies GetTriggersResponseDataInnerAttributes,
+          ),
+          response: {
+            slacks: selectedSlacks.map(
+              (url) =>
+                ({ url }) satisfies UpdateTriggerRequestResponseSlacksInner,
+            ),
+            emails: selectedEmails.map(
+              (address) =>
+                ({
+                  address,
+                }) satisfies UpdateTriggerRequestResponseEmailsInner,
+            ),
+          },
+          enabled,
+        },
+      })
+      navigate('/events/triggers')
+    } catch (error) {
+      console.error('Update trigger error: ', error)
+    }
+  }
+
+  return {
+    isUpdateLoading,
+    handleTriggerUpdate,
+    errorState,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/utils.ts
@@ -1,0 +1,91 @@
+import { GetTriggersResponseDataInnerAttributes } from '@cube-frontend/api'
+
+export type CreateStep =
+  | 'Select Template'
+  | 'Select Events'
+  | 'Set Response'
+  | 'Add Description'
+
+export type TriggersCreateStep = {
+  serialNumber: number
+  label: CreateStep
+}
+
+export const triggersCreateSteps: TriggersCreateStep[] = [
+  { serialNumber: 1, label: 'Select Template' },
+  { serialNumber: 2, label: 'Select Events' },
+  { serialNumber: 3, label: 'Set Response' },
+  { serialNumber: 4, label: 'Add Description' },
+] as const
+
+type GroupedAttribute = Record<string, GetTriggersResponseDataInnerAttributes[]>
+
+export const groupAttributeByName = (
+  arr: GetTriggersResponseDataInnerAttributes[] | undefined,
+): GroupedAttribute | undefined => {
+  if (!arr) return
+  return arr.reduce((acc: GroupedAttribute, item) => {
+    if (!acc[item.name]) {
+      acc[item.name] = []
+    }
+    acc[item.name].push(item)
+    return acc
+  }, {})
+}
+
+/**
+ * @returns An object containing:
+ *   - `isValid`: `true` if the form values are valid for the given step, otherwise `false`.
+ *   - `errorMessage`: A string describing the validation error, or `undefined` if valid.
+ */
+export const isFormValueValid = (
+  activeStep: TriggersCreateStep,
+  selectedTemplate: string | undefined,
+  selectedEmails: string[],
+  selectedSlacks: string[],
+): { isValid: boolean; errorMessage?: string } => {
+  switch (activeStep.label) {
+    case 'Select Template':
+      return {
+        isValid: Boolean(selectedTemplate),
+        errorMessage: selectedTemplate
+          ? undefined
+          : 'A template must be selected.',
+      }
+
+    case 'Set Response': {
+      const hasEmails = selectedEmails.length > 0
+      const hasSlacks = selectedSlacks.length > 0
+      return {
+        isValid: hasEmails && hasSlacks,
+        errorMessage: hasEmails
+          ? hasSlacks
+            ? undefined
+            : 'At least one Slack channel must be selected.'
+          : 'At least one email recipient must be selected.',
+      }
+    }
+
+    default:
+      return { isValid: true, errorMessage: undefined }
+  }
+}
+
+/**
+ * Check if a specific row is selected.
+ */
+export const isRowSelected = (id: string, selectedRowIds: string[]): boolean =>
+  selectedRowIds.includes(id)
+
+/**
+ * Check if all items in the original array are selected.
+ */
+export const isAllSelected = (
+  originalArray: string[],
+  selectedArray: string[],
+): boolean => {
+  return (
+    originalArray.length === selectedArray.length &&
+    originalArray.every((item) => selectedArray.includes(item))
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/_components/utils.ts
@@ -40,15 +40,15 @@ export const groupAttributeByName = (
  */
 export const isFormValueValid = (
   activeStep: TriggersCreateStep,
-  selectedTemplate: string | undefined,
+  selectedTemplateName: string | null,
   selectedEmails: string[],
   selectedSlacks: string[],
 ): { isValid: boolean; errorMessage?: string } => {
   switch (activeStep.label) {
     case 'Select Template':
       return {
-        isValid: Boolean(selectedTemplate),
-        errorMessage: selectedTemplate
+        isValid: Boolean(selectedTemplateName),
+        errorMessage: selectedTemplateName
           ? undefined
           : 'A template must be selected.',
       }

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/EventsTriggersTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/EventsTriggersTable.tsx
@@ -1,0 +1,56 @@
+import { CosLoadingSpinner, GetCosBasicTable } from '@cube-frontend/ui-library'
+import { TriggersActionCell } from './TriggersActionCell'
+import { TriggersStatusToggle } from './TriggersStatusToggle'
+import { useTriggerRows } from './useTriggerRows'
+import { getTriggerResponse, TriggerRow } from './utils'
+
+const TriggersTable = GetCosBasicTable<TriggerRow>()
+
+export const EventsTriggersTable = () => {
+  const { rows, isLoading, handleStatusChange, handleEdit, handleDelete } =
+    useTriggerRows()
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="primary-h5">Triggers</div>
+      <TriggersTable rows={rows} isLoading={isLoading}>
+        <TriggersTable.Column label="Triggers" property="name">
+          {(name, row) => (
+            <span className="flex items-center">
+              {name}
+              {row.isResetting && <CosLoadingSpinner variant="dot120" />}
+            </span>
+          )}
+        </TriggersTable.Column>
+        <TriggersTable.Column label="Description" property="description" />
+        <TriggersTable.Column label="Response" property="response">
+          {(response) => (
+            <span className="whitespace-nowrap">
+              {getTriggerResponse(response.types)}
+            </span>
+          )}
+        </TriggersTable.Column>
+        <TriggersTable.Column label="Status" property="enabled">
+          {(enabled, row) => (
+            <TriggersStatusToggle
+              isLoading={row.isResetting ?? false}
+              triggerName={row.name}
+              isOn={enabled}
+              onChange={handleStatusChange}
+            />
+          )}
+        </TriggersTable.Column>
+        <TriggersTable.Column>
+          {(_, row) => (
+            <TriggersActionCell
+              isLoading={row.isResetting ?? false}
+              triggerName={row.name}
+              onEditClick={handleEdit}
+              onDeleteClick={handleDelete}
+            />
+          )}
+        </TriggersTable.Column>
+      </TriggersTable>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/TriggersActionCell.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/TriggersActionCell.tsx
@@ -1,0 +1,52 @@
+import { cva } from 'class-variance-authority'
+import { twMerge } from 'tailwind-merge'
+import EditIcon from '@cube-frontend/ui-library/icons/monochrome/edit.svg?react'
+import DeleteIcon from '@cube-frontend/ui-library/icons/monochrome/delete.svg?react'
+
+const button = cva('icon-md text-functional-text', {
+  variants: {
+    disabled: { true: 'text-functional-disable-text' },
+  },
+})
+
+type TriggersActionCellProps = {
+  isLoading: boolean
+  triggerName: string
+  onEditClick: (triggerName: string) => void
+  onDeleteClick: () => void
+}
+
+export const TriggersActionCell = (props: TriggersActionCellProps) => {
+  const { triggerName, isLoading, onEditClick, onDeleteClick } = props
+
+  const handleEditButtonClick = () => {
+    onEditClick(triggerName)
+  }
+
+  const renderEditButton = () => {
+    return (
+      <button disabled={isLoading} onClick={handleEditButtonClick}>
+        <EditIcon className={twMerge(button({ disabled: isLoading }))} />
+      </button>
+    )
+  }
+
+  const renderDeleteButton = () => {
+    return (
+      /**
+       * The delete trigger function is not included in Phase 1,
+       * so the button should either be disabled or removed (pending UI update).
+       */
+      <button disabled={true} onClick={onDeleteClick}>
+        <DeleteIcon className={twMerge(button({ disabled: true }))} />
+      </button>
+    )
+  }
+
+  return (
+    <div className="flex items-center gap-x-4">
+      {renderEditButton()}
+      {renderDeleteButton()}
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/TriggersStatusToggle.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/TriggersStatusToggle.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react'
+import { CosToggle } from '@cube-frontend/ui-library'
+
+type TriggersStatusToggleProps = {
+  isLoading: boolean
+  triggerName: string
+  isOn: boolean
+  onChange: (triggerName: string, enabled: boolean) => Promise<void>
+}
+
+export const TriggersStatusToggle = (props: TriggersStatusToggleProps) => {
+  const { isLoading, triggerName, isOn: isOnProps, onChange } = props
+
+  const [isOn, setIsOn] = useState(isOnProps)
+
+  const handleToggleOn = () => {
+    onChange(triggerName, isOn)
+    setIsOn((prev) => !prev)
+  }
+
+  return (
+    <CosToggle isOn={isOn} onChange={handleToggleOn} disabled={isLoading} />
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/useTriggerRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/useTriggerRows.ts
@@ -1,0 +1,118 @@
+import { useContext, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router'
+import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { triggersApi } from '@cube-frontend/web-app/api/cosApi'
+import { TriggersApiGetTriggersRequest } from '@cube-frontend/api'
+import { mapToTriggerTableRows, TriggerRow } from './utils'
+
+export type UseTriggerRows = {
+  isLoading: boolean
+  rows: TriggerRow[]
+  handleStatusChange: (triggerName: string, enabled: boolean) => Promise<void>
+  handleEdit: (triggerName: string) => void
+  handleDelete: () => void
+}
+
+export const useTriggerRows = (): UseTriggerRows => {
+  const navigate = useNavigate()
+
+  const { name: dataCenter } = useContext(DataCenterContext)
+
+  const [rows, setRows] = useState<TriggerRow[]>([])
+
+  const { data: triggersResponse, isLoading } = useCosGetRequest(
+    triggersApi.getTriggers,
+    (): TriggersApiGetTriggersRequest => ({
+      dataCenter,
+    }),
+  )
+
+  useEffect(() => {
+    const formattedRows = mapToTriggerTableRows(triggersResponse ?? [])
+    setRows(formattedRows)
+  }, [triggersResponse])
+
+  const patchRow = (
+    triggerName: string,
+    payload: Partial<TriggerRow>,
+  ): void => {
+    setRows((prevRows) => {
+      const rowIndex = prevRows.findIndex((row) => row.name === triggerName)
+
+      if (rowIndex < 0) {
+        return prevRows
+      } else {
+        const newRows = [...prevRows]
+        Object.assign(newRows[rowIndex], payload)
+        return newRows
+      }
+    })
+  }
+
+  const handleStatusChange = async (
+    triggerName: string,
+    /**
+     * It is the new status to update for the trigger.
+     */
+    enabled: boolean,
+  ): Promise<void> => {
+    const targetRow = rows.find((row) => row.name === triggerName)
+
+    if (!targetRow) {
+      return undefined
+    }
+
+    const enabledBeforeUpdate = targetRow.enabled
+
+    patchRow(triggerName, {
+      enabled,
+      status: {
+        ...targetRow,
+        isUpdating: true,
+      },
+    })
+
+    try {
+      /**
+       * Update toggle status with the new API,
+       * which only updates the status without passing the rest of the request.
+       */
+    } catch (error) {
+      console.error('Trigger update error: ', error)
+      /**
+       * Handle update API errors
+       * and revert the row to its previous state if an error occurs.
+       */
+      patchRow(triggerName, {
+        enabled: enabledBeforeUpdate,
+        status: {
+          ...targetRow,
+          isUpdating: false,
+        },
+      })
+    }
+  }
+
+  const handleEdit = (triggerName: string) => {
+    /**
+     * Navigate to the Edit page for the selected trigger.
+     */
+    navigate(`/events/triggers/create?name=${triggerName}`)
+  }
+
+  const handleDelete = () => {
+    /**
+     * Handle trigger deletion here;
+     * the function is not included in Phase 1.
+     */
+  }
+
+  return {
+    rows,
+    isLoading,
+    handleStatusChange,
+    handleEdit,
+    handleDelete,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/_components/EventsTriggersTable/utils.ts
@@ -1,0 +1,30 @@
+import { uniqueId } from 'lodash'
+import { GetTriggersResponseDataInner } from '@cube-frontend/api'
+import { CosTableRow } from '@cube-frontend/ui-library'
+
+export type TriggerRow = GetTriggersResponseDataInner &
+  CosTableRow & {
+    isResetting?: boolean
+  }
+
+const getRowId = (): string => uniqueId('trigger')
+
+export const mapToTriggerTableRows = (
+  triggers: GetTriggersResponseDataInner[],
+): TriggerRow[] =>
+  triggers.map((trigger) => ({
+    ...trigger,
+    id: getRowId(),
+    isResetting: false,
+  }))
+
+export const getTriggerResponse = (res: string[]): string => {
+  const hasSlack = res.includes('slack')
+  const hasEmail = res.includes('email')
+
+  if (hasSlack && hasEmail) return 'Slack / Emails'
+  if (hasSlack) return 'Slack'
+  if (hasEmail) return 'Emails'
+
+  return ''
+}


### PR DESCRIPTION
#### What type of PR is this?

- feature

#### What this PR does / why we need it

##### 1) Select Template

- `When editing`: The table should display all available templates, but the others should be disabled.

https://github.com/user-attachments/assets/03be3de4-e5b6-46ac-a95d-d4e0c72fdd17

- `When creating`: The table should display all available templates, and all the rows are selectable.  It will be implemented in Phase 2.

<img width="1509" alt="Screenshot 2025-04-02 at 3 45 50 PM" src="https://github.com/user-attachments/assets/9c681048-7d76-4dec-831f-c18613ca4f9b" />

##### 2) Select Events

- In Phase 1, attributes cannot be added, edited, or removed.

https://github.com/user-attachments/assets/e794602f-d3d4-4ecb-a1c0-6bd7f1c5f238

##### 3) Set Response

- ⚠️ How does the UI reflect changes after updating?

https://github.com/user-attachments/assets/91b82a1a-aa05-4d36-a0cb-848441a7e9e7

##### 4) Add Description

- ⚠️ The description field is not yet included in the API parameters.

https://github.com/user-attachments/assets/6ac68daa-a06e-441c-bb48-24e5d92ba5da


#### Which issue(s) this PR fixes

- close #147 

#### Special notes for your reviewer

- It is based on PR #196 

#### Additional documentation

```docs

```
