### PR TITLE
204 show/hide remember me based on keycloak config

### DIFF
--- a/packages/cube-frontend-keycloak-login/keycloak/themes/cos-ui/login/login.ftl
+++ b/packages/cube-frontend-keycloak-login/keycloak/themes/cos-ui/login/login.ftl
@@ -9,6 +9,7 @@
                 formActionUrl: '${url.loginAction?js_string?no_esc}',
                 authSelectedCredentials: <#if auth.selectedCredential?has_content>"${auth.selectedCredential}"<#else>undefined</#if>,
                 loginGreeting: '${properties.loginGreeting?js_string?no_esc}',
+                isRememberMeEnabled: <#if realm.rememberMe && !usernameHidden??>true<#else>false</#if>
             }
         </script>
         <div id="kc-form-wrapper" style="height: 100%;"></div>

--- a/packages/cube-frontend-keycloak-login/src/components/LoginForm/LoginField.tsx
+++ b/packages/cube-frontend-keycloak-login/src/components/LoginForm/LoginField.tsx
@@ -7,7 +7,8 @@ import {
 import { useMemo } from 'react'
 
 export const LoginFields = () => {
-  const { incorrectCredentials, sessionTimedOut } = window.keycloakLoginContext
+  const { incorrectCredentials, sessionTimedOut, isRememberMeEnabled } =
+    window.keycloakLoginContext
 
   const naggingMessage = useMemo<string | undefined>(() => {
     if (sessionTimedOut) {
@@ -43,12 +44,14 @@ export const LoginFields = () => {
         autoComplete="off"
         tabIndex={0}
       />
-      <CosCheckbox
-        name="rememberMe"
-        label="Remember username"
-        defaultChecked={true}
-        tabIndex={0}
-      />
+      {isRememberMeEnabled && (
+        <CosCheckbox
+          name="rememberMe"
+          label="Remember username"
+          defaultChecked={true}
+          tabIndex={0}
+        />
+      )}
     </div>
   )
 }

--- a/packages/cube-frontend-keycloak-login/src/keycloakLoginContext.d.ts
+++ b/packages/cube-frontend-keycloak-login/src/keycloakLoginContext.d.ts
@@ -16,5 +16,6 @@ interface Window {
     formActionUrl: string
     authSelectedCredentials: string | undefined
     loginGreeting: string
+    isRememberMeEnabled: boolean
   }
 }

--- a/packages/cube-frontend-keycloak-login/src/keycloakLoginContextSetupDev.ts
+++ b/packages/cube-frontend-keycloak-login/src/keycloakLoginContextSetupDev.ts
@@ -7,5 +7,6 @@ if (import.meta.env.DEV) {
       'http://localhost:8642/auth/realms/master/login-actions/authenticate?session_code=a6ESSp_K4BexArNGC3-vShOEDcO79tvomSu8SJrN8_k&execution=336de572-f999-43b8-af68-961e86711af7&client_id=security-admin-console&tab_id=AQCFEittHgs',
     authSelectedCredentials: undefined,
     loginGreeting: '',
+    isRememberMeEnabled: true,
   }
 }


### PR DESCRIPTION
Close #204 

#### What type of PR is this?

Feat

#### What this PR does / why we need it

Show/hide the remember me control based on keycloak config.

#### Additional documentation

Cited from the [official docs](https://www.keycloak.org/docs/latest/server_admin/index.html#enabling-remember-me):

> A logged-in user closing their browser destroys their session, and that user must log in again. You can set Keycloak to keep the user’s login session open if that user clicks the Remember Me checkbox upon login. This action turns the login cookie from a session-only cookie to a persistence cookie.

https://github.com/user-attachments/assets/48fa0564-2fb3-4807-9e03-2f6f997fec67

I have written a [comment](https://github.com/bigstack-oss/cube-cos-ui/issues/204#issuecomment-2771357339) explaining how Keycloak's Remember Me feature works, which should be helpful understanding what this PR does.

Let me know if you have any question! 🙏 