### PR TITLE
ui library - update date picker behaviour and ui

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePicker.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePicker.tsx
@@ -7,19 +7,26 @@ import { CosDatePickerSkeleton } from './CosDatePickerSkeleton'
 import { CosDatePickerContext } from './context'
 
 type CosDatePickerProps = {
+  /**
+   * @default false
+   */
   disabled?: boolean
+  /**
+   * @default false
+   */
   isLoading?: boolean
   startDate: Dayjs | undefined
   endDate: Dayjs | undefined
   setStartDate: (date: Dayjs | undefined) => void
   setEndDate: (date: Dayjs | undefined) => void
-  onApplyClick?: () => void
-  onCancelClick?: () => void
   /**
-   * `onOutsideClickClose` triggered only when the date picker is closed by clicking outside.
-   * This will not be triggered when closing via "Apply" or "Cancel" buttons.
+   * Optional callback triggered when "Apply" button is clicked
    */
-  onOutsideClickClose?: () => void
+  onApplyClick?: () => void
+  /**
+   * Optional callback triggered when "Cancel" button is clicked
+   */
+  onCancelClick?: () => void
 }
 
 export const CosDatePicker = (props: CosDatePickerProps) => {
@@ -32,35 +39,50 @@ export const CosDatePicker = (props: CosDatePickerProps) => {
     setEndDate,
     onApplyClick,
     onCancelClick,
-    onOutsideClickClose,
   } = props
 
   const [isCalendarOpen, setIsCalendarOpen] = useState(false)
 
+  const [displayDates, setDisplayDates] = useState<{
+    start: Dayjs | undefined
+    end: Dayjs | undefined
+  }>({ start: startDate, end: endDate })
+
   const [currentMonth, setCurrentMonth] = useState(() => dayjs(new Date()))
 
-  const handleDayClick = (date: Dayjs) => {
-    if (startDate && endDate) {
-      setStartDate(date)
-      setEndDate(undefined)
-    } else if (!startDate) {
-      setStartDate(date)
-    } else if (startDate && date >= startDate) {
-      setEndDate(date)
+  const handleDisplayDatesChange = (date: Dayjs) => {
+    const { start, end } = displayDates
+
+    if (start && end) {
+      setDisplayDates({ start: date, end: undefined })
+    } else if (!displayDates.start) {
+      setDisplayDates({ start: date, end: undefined })
+    } else if (start && date >= start) {
+      setDisplayDates((prev) => ({ ...prev, end: date }))
     } else {
-      setStartDate(date)
-      setEndDate(startDate)
+      setDisplayDates((prev) => ({ start: date, end: prev.start }))
     }
   }
 
   const handleApply = () => {
-    if (onApplyClick) onApplyClick()
+    const { start, end } = displayDates
+
+    if (!start || !end) return
+
+    onApplyClick?.()
+    setStartDate(start)
+    setEndDate(end)
     setIsCalendarOpen(false)
   }
 
-  const handleCancel = () => {
-    if (onCancelClick) onCancelClick()
+  const handleCancel = useCallback(() => {
+    onCancelClick?.()
+    setDisplayDates({ start: startDate, end: endDate })
     setIsCalendarOpen(false)
+  }, [endDate, onCancelClick, startDate])
+
+  const handleReset = () => {
+    setDisplayDates({ start: startDate, end: endDate })
   }
 
   const toggleCalendarOpen = () => {
@@ -93,11 +115,10 @@ export const CosDatePicker = (props: CosDatePickerProps) => {
       const isMenu = elementRef.current?.contains(target)
 
       if (!isTrigger && !isMenu) {
-        onOutsideClickClose?.()
-        setIsCalendarOpen(false)
+        handleCancel()
       }
     },
-    [anchorRef, elementRef, onOutsideClickClose],
+    [anchorRef, elementRef, handleCancel],
   )
 
   useEffect(() => {
@@ -117,14 +138,14 @@ export const CosDatePicker = (props: CosDatePickerProps) => {
         toggleCalendarOpen,
         floatingProps,
         triggerDisabled: disabled,
-        isSelected: !!startDate || !!endDate,
-        startDate,
-        endDate,
-        onDateClick: handleDayClick,
+        isSelected: !!displayDates.start || !!displayDates.end,
+        displayDates,
+        onDateClick: handleDisplayDatesChange,
         onPreviousMonthClick: handlePreviousMonthClick,
         onNextMonthClick: handleNextMonthClick,
         onApplyClick: handleApply,
         onCancelClick: handleCancel,
+        onResetClick: handleReset,
       }}
     >
       <>

--- a/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePickerInput.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePickerInput.tsx
@@ -20,6 +20,7 @@ export const CosDatePickerInput = (props: CosDatePickerInputProps) => {
         type="text"
         value={value}
         placeholder={placeholder}
+        hideErrorIcon={true}
         readOnly
       />
     </div>

--- a/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePickerMenu.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePickerMenu.tsx
@@ -12,8 +12,7 @@ export const CosDatePickerMenu = () => {
   const {
     floatingProps,
     calendarOpen: isVisible,
-    startDate,
-    endDate,
+    displayDates,
     currentMonth,
     onPreviousMonthClick,
     onNextMonthClick,
@@ -21,6 +20,8 @@ export const CosDatePickerMenu = () => {
     onCancelClick,
     onApplyClick,
   } = useContext(CosDatePickerContext)
+
+  const { start, end } = displayDates
 
   const { elementRef, resolvedStyles } = floatingProps
 
@@ -33,12 +34,12 @@ export const CosDatePickerMenu = () => {
       <div className="flex gap-4">
         <CosDatePickerInput
           type="start"
-          value={startDate ? dayjs(startDate).format('YYYY/MM/DD') : ''}
+          value={start ? dayjs(start).format('YYYY/MM/DD') : ''}
           placeholder="Choose Start"
         />
         <CosDatePickerInput
           type="end"
-          value={endDate ? dayjs(endDate).format('YYYY/MM/DD') : ''}
+          value={end ? dayjs(end).format('YYYY/MM/DD') : ''}
           placeholder="Choose End"
         />
       </div>
@@ -47,14 +48,19 @@ export const CosDatePickerMenu = () => {
         onPreviousMonth={onPreviousMonthClick}
         onNextMonth={onNextMonthClick}
         onSelectDay={onDateClick}
-        startDate={startDate}
-        endDate={endDate}
+        startDate={start}
+        endDate={end}
       />
       <div className="flex justify-end gap-2">
         <CosButton size="sm" type="ghost" onClick={onCancelClick}>
           Cancel
         </CosButton>
-        <CosButton size="sm" type="primary" onClick={onApplyClick}>
+        <CosButton
+          size="sm"
+          type="primary"
+          onClick={onApplyClick}
+          disabled={!start || !end}
+        >
           Apply
         </CosButton>
       </div>

--- a/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePickerTrigger.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePickerTrigger.tsx
@@ -10,11 +10,12 @@ export const CosDatePickerTrigger = () => {
     floatingProps,
     isSelected,
     triggerDisabled: disabled,
-    startDate,
-    endDate,
     calendarOpen: isOpen,
     toggleCalendarOpen,
+    displayDates,
   } = useContext(CosDatePickerContext)
+
+  const { start, end } = displayDates
 
   return (
     <button
@@ -25,7 +26,7 @@ export const CosDatePickerTrigger = () => {
       className={twMerge(trigger({ isSelected, isOpen, disabled }))}
     >
       <CalendarIcon className="icon-md shrink-0" />
-      <span>{formatDateRange(startDate, endDate) ?? 'Time'}</span>
+      <span>{formatDateRange(start, end) ?? 'Time'}</span>
     </button>
   )
 }

--- a/packages/cube-frontend-ui-library/src/components/CosDatePicker/context.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosDatePicker/context.ts
@@ -10,13 +10,16 @@ export type CosDatePickerContextValue = {
 
   triggerDisabled: boolean
   isSelected: boolean
-  startDate: Dayjs | undefined
-  endDate: Dayjs | undefined
+  displayDates: {
+    start: Dayjs | undefined
+    end: Dayjs | undefined
+  }
   onDateClick: (date: Dayjs) => void
   onPreviousMonthClick: () => void
   onNextMonthClick: () => void
   onApplyClick: () => void
   onCancelClick: () => void
+  onResetClick: () => void
 }
 
 export const CosDatePickerContext = createContext<CosDatePickerContextValue>({
@@ -30,11 +33,14 @@ export const CosDatePickerContext = createContext<CosDatePickerContextValue>({
 
   triggerDisabled: false,
   isSelected: false,
-  startDate: undefined,
-  endDate: undefined,
+  displayDates: {
+    start: undefined,
+    end: undefined,
+  },
   onDateClick: () => {},
   onPreviousMonthClick: () => {},
   onNextMonthClick: () => {},
   onApplyClick: () => {},
   onCancelClick: () => {},
+  onResetClick: () => {},
 })

--- a/packages/cube-frontend-ui-library/src/components/CosDatePicker/styles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosDatePicker/styles.ts
@@ -71,7 +71,7 @@ export const menu = cva(
 )
 
 export const dayButton = cva(
-  'primary-body2 flex size-10 items-center justify-center',
+  'primary-body2 flex aspect-square w-full items-center justify-center',
   {
     variants: {
       status: {

--- a/packages/cube-frontend-ui-library/src/components/CosTableInput/CosTableInput.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosTableInput/CosTableInput.tsx
@@ -8,6 +8,7 @@ import { CosTableInputSkeleton } from './CosTableInputSkeleton'
 export type CosTableInputProps = InputHTMLAttributes<HTMLInputElement> & {
   isLoading?: boolean
   errorMessage?: string | boolean
+  hideErrorIcon?: boolean
 }
 
 const input = cva(
@@ -39,6 +40,7 @@ export const CosTableInput = forwardRef<HTMLInputElement, CosTableInputProps>(
       className,
       isLoading = false,
       errorMessage,
+      hideErrorIcon = false,
       disabled,
       ...restProps
     } = props
@@ -46,26 +48,24 @@ export const CosTableInput = forwardRef<HTMLInputElement, CosTableInputProps>(
     const defaultId = useId()
     const inputId = restProps.id || defaultId
 
-    const isError = !!errorMessage
+    const showErrorMessage = !!errorMessage && !hideErrorIcon
 
     const renderErrorIcon = () => {
+      if (!showErrorMessage) return null
+
       return (
-        <div className="flex size-4 shrink-0 items-center justify-center">
-          {isError && (
-            <CosTooltip
-              hoverContent={{
-                message: errorMessage?.toString(),
-              }}
-            >
-              <WarningFilled className="icon-md text-status-negative" />
-            </CosTooltip>
-          )}
-        </div>
+        <CosTooltip
+          hoverContent={{
+            message: errorMessage?.toString(),
+          }}
+        >
+          <WarningFilled className="icon-md absolute -right-6 text-status-negative" />
+        </CosTooltip>
       )
     }
 
     return (
-      <div className="flex items-center gap-x-2">
+      <div className="relative flex items-center gap-x-2">
         {isLoading ? (
           <CosTableInputSkeleton />
         ) : (
@@ -74,7 +74,10 @@ export const CosTableInput = forwardRef<HTMLInputElement, CosTableInputProps>(
             id={inputId}
             ref={ref}
             disabled={disabled}
-            className={twMerge(input({ isError, disabled }), className)}
+            className={twMerge(
+              input({ isError: showErrorMessage, disabled }),
+              className,
+            )}
           />
         )}
         {renderErrorIcon()}

--- a/packages/cube-frontend-web-app/src/pages/events/index/_components/EventsTable/FilterDatePicker.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/index/_components/EventsTable/FilterDatePicker.tsx
@@ -45,25 +45,6 @@ export const FilterDatePicker = (props: FilterDatePickerProps) => {
     })
   }
 
-  const handleOutsideClickClose = () => {
-    if (!startDate) return
-
-    if (startDate && !endDate) {
-      setEndDate(startDate)
-      onDatePickerChange({
-        startDate: startDate.format('YYYY-MM-DD'),
-        endDate: startDate.format('YYYY-MM-DD'),
-      })
-    }
-
-    if (startDate && endDate) {
-      onDatePickerChange({
-        startDate: startDate.format('YYYY-MM-DD'),
-        endDate: endDate.format('YYYY-MM-DD'),
-      })
-    }
-  }
-
   return (
     <CosDatePicker
       isLoading={isLoading}
@@ -73,7 +54,6 @@ export const FilterDatePicker = (props: FilterDatePickerProps) => {
       setEndDate={setEndDate}
       onApplyClick={handleApplyClick}
       onCancelClick={handleCancelClick}
-      onOutsideClickClose={handleOutsideClickClose}
     />
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/DatePickerFilter.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/DatePickerFilter.tsx
@@ -45,7 +45,6 @@ export const DatePickerFilter = (props: DatePickerFilterProps) => {
       setEndDate={setSelectedEndDate}
       onApplyClick={handleApply}
       onCancelClick={handleCancel}
-      onOutsideClickClose={handleCancel}
     />
   )
 }


### PR DESCRIPTION
#### What type of PR is this?

- Fix

#### What this PR does / why we need it

##### 1) Remove the gap between `<DayButton />`

|       | Before  | After  |
|------------|--------|--------|
| Gap    | <img width="300"  alt="Screenshot 2025-04-14 at 5 23 42 PM" src="https://github.com/user-attachments/assets/677ee17f-8b3d-405c-a3b6-3d654d63c336" /> | <img width="300"  alt="Screenshot 2025-04-14 at 5 23 42 PM" src="https://github.com/user-attachments/assets/27f2db43-14fc-445f-8cfe-f958117a6853" /> |


##### 2) Update 

- Changes will only be applied to the selected date when users click "Apply" button. 

- If the user clicks "Cancel" or anywhere outside the date picker, the dates will revert to their previous state before editing.

https://github.com/user-attachments/assets/c6395db7-6052-4f35-aacf-9b4a4ee2562b


#### Which issue(s) this PR fixes

- Close #230 

- Close #234


#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
