### PR TITLE
243 heatlh and health details page module name capitalization and spaces

### DIFF
--- a/packages/cube-frontend-keycloak-login/src/components/LoginForm/LoginField.tsx
+++ b/packages/cube-frontend-keycloak-login/src/components/LoginForm/LoginField.tsx
@@ -47,7 +47,7 @@ export const LoginFields = () => {
       {isRememberMeEnabled && (
         <CosCheckbox
           name="rememberMe"
-          label="Remember username"
+          label="Stay signed in"
           defaultChecked={true}
           tabIndex={0}
         />

--- a/packages/cube-frontend-web-app/src/layout/useSidebarBottomLinks.ts
+++ b/packages/cube-frontend-web-app/src/layout/useSidebarBottomLinks.ts
@@ -1,10 +1,16 @@
 import { SideBarBottomLinkProps } from '@cube-frontend/ui-library'
+import { useContext } from 'react'
+import { DataCenterContext } from '../context/DataCenterContext'
 
 export const useSidebarBottomLinks = (): SideBarBottomLinkProps[] => {
+  const { additional } = useContext(DataCenterContext)
+
   const links: SideBarBottomLinkProps[] = [
     {
       text: 'Help',
-      href: 'https://docs.bigstack.co/docs/cubecos/quick_start/get_started',
+      href:
+        additional.helpUrl ||
+        'https://docs.bigstack.co/docs/cubecos/quick_start/get_started',
     },
   ]
 

--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthDetailsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthDetailsPage.tsx
@@ -6,6 +6,7 @@ import {
 import { noop } from 'lodash'
 import { useMemo, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router'
+import { moduleNameToLabel, serviceNameToLabel } from '../homeHealthPageUtils'
 import { HealthDetails } from './HealthDetails'
 
 export const HealthDetailsPage = () => {
@@ -37,12 +38,12 @@ export const HealthDetailsPage = () => {
       <div className="flex items-center justify-between">
         <Link to="/home/health">
           <CosBackButton
-            details={`${moduleName} Details`}
+            details={`${moduleNameToLabel(moduleName)} Details`}
             loading={!module}
             // Assign noop because `CosBackButton` requires either `href` or `onClick` prop to be presented.
             onClick={noop}
           >
-            {module?.service ?? ''}
+            {serviceNameToLabel(module?.service)}
           </CosBackButton>
         </Link>
         <CosToggle

--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanelHeader.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanelHeader.tsx
@@ -9,6 +9,7 @@ import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRe
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { ModuleMetadata } from '@cube-frontend/web-app/hooks/useServices/useServices'
 import { useContext } from 'react'
+import { moduleNameToLabel } from '../homeHealthPageUtils'
 
 export type HealthHistoryPanelHeaderProps = {
   module: ModuleMetadata | undefined
@@ -51,7 +52,11 @@ export const HealthHistoryPanelHeader = (
     <div className="flex items-center justify-between">
       <div className="flex items-center gap-x-3">
         <span className="primary-h4 text-functional-text">
-          {!module ? <CosSkeleton className="h-6 w-16" /> : module.name}
+          {!module ? (
+            <CosSkeleton className="h-6 w-16" />
+          ) : (
+            moduleNameToLabel(module.name)
+          )}
         </span>
         <CosButton
           loading={isCallingRepairApi}

--- a/packages/cube-frontend-web-app/src/pages/home/health/_components/healthAccordion/HealthAccordionItem.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/_components/healthAccordion/HealthAccordionItem.tsx
@@ -3,7 +3,7 @@ import ChevronDown from '@cube-frontend/ui-library/icons/monochrome/chevron_down
 import { HealthTimeRange } from '../../healthTimeRangeUtils'
 import { cva } from 'class-variance-authority'
 import { Dayjs } from 'dayjs'
-import { capitalize } from 'lodash'
+import { startCase } from 'lodash'
 import { ServiceCategory } from './healthAccordionUtils'
 import { ServiceHealth } from './ServiceHealth'
 
@@ -52,7 +52,7 @@ export const HealthAccordionItem = (props: HealthAccordionItemProps) => {
         onClick={onExpand}
       >
         <h5 className="secondary-h5 text-functional-text">
-          {capitalize(category.name)}
+          {startCase(category.name)}
         </h5>
         <span className="flex items-center justify-center p-2">
           <ChevronDown className={chevron({ isExpanded })} />

--- a/packages/cube-frontend-web-app/src/pages/home/health/_components/healthAccordion/ModuleHealth.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/_components/healthAccordion/ModuleHealth.tsx
@@ -7,9 +7,10 @@ import ChevronRight from '@cube-frontend/ui-library/icons/monochrome/chevron_rig
 import { TimePoint } from '@cube-frontend/web-app/components/HealthSegmentedBar/createTimePoints'
 import { HealthSegmentedBar } from '@cube-frontend/web-app/components/HealthSegmentedBar/HealthSegmentedBar'
 import { Dayjs } from 'dayjs'
-import { capitalize, noop } from 'lodash'
+import { noop } from 'lodash'
 import { useMemo } from 'react'
 import { Link } from 'react-router'
+import { moduleNameToLabel } from '../../homeHealthPageUtils'
 import { timePointFns } from './healthAccordionUtils'
 import { HealthBarSkeleton } from './HealthBarSkeleton'
 import { HealthTimeTrack, timeTrackHeight } from './HealthTimeTrack'
@@ -46,7 +47,7 @@ export const ModuleHealth = (props: ModuleHealthProps) => {
           // Assign noop because `CosHyperlink` requires either `href` or `onClick` prop to be presented.
           onClick={noop}
         >
-          {capitalize(moduleName)}
+          {moduleNameToLabel(moduleName)}
         </CosHyperlink>
       </Link>
       {isLoading ? (

--- a/packages/cube-frontend-web-app/src/pages/home/health/_components/healthAccordion/ServiceHealth.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/_components/healthAccordion/ServiceHealth.tsx
@@ -11,9 +11,11 @@ import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterCont
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
 import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentialInterval/useSequentialInterval'
 import { Dayjs } from 'dayjs'
-import { upperFirst } from 'lodash'
 import { useContext, useMemo } from 'react'
-import { HOME_HEALTH_PAGE_POLLING_INTERVAL } from '../../homeHealthPageUtils'
+import {
+  HOME_HEALTH_PAGE_POLLING_INTERVAL,
+  serviceNameToLabel,
+} from '../../homeHealthPageUtils'
 import { ModuleHealth } from './ModuleHealth'
 import { useIsVisible } from './useIsVisible'
 import { HealthTimeRange } from '../../healthTimeRangeUtils'
@@ -78,7 +80,7 @@ export const ServiceHealth = (props: ServiceHealthProps) => {
   return (
     <div className="flex flex-col gap-y-2">
       <div className="primary-body3 font-medium text-functional-text">
-        {upperFirst(service.name)}
+        {serviceNameToLabel(service.name)}
       </div>
       <div
         ref={elementRef}

--- a/packages/cube-frontend-web-app/src/pages/home/health/homeHealthPageUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/health/homeHealthPageUtils.ts
@@ -1,1 +1,107 @@
 export const HOME_HEALTH_PAGE_POLLING_INTERVAL = 5 * 1000
+
+const serviceNameLabelMap: Record<string, string> = {
+  clusterLink: 'Cluster Link',
+  clusterSys: 'Cluster Sys',
+  clusterSettings: 'Cluster Settings',
+  haCluster: 'HA Cluster',
+  msgQueue: 'Msg Queue',
+  iaasDb: 'Iaas DB',
+  virtualIp: 'Virtual IP',
+  apiService: 'API Service',
+  singleSignOn: 'Single Sign On',
+  storage: 'Storage',
+  network: 'Network',
+  compute: 'Compute',
+  bareMetal: 'Bare Metal',
+  image: 'Image',
+  blockStor: 'BlockStor',
+  fileStor: 'FileStor',
+  objectStor: 'ObjectStor',
+  orchestration: 'Orchestration',
+  lbaas: 'LBaaS',
+  dnsaas: 'DNSaaS',
+  k8saas: 'K8saaS',
+  instanceHa: 'Instance HA',
+  businessLogic: 'Business Logic',
+  dataPipe: 'Data Pipe',
+  metrics: 'Metrics',
+  logAnalytics: 'Log Analytics',
+  notifications: 'Notifications',
+}
+
+export const serviceNameToLabel = (name: string | undefined): string => {
+  if (!name) return ''
+  const label = serviceNameLabelMap[name]
+  if (!label) {
+    console.warn(`Cannot find the label for service ${name}`)
+  }
+  return label || name
+}
+
+const moduleNameLabelMap: Record<string, string> = {
+  link: 'Link',
+  clock: 'Clock',
+  dns: 'DNS',
+  bootstrap: 'Bootstrap',
+  license: 'License',
+  etcd: 'etcd',
+  nodelist: 'Node List',
+  hacluster: 'HA Cluster',
+  rabbitmq: 'RabbitMQ',
+  mysql: 'MySQL',
+  mongodb: 'MongoDB',
+  vip: 'VIP',
+  haproxy_ha: 'HA Proxy HA',
+  haproxy: 'HAProxy',
+  httpd: 'Httpd',
+  skyline: 'Skyline',
+  lmi: 'LMI',
+  memcache: 'Memcache',
+  api: 'API',
+  k3s: 'K3s',
+  keycloak: 'Keycloak',
+  ceph: 'Ceph',
+  ceph_mon: 'Ceph MON',
+  ceph_mgr: 'Ceph MGR',
+  ceph_mds: 'Ceph MDS',
+  ceph_osd: 'Ceph OSD',
+  ceph_rgw: 'Ceph RGW',
+  rbd_target: 'RBD Target',
+  neutron: 'Neutron',
+  nova: 'Nova',
+  cyborg: 'Cyborg',
+  ironic: 'Ironic',
+  glance: 'Glance',
+  cinder: 'Cinder',
+  manila: 'Manila',
+  swift: 'Swift',
+  heat: 'Heat',
+  octavia: 'Octavia',
+  designate: 'Designate',
+  rancher: 'Rancher',
+  masakari: 'Masakari',
+  senlin: 'Senlin',
+  watcher: 'Watcher',
+  zookeeper: 'ZooKeeper',
+  kafka: 'Kafka',
+  monasca: 'Monasca',
+  telegraf: 'Telegraf',
+  grafana: 'Grafana',
+  filebeat: 'Filebeat',
+  auditbeat: 'Auditbeat',
+  logstash: 'Logstash',
+  opensearch: 'OpenSearch',
+  'opensearch-dashboards': 'OpenSearch Dashboards',
+  influxdb: 'InfluxDB',
+  kapacitor: 'Kapacitor',
+}
+
+export const moduleNameToLabel = (name: string | undefined): string => {
+  if (!name) return ''
+  const label = moduleNameLabelMap[name]
+  if (!label) {
+    console.warn(`Cannot find the label for module ${name}`)
+  }
+  return label || name
+}

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDevices.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDevices.tsx
@@ -72,6 +72,7 @@ export const NodeDevices = (props: NodeDevicesProps) => {
       <DeviceTable isLoading={!node} rows={rows}>
         <DeviceTable.Column label="Device" property="device" emphasize={true} />
         <DeviceTable.Column label="Type" property="type" />
+        <DeviceTable.Column label="Serial" property="serial" />
         <DeviceTable.Column label="Size" property="sizeMiB">
           {(sizeMiB) => toReadableSizeString(sizeMiB, 'MiB')}
         </DeviceTable.Column>

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDevices.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDevices.tsx
@@ -71,8 +71,8 @@ export const NodeDevices = (props: NodeDevicesProps) => {
       <div className="primary-body3 text-functional-text">Devices</div>
       <DeviceTable isLoading={!node} rows={rows}>
         <DeviceTable.Column label="Device" property="device" emphasize={true} />
+        <DeviceTable.Column label="Serial number" property="serial" />
         <DeviceTable.Column label="Type" property="type" />
-        <DeviceTable.Column label="Serial" property="serial" />
         <DeviceTable.Column label="Size" property="sizeMiB">
           {(sizeMiB) => toReadableSizeString(sizeMiB, 'MiB')}
         </DeviceTable.Column>


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Updates the labels for all services and modules in the Health & Health Details pages.

#### Which issue(s) this PR fixes

Fixes #243

#### Special notes for your reviewer

- There will be a warning in the console (``console.warn(`Cannot find the label for service/module ${name}`)``) when the corresponding label is not defined in the map. Not seeing this warning means everything is good.
- I sneaked in a commit that fixes the help link in the sidebar. Previously it was hard-coded, but we should use the value of `additional.helpUrl` when applicable.

https://github.com/user-attachments/assets/aa3b496e-1063-4b2b-9f3c-0add8be53a12
