### PR TITLE
21 ui library - CosToastNotification

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosInlineNotification/CosInlineNotification.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosInlineNotification/CosInlineNotification.tsx
@@ -2,18 +2,14 @@ import { PropsWithChildren, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import { cva } from 'class-variance-authority'
 import { PropsWithClassName } from '@cube-frontend/utils'
-import CircleFill from '../../../components/CosIcon/monochrome/circle_fill.svg?react'
-import WarningFilled from '../../../components/CosIcon/monochrome/warning_filled.svg?react'
-import WarningAltFilled from '../../../components/CosIcon/monochrome/warning_alt_filled.svg?react'
-import CloseIcon from '../../../components/CosIcon/monochrome/x_small.svg?react'
-import { CosHyperlink } from '../../CosHyperlink/CosHyperlink'
 import { CosInlineNotificationSkeleton } from './CosInlineNotificationSkeleton'
-
-export type CosInlineNotificationType =
-  | 'neutral'
-  | 'positive'
-  | 'warning'
-  | 'error'
+import { CosNotificationBaseProps } from '../cosNotificationTypes'
+import {
+  renderCloseButton,
+  renderIcon,
+  renderLink,
+  renderTitle,
+} from '../cosNotificationUtils'
 
 const notificationStyles = cva(
   [
@@ -40,20 +36,11 @@ const notificationStyles = cva(
 )
 
 type CosInlineNotificationProps = PropsWithChildren<
-  PropsWithClassName & {
-    isLoading?: boolean
-    /**
-     * @default 'neutral'
-     */
-    type?: CosInlineNotificationType
-    title?: string
-    link?: {
-      href: string
-      text: string
+  PropsWithClassName &
+    CosNotificationBaseProps & {
+      isLoading?: boolean
+      skeletonClassName?: string
     }
-    onClose?: () => void
-    skeletonClassName?: string
-  }
 >
 
 export const CosInlineNotification = (props: CosInlineNotificationProps) => {
@@ -75,50 +62,6 @@ export const CosInlineNotification = (props: CosInlineNotificationProps) => {
     setClose(true)
   }
 
-  const renderIcon = () => {
-    switch (type) {
-      case 'positive':
-        return <CircleFill className="icon-md shrink-0 text-status-positive" />
-      case 'warning':
-        return (
-          <WarningAltFilled className="icon-md shrink-0 text-status-warning" />
-        )
-      case 'error':
-        return (
-          <WarningFilled className="icon-md shrink-0 text-status-negative" />
-        )
-      default:
-        return null
-    }
-  }
-
-  const renderTitle = () => {
-    if (!title) {
-      return null
-    }
-    return <div className="font-semibold text-functional-title">{title}</div>
-  }
-
-  const renderLink = () => {
-    if (!link) {
-      return null
-    }
-    return (
-      <CosHyperlink size="sm" variant="text-inline" href={link.href}>
-        {link.text}
-      </CosHyperlink>
-    )
-  }
-
-  const renderCloseButton = () => {
-    return (
-      <CloseIcon
-        className="icon-md shrink-0 cursor-pointer text-functional-text hover:text-functional-text-light"
-        onClick={handleClose}
-      />
-    )
-  }
-
   if (isLoading)
     return (
       <CosInlineNotificationSkeleton
@@ -138,13 +81,13 @@ export const CosInlineNotification = (props: CosInlineNotificationProps) => {
       )}
     >
       <div className="flex flex-1 items-start gap-2">
-        {renderIcon()}
-        {renderTitle()}
+        {renderIcon(type)}
+        {renderTitle(title)}
         {children}
       </div>
       <div className="flex items-center gap-2 self-start">
-        {renderLink()}
-        {renderCloseButton()}
+        {renderLink(link)}
+        {renderCloseButton(handleClose)}
       </div>
     </div>
   )

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToast.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToast.tsx
@@ -1,0 +1,122 @@
+import { useEffect } from 'react'
+import { CosToastType, TOAST_LIFETIME } from './utils'
+import { cva } from 'class-variance-authority'
+import CircleFill from '../../../components/CosIcon/monochrome/circle_fill.svg?react'
+import WarningFilled from '../../../components/CosIcon/monochrome/warning_filled.svg?react'
+import WarningAltFilled from '../../../components/CosIcon/monochrome/warning_alt_filled.svg?react'
+import CloseIcon from '../../../components/CosIcon/monochrome/x_small.svg?react'
+import { CosHyperlink } from '../../CosHyperlink/CosHyperlink'
+
+const toastStyles = cva(
+  [
+    'flex w-[352px] shrink-0 flex-col gap-[10px] rounded-[5px] border p-5',
+    'primary-body4 text-functional-text-light',
+  ],
+  {
+    variants: {
+      type: {
+        neutral: 'border-primary bg-primary-0',
+        positive: 'border-status-positive bg-green-0',
+        warning: 'border-status-warning bg-yellow-0',
+        error: 'border-status-negative bg-red-0',
+      },
+    },
+  },
+)
+
+type CosToastProps = CosToastType & {
+  onToastClose: (id: string) => void
+}
+
+export const CosToast = (props: CosToastProps) => {
+  const {
+    id,
+    type = 'neutral',
+    title,
+    message,
+    link,
+    onToastClose,
+    time,
+  } = props
+
+  const renderIcon = () => {
+    switch (type) {
+      case 'positive':
+        return <CircleFill className="icon-md shrink-0 text-status-positive" />
+      case 'warning':
+        return (
+          <WarningAltFilled className="icon-md shrink-0 text-status-warning" />
+        )
+      case 'error':
+        return (
+          <WarningFilled className="icon-md shrink-0 text-status-negative" />
+        )
+      default:
+        return null
+    }
+  }
+
+  const renderHeader = () => {
+    if (!title) return null
+
+    return (
+      <div className="flex items-center gap-[6px]">
+        {renderIcon()}
+        <div className="font-semibold text-functional-title">{title}</div>
+      </div>
+    )
+  }
+
+  const renderLink = () => {
+    if (!link) return null
+
+    return (
+      <CosHyperlink size="sm" variant="text-inline" href={link.href}>
+        {link.text}
+      </CosHyperlink>
+    )
+  }
+
+  const renderTime = () => {
+    return <div className="primary-body5 ml-auto">{time}</div>
+  }
+
+  const renderCloseButton = () => {
+    return (
+      <CloseIcon
+        className="icon-md shrink-0 cursor-pointer text-functional-text hover:text-functional-text-light"
+        onClick={() => onToastClose(id)}
+      />
+    )
+  }
+
+  return (
+    <div className={toastStyles({ type })}>
+      <div className="flex gap-4">
+        <div className="flex flex-1 flex-col gap-3">
+          {renderHeader()}
+          {message}
+        </div>
+        {renderCloseButton()}
+      </div>
+      <div className="flex w-full items-center">
+        {renderLink()}
+        {renderTime()}
+      </div>
+    </div>
+  )
+}
+
+export const CosToastWrapper = (props: CosToastProps) => {
+  const { id, onToastClose, ...restProps } = props
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      onToastClose(id)
+    }, TOAST_LIFETIME)
+
+    return () => clearTimeout(timer)
+  }, [id, onToastClose])
+
+  return <CosToast {...restProps} id={id} onToastClose={onToastClose} />
+}

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToast.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToast.tsx
@@ -1,11 +1,12 @@
 import { useEffect } from 'react'
 import { CosToastType, TOAST_LIFETIME } from './utils'
 import { cva } from 'class-variance-authority'
-import CircleFill from '../../../components/CosIcon/monochrome/circle_fill.svg?react'
-import WarningFilled from '../../../components/CosIcon/monochrome/warning_filled.svg?react'
-import WarningAltFilled from '../../../components/CosIcon/monochrome/warning_alt_filled.svg?react'
-import CloseIcon from '../../../components/CosIcon/monochrome/x_small.svg?react'
-import { CosHyperlink } from '../../CosHyperlink/CosHyperlink'
+import {
+  renderCloseButton,
+  renderIcon,
+  renderLink,
+  renderTitle,
+} from '../cosNotificationUtils'
 
 const toastStyles = cva(
   [
@@ -39,41 +40,14 @@ export const CosToast = (props: CosToastProps) => {
     time,
   } = props
 
-  const renderIcon = () => {
-    switch (type) {
-      case 'positive':
-        return <CircleFill className="icon-md shrink-0 text-status-positive" />
-      case 'warning':
-        return (
-          <WarningAltFilled className="icon-md shrink-0 text-status-warning" />
-        )
-      case 'error':
-        return (
-          <WarningFilled className="icon-md shrink-0 text-status-negative" />
-        )
-      default:
-        return null
-    }
-  }
-
   const renderHeader = () => {
     if (!title) return null
 
     return (
       <div className="flex items-center gap-[6px]">
-        {renderIcon()}
-        <div className="font-semibold text-functional-title">{title}</div>
+        {renderIcon(type)}
+        {renderTitle(title)}
       </div>
-    )
-  }
-
-  const renderLink = () => {
-    if (!link) return null
-
-    return (
-      <CosHyperlink size="sm" variant="text-inline" href={link.href}>
-        {link.text}
-      </CosHyperlink>
     )
   }
 
@@ -81,14 +55,7 @@ export const CosToast = (props: CosToastProps) => {
     return <div className="primary-body5 ml-auto">{time}</div>
   }
 
-  const renderCloseButton = () => {
-    return (
-      <CloseIcon
-        className="icon-md shrink-0 cursor-pointer text-functional-text hover:text-functional-text-light"
-        onClick={() => onToastClose(id)}
-      />
-    )
-  }
+  const handleClose = () => onToastClose(id)
 
   return (
     <div className={toastStyles({ type })}>
@@ -97,10 +64,10 @@ export const CosToast = (props: CosToastProps) => {
           {renderHeader()}
           {message}
         </div>
-        {renderCloseButton()}
+        {renderCloseButton(handleClose)}
       </div>
       <div className="flex w-full items-center">
-        {renderLink()}
+        {renderLink(link)}
         {renderTime()}
       </div>
     </div>

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToastList.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToastList.tsx
@@ -1,8 +1,13 @@
 import { CosToastWrapper } from './CosToast'
-import { useToast } from './useToast'
+import { CosToastType } from './utils'
 
-export const CosToastNotification = () => {
-  const { toasts, removeToast } = useToast()
+type CosToastListProps = {
+  toasts: CosToastType[]
+  removeToast: (id: string) => void
+}
+
+export const CosToastList = (props: CosToastListProps) => {
+  const { toasts, removeToast } = props
 
   return (
     <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-5">
@@ -14,7 +19,6 @@ export const CosToastNotification = () => {
           title={toast.title}
           message={toast.message}
           link={toast.link}
-          isLoading={toast.isLoading}
           onToastClose={removeToast}
           time={toast.time}
         />

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToastNotification.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToastNotification.tsx
@@ -1,0 +1,24 @@
+import { CosToastWrapper } from './CosToast'
+import { useToast } from './useToast'
+
+export const CosToastNotification = () => {
+  const { toasts, removeToast } = useToast()
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 flex flex-col gap-5">
+      {toasts.map((toast) => (
+        <CosToastWrapper
+          key={toast.id}
+          id={toast.id}
+          type={toast.type}
+          title={toast.title}
+          message={toast.message}
+          link={toast.link}
+          isLoading={toast.isLoading}
+          onToastClose={removeToast}
+          time={toast.time}
+        />
+      ))}
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToastProvider.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToastProvider.tsx
@@ -1,0 +1,31 @@
+import { PropsWithChildren, useCallback, useState } from 'react'
+import { CosToastType, MAX_VISIBLE_TOASTS_AMOUNT } from './utils'
+import { CosToastContext } from './context'
+
+type ToastProviderProps = PropsWithChildren
+
+export const CosToastProvider = (props: ToastProviderProps) => {
+  const { children } = props
+
+  const [toasts, setToasts] = useState<CosToastType[]>([])
+
+  const addToast = useCallback((toast: CosToastType) => {
+    setToasts((prevToasts) => {
+      const next = [...prevToasts, toast]
+      if (next.length > MAX_VISIBLE_TOASTS_AMOUNT) {
+        next.shift()
+      }
+      return next
+    })
+  }, [])
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id))
+  }, [])
+
+  return (
+    <CosToastContext.Provider value={{ toasts, addToast, removeToast }}>
+      {children}
+    </CosToastContext.Provider>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToastProvider.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToastProvider.tsx
@@ -1,14 +1,17 @@
-import { PropsWithChildren, useCallback, useState } from 'react'
+import { PropsWithChildren, useCallback, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 import { CosToastType, MAX_VISIBLE_TOASTS_AMOUNT } from './utils'
 import { CosToastContext } from './context'
+import { CosToastList } from './CosToastList'
 
-type ToastProviderProps = PropsWithChildren
-
-export const CosToastProvider = (props: ToastProviderProps) => {
+export const CosToastProvider = (props: PropsWithChildren) => {
   const { children } = props
 
   const [toasts, setToasts] = useState<CosToastType[]>([])
 
+  /**
+   * Only expose add/remove in the context to avoid unnecessary re-renders
+   */
   const addToast = useCallback((toast: CosToastType) => {
     setToasts((prevToasts) => {
       const next = [...prevToasts, toast]
@@ -23,9 +26,21 @@ export const CosToastProvider = (props: ToastProviderProps) => {
     setToasts((prevToasts) => prevToasts.filter((toast) => toast.id !== id))
   }, [])
 
+  /**
+   * Memorize context value with a stable reference
+   */
+  const contextValueRef = useRef({
+    addToast,
+    removeToast,
+  })
+
   return (
-    <CosToastContext.Provider value={{ toasts, addToast, removeToast }}>
+    <CosToastContext.Provider value={contextValueRef.current}>
       {children}
+      {createPortal(
+        <CosToastList toasts={toasts} removeToast={removeToast} />,
+        document.body,
+      )}
     </CosToastContext.Provider>
   )
 }

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/context.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/context.ts
@@ -1,0 +1,14 @@
+import { createContext } from 'react'
+import { CosToastType } from './utils'
+
+export type CosToastContextValue = {
+  toasts: CosToastType[]
+  addToast: (toast: CosToastType) => void
+  removeToast: (id: string) => void
+}
+
+export const CosToastContext = createContext<CosToastContextValue>({
+  toasts: [],
+  addToast: () => {},
+  removeToast: () => {},
+})

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/context.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/context.ts
@@ -2,13 +2,11 @@ import { createContext } from 'react'
 import { CosToastType } from './utils'
 
 export type CosToastContextValue = {
-  toasts: CosToastType[]
   addToast: (toast: CosToastType) => void
   removeToast: (id: string) => void
 }
 
 export const CosToastContext = createContext<CosToastContextValue>({
-  toasts: [],
   addToast: () => {},
   removeToast: () => {},
 })

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/useToast.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/useToast.ts
@@ -1,0 +1,4 @@
+import { useContext } from 'react'
+import { CosToastContext } from './context'
+
+export const useToast = () => useContext(CosToastContext)

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/utils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/utils.ts
@@ -1,0 +1,27 @@
+// Visible toasts amount
+export const MAX_VISIBLE_TOASTS_AMOUNT = 4
+
+// Default lifetime of a toasts (in ms)
+export const TOAST_LIFETIME = 5000
+
+export type CosToastNotificationType =
+  | 'neutral'
+  | 'positive'
+  | 'warning'
+  | 'error'
+
+export type CosToastType = {
+  id: string
+  isLoading?: boolean
+  /**
+   * @default 'neutral'
+   */
+  type?: CosToastNotificationType
+  title?: string
+  message: string
+  link?: {
+    text: string
+    href: string
+  }
+  time: string
+}

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/utils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/utils.ts
@@ -1,27 +1,13 @@
+import { CosNotificationBaseProps } from '../cosNotificationTypes'
+
 // Visible toasts amount
 export const MAX_VISIBLE_TOASTS_AMOUNT = 4
 
 // Default lifetime of a toasts (in ms)
 export const TOAST_LIFETIME = 5000
 
-export type CosToastNotificationType =
-  | 'neutral'
-  | 'positive'
-  | 'warning'
-  | 'error'
-
-export type CosToastType = {
+export type CosToastType = CosNotificationBaseProps & {
   id: string
-  isLoading?: boolean
-  /**
-   * @default 'neutral'
-   */
-  type?: CosToastNotificationType
-  title?: string
   message: string
-  link?: {
-    text: string
-    href: string
-  }
   time: string
 }

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/cosNotificationTypes.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/cosNotificationTypes.ts
@@ -1,0 +1,14 @@
+export type CosNotificationType = 'neutral' | 'positive' | 'warning' | 'error'
+
+export type CosNotificationBaseProps = {
+  /**
+   * @default 'neutral'
+   */
+  type?: CosNotificationType
+  title?: string
+  link?: {
+    text: string
+    href: string
+  }
+  onClose?: () => void
+}

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/cosNotificationUtils.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/cosNotificationUtils.tsx
@@ -1,0 +1,49 @@
+import CircleFill from '../../components/CosIcon/monochrome/circle_fill.svg?react'
+import WarningFilled from '../../components/CosIcon/monochrome/warning_filled.svg?react'
+import WarningAltFilled from '../../components/CosIcon/monochrome/warning_alt_filled.svg?react'
+import CloseIcon from '../../components/CosIcon/monochrome/x_small.svg?react'
+import { CosHyperlink } from '../CosHyperlink/CosHyperlink'
+
+import { CosNotificationType } from './cosNotificationTypes'
+
+export const renderIcon = (type: CosNotificationType) => {
+  switch (type) {
+    case 'positive':
+      return <CircleFill className="icon-md shrink-0 text-status-positive" />
+    case 'warning':
+      return (
+        <WarningAltFilled className="icon-md shrink-0 text-status-warning" />
+      )
+    case 'error':
+      return <WarningFilled className="icon-md shrink-0 text-status-negative" />
+    default:
+      return null
+  }
+}
+
+export const renderTitle = (title?: string) => {
+  if (!title) {
+    return null
+  }
+  return <div className="font-semibold text-functional-title">{title}</div>
+}
+
+export const renderLink = (link?: { text: string; href: string }) => {
+  if (!link) {
+    return null
+  }
+  return (
+    <CosHyperlink size="sm" variant="text-inline" href={link.href}>
+      {link.text}
+    </CosHyperlink>
+  )
+}
+
+export const renderCloseButton = (handleClose: () => void) => {
+  return (
+    <CloseIcon
+      className="icon-md shrink-0 cursor-pointer text-functional-text hover:text-functional-text-light"
+      onClick={handleClose}
+    />
+  )
+}

--- a/packages/cube-frontend-ui-library/src/index.ts
+++ b/packages/cube-frontend-ui-library/src/index.ts
@@ -31,6 +31,9 @@ export * from './components/CosLoadingSpinner/CosLoadingSpinner'
 export * from './components/CosModal/CosModal'
 export * from './components/CosNagging/CosNagging'
 export * from './components/CosNotification/CosInlineNotification/CosInlineNotification'
+export * from './components/CosNotification/CosToastNotification/CosToastProvider'
+export * from './components/CosNotification/CosToastNotification/useToast'
+export { type CosToastType } from './components/CosNotification/CosToastNotification/utils'
 export * from './components/CosPagination/CosPagination'
 export {
   DEFAULT_ITEMS_PER_PAGE,

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/CosNotification.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/CosNotification.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react'
 import { InlineNotificationLayout } from './InlineNotification/InlineNotificationLayout'
+import { CosToastProvider } from '../../../components/CosNotification/CosToastNotification/CosToastProvider'
+import { ToastNotificationLayout } from './ToastNotification/ToastNotificationLayout'
 
 const meta = {
   title: 'Molecules/Notification',
@@ -9,4 +11,12 @@ export default meta
 
 export const InlineNotification: StoryObj = {
   render: () => <InlineNotificationLayout />,
+}
+
+export const ToastNotification: StoryObj = {
+  render: () => (
+    <CosToastProvider>
+      <ToastNotificationLayout />
+    </CosToastProvider>
+  ),
 }

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/InlineNotification/InlineNotificationLayout.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/InlineNotification/InlineNotificationLayout.tsx
@@ -1,8 +1,6 @@
 import { StoryLayout } from '../../../../internal/components/StoryLayout/StoryLayout'
-import {
-  CosInlineNotification,
-  CosInlineNotificationType,
-} from '../../../../components/CosNotification/CosInlineNotification/CosInlineNotification'
+import { CosNotificationBaseProps } from '../../../../components/CosNotification/cosNotificationTypes'
+import { CosInlineNotification } from '../../../../components/CosNotification/CosInlineNotification/CosInlineNotification'
 import { InlineNotificationGrid } from './InlineNotificationGrid'
 
 const hyperlink = {
@@ -158,14 +156,8 @@ export const InlineNotificationLayout = () => {
   )
 }
 
-type InlineNotificationProps = {
-  type: CosInlineNotificationType
-  title?: string
+type InlineNotificationProps = CosNotificationBaseProps & {
   content?: string
-  link?: {
-    href: string
-    text: string
-  }
   isLoading?: boolean
 }
 

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/CreateToastButton.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/CreateToastButton.tsx
@@ -1,0 +1,25 @@
+import { useState } from 'react'
+import { CosButton } from '../../../../components/CosButton/CosButton'
+import { useToast } from '../../../../components/CosNotification/CosToastNotification/useToast'
+import { mockToasts } from './mockData'
+
+export const CreateToastButton = () => {
+  const { addToast } = useToast()
+
+  const [activeToast, setActiveToast] = useState(0)
+
+  const handleAddToast = () => {
+    addToast(mockToasts[activeToast])
+    if (activeToast === mockToasts.length - 1) {
+      setActiveToast(0)
+    } else {
+      setActiveToast(activeToast + 1)
+    }
+  }
+
+  return (
+    <CosButton type="primary" usage="text-only" onClick={handleAddToast}>
+      Create Toast
+    </CosButton>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/ToastNotificationGrid.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/ToastNotificationGrid.tsx
@@ -1,0 +1,24 @@
+import { PropsWithChildren } from 'react'
+
+type ToastNotificationGridProps = PropsWithChildren<{
+  title?: string
+}>
+
+export const InlineNotificationGrid = (props: ToastNotificationGridProps) => {
+  const { children: childrenProps, title } = props
+
+  const children = Array.isArray(childrenProps)
+    ? childrenProps
+    : [childrenProps]
+
+  return (
+    <div className="grid grid-cols-5 items-center gap-6 [&:not(:last-child)]:mb-6">
+      <div className="primary-body2 col-span-1 font-medium">{title}</div>
+      {children.map((child, index) => (
+        <div key={index} className="col-span-2 flex justify-center">
+          {child}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/ToastNotificationGrid.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/ToastNotificationGrid.tsx
@@ -4,7 +4,7 @@ type ToastNotificationGridProps = PropsWithChildren<{
   title?: string
 }>
 
-export const InlineNotificationGrid = (props: ToastNotificationGridProps) => {
+export const ToastNotificationGrid = (props: ToastNotificationGridProps) => {
   const { children: childrenProps, title } = props
 
   const children = Array.isArray(childrenProps)

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/ToastNotificationLayout.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/ToastNotificationLayout.tsx
@@ -1,10 +1,9 @@
 import { useState } from 'react'
 import { uniqueId } from 'lodash'
 import { StoryLayout } from '../../../../internal/components/StoryLayout/StoryLayout'
-import { CosToastNotification } from '../../../../components/CosNotification/CosToastNotification/CosToastNotification'
 import { CosToast } from '../../../../components/CosNotification/CosToastNotification/CosToast'
 import { CosToastType } from '../../../../components/CosNotification/CosToastNotification/utils'
-import { InlineNotificationGrid } from './ToastNotificationGrid'
+import { ToastNotificationGrid } from './ToastNotificationGrid'
 import { CreateToastButton } from './CreateToastButton'
 
 const notificationTitle = 'Notification Title'
@@ -21,7 +20,7 @@ export const ToastNotificationLayout = () => {
       desc="A maximum of four notifications can be displayed at once, each lasting up to 5 seconds; if exceeded, the earlier notifications will disappear."
     >
       <StoryLayout.Section title="Notification - Toast">
-        <InlineNotificationGrid title="Master">
+        <ToastNotificationGrid title="Master">
           <ToastNotification
             id={uniqueId()}
             type="neutral"
@@ -29,14 +28,13 @@ export const ToastNotificationLayout = () => {
             link={hyperlink}
             time={notificationTime}
           />
-        </InlineNotificationGrid>
-        <InlineNotificationGrid title="Custom">
+        </ToastNotificationGrid>
+        <ToastNotificationGrid title="Custom">
           <CreateToastButton />
-        </InlineNotificationGrid>
-        <CosToastNotification />
+        </ToastNotificationGrid>
       </StoryLayout.Section>
       <StoryLayout.Section title="Usage">
-        <InlineNotificationGrid title="Neutral">
+        <ToastNotificationGrid title="Neutral">
           <ToastNotification
             id={uniqueId()}
             type="neutral"
@@ -44,8 +42,8 @@ export const ToastNotificationLayout = () => {
             link={hyperlink}
             time={notificationTime}
           />
-        </InlineNotificationGrid>
-        <InlineNotificationGrid title="Positive">
+        </ToastNotificationGrid>
+        <ToastNotificationGrid title="Positive">
           <ToastNotification
             id={uniqueId()}
             type="positive"
@@ -53,8 +51,8 @@ export const ToastNotificationLayout = () => {
             link={hyperlink}
             time={notificationTime}
           />
-        </InlineNotificationGrid>
-        <InlineNotificationGrid title="Warning">
+        </ToastNotificationGrid>
+        <ToastNotificationGrid title="Warning">
           <ToastNotification
             id={uniqueId()}
             type="warning"
@@ -62,8 +60,8 @@ export const ToastNotificationLayout = () => {
             link={hyperlink}
             time={notificationTime}
           />
-        </InlineNotificationGrid>
-        <InlineNotificationGrid title="Error">
+        </ToastNotificationGrid>
+        <ToastNotificationGrid title="Error">
           <ToastNotification
             id={uniqueId()}
             type="error"
@@ -71,14 +69,14 @@ export const ToastNotificationLayout = () => {
             link={hyperlink}
             time={notificationTime}
           />
-        </InlineNotificationGrid>
+        </ToastNotificationGrid>
       </StoryLayout.Section>
       <StoryLayout.Section title="Layout">
-        <InlineNotificationGrid title="">
+        <ToastNotificationGrid title="">
           <div className="primary-body2 text-center font-medium">Neutral</div>
           <div className="primary-body2 text-center font-medium">Positive</div>
-        </InlineNotificationGrid>
-        <InlineNotificationGrid title="No title or link">
+        </ToastNotificationGrid>
+        <ToastNotificationGrid title="No title or link">
           <ToastNotification
             id={uniqueId()}
             type="neutral"
@@ -89,8 +87,8 @@ export const ToastNotificationLayout = () => {
             type="positive"
             time={notificationTime}
           />
-        </InlineNotificationGrid>
-        <InlineNotificationGrid title="With title">
+        </ToastNotificationGrid>
+        <ToastNotificationGrid title="With title">
           <ToastNotification
             id={uniqueId()}
             type="neutral"
@@ -103,8 +101,8 @@ export const ToastNotificationLayout = () => {
             title={notificationTitle}
             time={notificationTime}
           />
-        </InlineNotificationGrid>
-        <InlineNotificationGrid title="With link">
+        </ToastNotificationGrid>
+        <ToastNotificationGrid title="With link">
           <ToastNotification
             id={uniqueId()}
             type="neutral"
@@ -117,8 +115,8 @@ export const ToastNotificationLayout = () => {
             link={hyperlink}
             time={notificationTime}
           />
-        </InlineNotificationGrid>
-        <InlineNotificationGrid title="With both title and link">
+        </ToastNotificationGrid>
+        <ToastNotificationGrid title="With both title and link">
           <ToastNotification
             id={uniqueId()}
             type="neutral"
@@ -133,7 +131,7 @@ export const ToastNotificationLayout = () => {
             link={hyperlink}
             time={notificationTime}
           />
-        </InlineNotificationGrid>
+        </ToastNotificationGrid>
       </StoryLayout.Section>
     </StoryLayout>
   )

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/ToastNotificationLayout.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/ToastNotificationLayout.tsx
@@ -1,0 +1,156 @@
+import { useState } from 'react'
+import { uniqueId } from 'lodash'
+import { StoryLayout } from '../../../../internal/components/StoryLayout/StoryLayout'
+import { CosToastNotification } from '../../../../components/CosNotification/CosToastNotification/CosToastNotification'
+import { CosToast } from '../../../../components/CosNotification/CosToastNotification/CosToast'
+import { CosToastType } from '../../../../components/CosNotification/CosToastNotification/utils'
+import { InlineNotificationGrid } from './ToastNotificationGrid'
+import { CreateToastButton } from './CreateToastButton'
+
+const notificationTitle = 'Notification Title'
+const notificationTime = 'yyyy/mm/dd 00:00'
+const hyperlink = {
+  text: 'Call to action',
+  href: `/#${Math.random()}`,
+}
+
+export const ToastNotificationLayout = () => {
+  return (
+    <StoryLayout
+      title="Notification - Toast"
+      desc="A maximum of four notifications can be displayed at once, each lasting up to 5 seconds; if exceeded, the earlier notifications will disappear."
+    >
+      <StoryLayout.Section title="Notification - Toast">
+        <InlineNotificationGrid title="Master">
+          <ToastNotification
+            id={uniqueId()}
+            type="neutral"
+            title={notificationTitle}
+            link={hyperlink}
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+        <InlineNotificationGrid title="Custom">
+          <CreateToastButton />
+        </InlineNotificationGrid>
+        <CosToastNotification />
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Usage">
+        <InlineNotificationGrid title="Neutral">
+          <ToastNotification
+            id={uniqueId()}
+            type="neutral"
+            title={notificationTitle}
+            link={hyperlink}
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+        <InlineNotificationGrid title="Positive">
+          <ToastNotification
+            id={uniqueId()}
+            type="positive"
+            title={notificationTitle}
+            link={hyperlink}
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+        <InlineNotificationGrid title="Warning">
+          <ToastNotification
+            id={uniqueId()}
+            type="warning"
+            title={notificationTitle}
+            link={hyperlink}
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+        <InlineNotificationGrid title="Error">
+          <ToastNotification
+            id={uniqueId()}
+            type="error"
+            title={notificationTitle}
+            link={hyperlink}
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Layout">
+        <InlineNotificationGrid title="">
+          <div className="primary-body2 text-center font-medium">Neutral</div>
+          <div className="primary-body2 text-center font-medium">Positive</div>
+        </InlineNotificationGrid>
+        <InlineNotificationGrid title="No title or link">
+          <ToastNotification
+            id={uniqueId()}
+            type="neutral"
+            time={notificationTime}
+          />
+          <ToastNotification
+            id={uniqueId()}
+            type="positive"
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+        <InlineNotificationGrid title="With title">
+          <ToastNotification
+            id={uniqueId()}
+            type="neutral"
+            title={notificationTitle}
+            time={notificationTime}
+          />
+          <ToastNotification
+            id={uniqueId()}
+            type="positive"
+            title={notificationTitle}
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+        <InlineNotificationGrid title="With link">
+          <ToastNotification
+            id={uniqueId()}
+            type="neutral"
+            link={hyperlink}
+            time={notificationTime}
+          />
+          <ToastNotification
+            id={uniqueId()}
+            type="positive"
+            link={hyperlink}
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+        <InlineNotificationGrid title="With both title and link">
+          <ToastNotification
+            id={uniqueId()}
+            type="neutral"
+            title={notificationTitle}
+            link={hyperlink}
+            time={notificationTime}
+          />
+          <ToastNotification
+            id={uniqueId()}
+            type="positive"
+            title={notificationTitle}
+            link={hyperlink}
+            time={notificationTime}
+          />
+        </InlineNotificationGrid>
+      </StoryLayout.Section>
+    </StoryLayout>
+  )
+}
+
+type ToastNotificationProps = Omit<CosToastType, 'message'>
+
+const ToastNotification = (props: ToastNotificationProps) => {
+  const [isToastClose, setIsToastClose] = useState(false)
+
+  if (isToastClose) return null
+
+  return (
+    <CosToast
+      {...props}
+      message="Subtitle text goes here. Subtitle text goes here. Subtitle text goes here."
+      onToastClose={() => setIsToastClose(true)}
+    />
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/mockData.ts
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/mockData.ts
@@ -1,0 +1,83 @@
+import { CosToastType } from '../../../../components/CosNotification/CosToastNotification/utils'
+
+export const mockToasts: CosToastType[] = [
+  {
+    id: 'mock-toast-1',
+    type: 'neutral',
+    title: 'Heads up!',
+    message: 'This is a neutral notification with general info.',
+    time: 'yyyy/mm/dd 00:00',
+  },
+  {
+    id: 'mock-toast-2',
+    type: 'positive',
+    title: 'Success!',
+    message: 'Your profile was updated successfully.',
+    link: {
+      text: 'View Profile',
+      href: `/#${Math.random()}`,
+    },
+    time: 'yyyy/mm/dd 00:00',
+  },
+  {
+    id: 'mock-toast-3',
+    type: 'warning',
+    title: 'Almost there!',
+    message: 'You’re reaching your usage limit. Consider upgrading.',
+    link: {
+      text: 'Upgrade Now',
+      href: `/#${Math.random()}`,
+    },
+    time: 'yyyy/mm/dd 00:00',
+  },
+  {
+    id: 'mock-toast-4',
+    type: 'error',
+    title: 'Something went wrong',
+    message: 'We couldn’t save your changes. Please try again later.',
+    time: 'yyyy/mm/dd 00:00',
+  },
+  {
+    id: 'mock-toast-5',
+    type: 'neutral',
+    isLoading: true,
+    message: 'Uploading your files…',
+    time: 'yyyy/mm/dd 00:00',
+  },
+  {
+    id: 'mock-toast-6',
+    type: 'neutral',
+    title: 'Heads up!',
+    message: 'This is a neutral notification with general info.',
+    time: 'yyyy/mm/dd 00:00',
+  },
+  {
+    id: 'mock-toast-7',
+    type: 'positive',
+    title: 'Success!',
+    message: 'Your profile was updated successfully.',
+    link: {
+      text: 'View Profile',
+      href: `/#${Math.random()}`,
+    },
+    time: 'yyyy/mm/dd 00:00',
+  },
+  {
+    id: 'mock-toast-8',
+    type: 'warning',
+    title: 'Almost there!',
+    message: 'You’re reaching your usage limit. Consider upgrading.',
+    link: {
+      text: 'Upgrade Now',
+      href: `/#${Math.random()}`,
+    },
+    time: 'yyyy/mm/dd 00:00',
+  },
+  {
+    id: 'mock-toast-9',
+    type: 'error',
+    title: 'Something went wrong',
+    message: 'We couldn’t save your changes. Please try again later.',
+    time: 'yyyy/mm/dd 00:00',
+  },
+]

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/mockData.ts
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNotification/ToastNotification/mockData.ts
@@ -40,7 +40,6 @@ export const mockToasts: CosToastType[] = [
   {
     id: 'mock-toast-5',
     type: 'neutral',
-    isLoading: true,
     message: 'Uploading your files…',
     time: 'yyyy/mm/dd 00:00',
   },

--- a/packages/cube-frontend-web-app/src/App.tsx
+++ b/packages/cube-frontend-web-app/src/App.tsx
@@ -5,6 +5,7 @@ import '@fontsource/urbanist/400.css'
 import '@fontsource/urbanist/500.css'
 import '@fontsource/urbanist/600.css'
 import '@fontsource/urbanist/800.css'
+import { CosToastProvider } from '@cube-frontend/ui-library'
 import { DataCenterProvider } from './context/DataCenterProvider'
 import { IntegrationsContextProvider } from './context/IntegrationsContextProvider'
 import { UserContextProvider } from './context/UserContextProvider'
@@ -20,9 +21,11 @@ function App() {
     <DataCenterProvider>
       <UserContextProvider>
         <IntegrationsContextProvider>
-          <Layout>
-            <CosRoutes />
-          </Layout>
+          <CosToastProvider>
+            <Layout>
+              <CosRoutes />
+            </Layout>
+          </CosToastProvider>
         </IntegrationsContextProvider>
       </UserContextProvider>
     </DataCenterProvider>


### PR DESCRIPTION
#### What type of PR is this?

- Feature

#### What this PR does / why we need it

- Create `CosToastNotification`

##### 1) Default display


https://github.com/user-attachments/assets/a826b71f-c3e2-4ee3-8911-08f709cbd650


##### 2) Usage

<img width="765" alt="Screenshot 2025-04-10 at 5 47 37 PM" src="https://github.com/user-attachments/assets/5eed061c-cd3c-4a6e-9554-e7992131b10c" /> 

##### 3) Layout

<img width="1155" alt="Screenshot 2025-04-10 at 5 47 09 PM" src="https://github.com/user-attachments/assets/8e76af11-4875-413f-828a-2f4c4126f74d" />


#### Which issue(s) this PR fixes

- Close #21 

#### Special notes for your reviewer

- 🤔 Discussion: is implementing a `Skeleton` component for a Toast notification necessary?
   1) Toasts are often displayed after an action has been completed, which means the API response has already been received.
   2) Toasts typically disappear quickly (in our case, after 5 seconds), so a loading placeholder may not significantly improve the user experience.

#### Additional documentation

```docs

```
