### PR TITLE
215 home chart disk io read/write duplicate labels

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/RankingPanels/RankingChart/RankingItem.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/RankingPanels/RankingChart/RankingItem.tsx
@@ -15,6 +15,19 @@ export type RankingItemProps = {
 export const RankingItem = (props: RankingItemProps) => {
   const { rankingItem, unit, isBlur, onMouseEnter, onMouseLeave } = props
 
+  const getName = () => {
+    const { name, device } = rankingItem
+    if (device) {
+      return (
+        <span>
+          <span className="break-all">{name}</span>
+          <span className="ml-1 text-functional-text-light">{`(${device})`}</span>
+        </span>
+      )
+    }
+    return name
+  }
+
   const abbreviationUnit = toUnitAbbreviation(unit)
 
   return (
@@ -25,7 +38,7 @@ export const RankingItem = (props: RankingItemProps) => {
       )}
     >
       <span className="primary-body3 w-[140px] text-functional-text">
-        {rankingItem.name}
+        {getName()}
       </span>
       <div className="flex h-[36px] flex-1 items-center gap-x-1.5">
         <span className="primary-body5 w-[48px]">


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix the duplicate labels issue in Home Chart page, disk IO read/write charts.

#### Which issue(s) this PR fixes

Fixes #215

#### Special notes for your reviewer

In short: Append `device` to the end of the ranking item label when available as a quick workaround.

https://github.com/user-attachments/assets/ad0b53bd-144e-41bb-b021-e2c4d27aa580
