### PR TITLE
feat(ui-library): view details table

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/CosBasicTable.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/CosBasicTable.tsx
@@ -1,6 +1,7 @@
 import {
   ComponentProps,
   ComponentType,
+  Fragment,
   PropsWithChildren,
   useMemo,
 } from 'react'
@@ -17,6 +18,7 @@ import { CosTableTh } from './rendering/CosTableTh'
 import { SortingState } from './sorting/sortingUtils'
 import { useSortedRows } from './sorting/useSortedRows'
 import { useColumnPayloads } from './useColumnPayloads'
+import { useSubRows } from './useSubRows'
 
 const tdBorderRadiusClass = twMerge(
   '[&:last-of-type>td:first-of-type]:rounded-bl-[5px]',
@@ -49,6 +51,8 @@ export const CosBasicTable = <Row extends CosTableRow>(
   } = props
 
   const { columns, rowCompareFnMapRef } = useColumnPayloads<Row>(children)
+
+  const subRows = useSubRows<Row>(children)
 
   const { sortedRows, sortingState, onSortDirectionChange } = useSortedRows(
     rows,
@@ -86,25 +90,55 @@ export const CosBasicTable = <Row extends CosTableRow>(
     if (sortedRows.length === 0) return renderEmptyRow()
 
     return sortedRows.map((row, rowIndex) => (
-      <tr
-        key={row.id}
-        className={twMerge(
-          '[&>td]:hover:bg-functional-hover-grey',
-          tdBorderRadiusClass,
-          computeRowClassName(rowClassName, row),
-        )}
-        onClick={() => onRowClick?.(row)}
-      >
-        {columns.map((column, colIndex) => (
-          <CosTableTd
-            key={`${column.property?.toString() ?? ''}-${colIndex}`}
-            row={row}
-            rowIndex={rowIndex}
-            column={column}
-          />
-        ))}
-      </tr>
+      <Fragment key={row.id}>
+        <tr
+          className={twMerge(
+            '[&>td]:hover:bg-functional-hover-grey',
+            tdBorderRadiusClass,
+            computeRowClassName(rowClassName, row),
+          )}
+          onClick={() => onRowClick?.(row)}
+        >
+          {columns.map((column, colIndex) => (
+            <CosTableTd
+              key={`${column.property?.toString() ?? ''}-${colIndex}`}
+              row={row}
+              rowIndex={rowIndex}
+              column={column}
+            />
+          ))}
+        </tr>
+        {renderSubRows(row)}
+      </Fragment>
     ))
+  }
+
+  const renderSubRows = (parentRow: Row) => {
+    if (!subRows.length) return undefined
+
+    return subRows.map((subRow, subRowIndex) => {
+      const { className, isVisible } = subRow.props
+      return (
+        <tr
+          key={`${parentRow.id}-sub-row-${subRowIndex}`}
+          className={twMerge(
+            '[&>td]:hover:bg-functional-hover-grey',
+            tdBorderRadiusClass,
+            computeRowClassName(className, parentRow),
+            !isVisible(parentRow) && 'invisible [&>td]:p-0',
+          )}
+        >
+          {subRow.columns.map((column, columnIndex) => (
+            <CosTableTd
+              key={columnIndex}
+              row={parentRow}
+              rowIndex={subRowIndex}
+              column={column}
+            />
+          ))}
+        </tr>
+      )
+    })
   }
 
   return (

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/cosTableUtils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/cosTableUtils.ts
@@ -1,6 +1,7 @@
 import { isValidElement, ReactElement, ReactNode } from 'react'
 import { ClassNameValue } from 'tailwind-merge'
 import { CosTableColumnProps } from './rendering/CosTableColumn'
+import { CosTableSubRowProps } from './rendering/CosTableSubRow'
 
 export type CosTableRow = {
   id: string
@@ -13,6 +14,8 @@ export type CosBatchActionTableRow = CosTableRow & {
 
 export const COS_TABLE_COLUMN_SYMBOL = Symbol('CosTableColumn')
 
+export const COS_TABLE_SUB_ROW_SYMBOL = Symbol('CosTableSubRow')
+
 export const isCosTableColumn = <Row extends CosTableRow>(
   node: ReactNode,
 ): node is ReactElement<CosTableColumnProps<Row, keyof Row | never>> => {
@@ -20,6 +23,17 @@ export const isCosTableColumn = <Row extends CosTableRow>(
     return false
   }
   return typeof node.type === 'function' && COS_TABLE_COLUMN_SYMBOL in node.type
+}
+
+export const isCosTableSubRow = <ParentRow extends CosTableRow>(
+  node: ReactNode,
+): node is ReactElement<CosTableSubRowProps<ParentRow>> => {
+  if (!isValidElement(node)) {
+    return false
+  }
+  return (
+    typeof node.type === 'function' && COS_TABLE_SUB_ROW_SYMBOL in node.type
+  )
 }
 
 export type RowClassNameProp<Row extends CosTableRow> =
@@ -38,4 +52,9 @@ export const computeRowClassName = <Row extends CosTableRow>(
     return prop(row)
   }
   return prop
+}
+
+export type CosViewDetailsTableDetailItem = {
+  title: string
+  value: string | number
 }

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableColumn.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableColumn.tsx
@@ -43,6 +43,10 @@ export type CosTableColumnProps<
    * @default 'regular'
    */
   skeletonVariant?: CosTableColumnSkeletonVariant
+  /**
+   * @default undefined
+   */
+  colSpan?: number
 }
 
 // Wrapper function to help TypeScript correctly infer the type of `Row[Property]`.

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableSubRow.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableSubRow.tsx
@@ -1,0 +1,21 @@
+import { ReactNode } from 'react'
+import {
+  COS_TABLE_SUB_ROW_SYMBOL,
+  CosTableRow,
+  RowClassNameProp,
+} from '../cosTableUtils'
+
+export type CosTableSubRowProps<ParentRow extends CosTableRow> = {
+  className?: RowClassNameProp<ParentRow>
+  children: ReactNode
+  isVisible: (parentRow: ParentRow) => boolean
+}
+
+export const CosTableSubRow = <ParentRow extends CosTableRow>(
+  _props: CosTableSubRowProps<ParentRow>,
+) => {
+  // The actual rendering logic is handled by CosBasicTable.
+  return undefined
+}
+
+CosTableSubRow[COS_TABLE_SUB_ROW_SYMBOL] = true

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTd.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/rendering/CosTableTd.tsx
@@ -79,6 +79,7 @@ export const CosTableTd = <Row extends CosTableRow>(
         emphasize: getEmphasize(),
         fitContent: column.fitContent,
       })}
+      colSpan={column.colSpan}
     >
       {isLoading ? (
         <CosTableTdSkeleton variant={column.skeletonVariant ?? 'regular'} />

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/useColumnPayloads.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/useColumnPayloads.ts
@@ -28,13 +28,7 @@ export const useColumnPayloads = <Row extends CosTableRow>(
     const nextRowCompareFnMap: RowCompareFnMap<Row> = {}
 
     Children.toArray(children).forEach((child) => {
-      if (!isCosTableColumn<Row>(child)) {
-        console.warn(
-          'The children of CosTable can only be CosTableColumn, but found: ',
-          child,
-        )
-        return
-      }
+      if (!isCosTableColumn<Row>(child)) return
 
       const columnProps = child.props as CosTableColumnProps<
         Row,

--- a/packages/cube-frontend-ui-library/src/components/CosBasicTable/useSubRows.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosBasicTable/useSubRows.ts
@@ -1,0 +1,53 @@
+import { Children, ReactNode, useEffect, useState } from 'react'
+import {
+  CosTableRow,
+  isCosTableColumn,
+  isCosTableSubRow,
+} from './cosTableUtils'
+import { CosTableColumnProps } from './rendering/CosTableColumn'
+import { CosTableSubRowProps } from './rendering/CosTableSubRow'
+
+export type SubRow<ParentRow extends CosTableRow> = {
+  columns: CosTableColumnProps<ParentRow, keyof ParentRow | never>[]
+  props: CosTableSubRowProps<ParentRow>
+}
+
+export const useSubRows = <ParentRow extends CosTableRow>(
+  tableChildren: ReactNode,
+): SubRow<ParentRow>[] => {
+  const [subRows, setSubRows] = useState<SubRow<ParentRow>[]>([])
+
+  useEffect(() => {
+    const nextSubRows: SubRow<ParentRow>[] = []
+
+    Children.toArray(tableChildren).forEach((subRowNode) => {
+      if (!isCosTableSubRow<ParentRow>(subRowNode)) return
+
+      const subRowColumns: CosTableColumnProps<
+        ParentRow,
+        keyof ParentRow | never
+      >[] = []
+
+      Children.toArray(subRowNode.props.children).forEach((columnNode) => {
+        if (!isCosTableColumn<ParentRow>(columnNode)) return
+
+        const columnProps = columnNode.props as CosTableColumnProps<
+          ParentRow,
+          keyof ParentRow | never
+        >
+        subRowColumns.push(columnProps)
+      })
+
+      if (subRowColumns.length) {
+        nextSubRows.push({
+          columns: subRowColumns,
+          props: subRowNode.props,
+        })
+      }
+    })
+
+    setSubRows(nextSubRows)
+  }, [tableChildren])
+
+  return subRows
+}

--- a/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/CosViewDetailsTable.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/CosViewDetailsTable.tsx
@@ -1,0 +1,139 @@
+import ChevronDown from '@cube-frontend/ui-library/icons/monochrome/chevron_down.svg?react'
+import { cva } from 'class-variance-authority'
+import { ClassNameValue, twMerge } from 'tailwind-merge'
+import {
+  CosBasicTable,
+  CosBasicTableProps,
+  GetCosBasicTable,
+} from '../CosBasicTable/CosBasicTable'
+import {
+  CosTableRow,
+  CosViewDetailsTableDetailItem,
+} from '../CosBasicTable/cosTableUtils'
+import { CreateCosTableColumn } from '../CosBasicTable/rendering/CosTableColumn'
+import { CosTableSubRow } from '../CosBasicTable/rendering/CosTableSubRow'
+import { DetailCell } from './DetailCell'
+import { useColumnCount } from './useColumnCount'
+
+export type CosViewDetailsTableProps<ParentRow extends CosTableRow> = Omit<
+  CosBasicTableProps<ParentRow> & {
+    expandedRowIdSet: Set<string>
+    onExpandChange: (parentRowId: string, value: boolean) => void
+    detailTitle?: string | ((parentRow: ParentRow) => string)
+    getDetailItems: (parentRow: ParentRow) => CosViewDetailsTableDetailItem[]
+  },
+  'rowClassName'
+>
+
+const expandButton = cva('transition-transform', {
+  variants: {
+    isExpanded: {
+      true: 'rotate-180',
+      false: 'rotate-0',
+    },
+  },
+})
+
+const CosViewDetailsTable = <ParentRow extends CosTableRow>(
+  props: CosViewDetailsTableProps<ParentRow>,
+) => {
+  const {
+    children,
+    expandedRowIdSet,
+    onExpandChange: onExpandChangeProp,
+    detailTitle,
+    getDetailItems,
+    ...restProps
+  } = props
+
+  const TypedBasicTable = GetCosBasicTable<ParentRow>()
+
+  const columnCount = useColumnCount(children)
+
+  const isExpanded = (parentRowId: string): boolean => {
+    return expandedRowIdSet.has(parentRowId)
+  }
+
+  const onExpandChange = (parentRowId: string): void => {
+    const value = !expandedRowIdSet.has(parentRowId)
+    onExpandChangeProp(parentRowId, value)
+  }
+
+  const computeParentRowClassName = (row: ParentRow): ClassNameValue => {
+    if (isExpanded(row.id)) {
+      return twMerge(
+        '[&>td]:bg-functional-hover-secondary',
+        '[&>td]:hover:bg-functional-hover-secondary',
+      )
+    }
+    return undefined
+  }
+
+  const computeSubRowClassName = (parentRow: ParentRow): ClassNameValue => {
+    if (isExpanded(parentRow.id)) {
+      return twMerge(
+        '[&>td]:bg-scene-background',
+        '[&>td]:hover:bg-scene-background',
+      )
+    }
+    // Hide the border of sub-rows when collapsed because it's still visible
+    // even when `max-height` is 0.
+    return twMerge('[&>td]:border-none')
+  }
+
+  const computeDetailTitle = (parentRow: ParentRow): string | undefined => {
+    if (typeof detailTitle === 'function') {
+      return detailTitle(parentRow)
+    }
+    return detailTitle
+  }
+
+  return (
+    <TypedBasicTable {...restProps} rowClassName={computeParentRowClassName}>
+      <TypedBasicTable.Column skeletonVariant="icon-only" fitContent={true}>
+        {(_, parentRow) => (
+          <button
+            type="button"
+            className={expandButton({
+              isExpanded: isExpanded(parentRow.id),
+            })}
+            onClick={() => onExpandChange(parentRow.id)}
+          >
+            <ChevronDown className="icon-md text-functional-text" />
+          </button>
+        )}
+      </TypedBasicTable.Column>
+      {children}
+      <CosTableSubRow
+        className={computeSubRowClassName}
+        isVisible={(row) => isExpanded(row.id)}
+      >
+        {/* Placeholder column for the expand button. */}
+        <TypedBasicTable.Column />
+        {/* Details column. */}
+        <TypedBasicTable.Column colSpan={columnCount}>
+          {(_, row) => (
+            <DetailCell
+              isExpanded={isExpanded(row.id)}
+              title={computeDetailTitle(row)}
+              items={getDetailItems(row)}
+            />
+          )}
+        </TypedBasicTable.Column>
+      </CosTableSubRow>
+    </TypedBasicTable>
+  )
+}
+
+CosViewDetailsTable.Column = CosBasicTable.Column
+
+type CosViewDetailsTableWithColumn<ParentRow extends CosTableRow> =
+  typeof CosViewDetailsTable<ParentRow> & {
+    Column: ReturnType<typeof CreateCosTableColumn<ParentRow>>
+  }
+
+export const GetCosViewDetailsTable = <
+  ParentRow extends CosTableRow,
+>(): CosViewDetailsTableWithColumn<ParentRow> => {
+  return CosViewDetailsTable as CosViewDetailsTableWithColumn<ParentRow>
+}

--- a/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/DetailCell.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/DetailCell.tsx
@@ -1,0 +1,53 @@
+import { cva } from 'class-variance-authority'
+import { CosViewDetailsTableDetailItem } from '../CosBasicTable/cosTableUtils'
+
+type DetailCellProps = {
+  isExpanded: boolean
+  title?: string
+  items: CosViewDetailsTableDetailItem[]
+}
+
+const container = cva(
+  [
+    'flex flex-col gap-y-4 overflow-hidden',
+    'transition-[max-height,padding-top,padding-bottom]',
+  ],
+  {
+    variants: {
+      isExpanded: {
+        // TODO: `max-height` transition needs a fixed value (e.g., 400px) to
+        // work properly. We could use something large like 9999px, but that
+        // makes the animation look slow as it has to go from 0 to 9999.
+        // 400px is chosen because it works well for all current use cases.
+        // Consider making this value configurable, or look into a better way
+        // to animate height.
+        true: 'max-h-[400px] py-1.5 pr-8',
+        false: 'max-h-0 p-0',
+      },
+    },
+  },
+)
+
+export const DetailCell = (props: DetailCellProps) => {
+  const { isExpanded, title, items } = props
+
+  return (
+    <div className={container({ isExpanded })}>
+      {title && (
+        <div className="primary-body4 text-functional-text-light">{title}</div>
+      )}
+      <div className="flex flex-wrap gap-4">
+        {items.map((item, index) => (
+          <div key={index} className="flex items-center gap-x-4">
+            <span className="primary-body4 w-[80px] text-functional-text">
+              {item.title}
+            </span>
+            <span className="primary-body5 w-[164px] text-functional-text-light">
+              {item.value}
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/useColumnCount.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/useColumnCount.ts
@@ -1,0 +1,19 @@
+import { Children, ReactNode, useEffect, useState } from 'react'
+import { CosTableRow, isCosTableColumn } from '../CosBasicTable/cosTableUtils'
+
+// CosViewDetailsTable is built on top of CosBasicTable, so passing the column
+// count from the base (CosBasicTable) up to CosViewDetailsTable (or any other
+// table built on top of it) would take extra effort.
+// To keep things simple, we calculate the column count here for now.
+export const useColumnCount = (children: ReactNode): number => {
+  const [columnCount, setColumnCount] = useState(0)
+
+  useEffect(() => {
+    const columnNodeCount = Children.toArray(children).filter((child) => {
+      return isCosTableColumn<CosTableRow>(child)
+    }).length
+    setColumnCount(columnNodeCount)
+  }, [children])
+
+  return columnCount
+}

--- a/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/useExpandedRowIdSet.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/useExpandedRowIdSet.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+
+type UseExpandedRowIdSet = {
+  expandedRowIdSet: Set<string>
+  onExpandChange: (parentRowId: string, value: boolean) => void
+  resetExpandedRowIdSet: () => void
+}
+
+export const useExpandedRowIdSet = (): UseExpandedRowIdSet => {
+  const [expandedRowIdSet, setExpandedRowIdSet] = useState<Set<string>>(
+    () => new Set(),
+  )
+
+  const onExpandChange = (parentRowId: string, value: boolean): void => {
+    setExpandedRowIdSet((prev) => {
+      const next = new Set(prev)
+      if (value) {
+        next.add(parentRowId)
+      } else {
+        next.delete(parentRowId)
+      }
+      return next
+    })
+  }
+
+  const resetExpandedRowIdSet = (): void => {
+    setExpandedRowIdSet(new Set())
+  }
+
+  return {
+    expandedRowIdSet,
+    onExpandChange,
+    resetExpandedRowIdSet,
+  }
+}

--- a/packages/cube-frontend-ui-library/src/index.ts
+++ b/packages/cube-frontend-ui-library/src/index.ts
@@ -8,6 +8,7 @@ export {
 export type {
   CosTableRow,
   CosBatchActionTableRow,
+  CosViewDetailsTableDetailItem,
 } from './components/CosBasicTable/cosTableUtils'
 export * from './components/CosBasicTable/rendering/CosTableTdSkeleton'
 export type {
@@ -18,6 +19,11 @@ export {
   type CosBatchActionTableProps,
   GetCosBatchActionTable,
 } from './components/CosBatchActionTable/CosBatchActionTable'
+export {
+  type CosViewDetailsTableProps,
+  GetCosViewDetailsTable,
+} from './components/CosViewDetailsTable/CosViewDetailsTable'
+export { useExpandedRowIdSet } from './components/CosViewDetailsTable/useExpandedRowIdSet'
 export * from './components/CosButton/CosButton'
 export * from './components/CosButton/CosButtonSkeleton'
 export * from './components/CosCheckbox/CosCheckbox'

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTables/ViewDetails/CosViewDetailsTable.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTables/ViewDetails/CosViewDetailsTable.stories.tsx
@@ -1,0 +1,242 @@
+import {
+  CosViewDetailsTableDetailItem,
+  useExpandedRowIdSet,
+} from '@cube-frontend/ui-library'
+import { Meta, StoryObj } from '@storybook/react'
+import { capitalize } from 'lodash'
+import { StoryLayout } from '../../../../internal/components/StoryLayout/StoryLayout'
+import {
+  isCmpLicense,
+  LicenseTable,
+  MockLicense,
+  mockLicenses,
+} from './cosViewDetailsTableStoryUtils'
+
+const meta = {
+  title: 'organisms/Tables/View Details',
+  component: LicenseTable,
+} satisfies Meta
+
+export default meta
+
+export const Gallery: StoryObj = {
+  render: () => (
+    <StoryLayout title="Table - View Details">
+      <StoryLayout.Section title="Default">
+        <Default />
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Without Title">
+        <WithoutTitle />
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Dynamic Content">
+        <DynamicContent />
+      </StoryLayout.Section>
+      <StoryLayout.Section title="Skeleton">
+        <Skeleton />
+      </StoryLayout.Section>
+    </StoryLayout>
+  ),
+}
+
+const Default = () => {
+  const { expandedRowIdSet, onExpandChange } = useExpandedRowIdSet()
+
+  const getDetailItems = (
+    license: MockLicense,
+  ): CosViewDetailsTableDetailItem[] => {
+    return [
+      {
+        title: 'Quantity',
+        value: license.quantity,
+      },
+      {
+        title: 'Support Plan',
+        value: license.supportPlan,
+      },
+      {
+        title: 'Feature',
+        value: capitalize(license.feature),
+      },
+    ]
+  }
+
+  return (
+    <LicenseTable
+      rows={mockLicenses}
+      expandedRowIdSet={expandedRowIdSet}
+      onExpandChange={onExpandChange}
+      detailTitle="License Detail"
+      getDetailItems={getDetailItems}
+    >
+      <LicenseTable.Column label="Product" property="product" />
+      <LicenseTable.Column label="License name" property="name" />
+      <LicenseTable.Column label="Hosts" property="hosts">
+        {(hosts) => hosts.join(', ')}
+      </LicenseTable.Column>
+      <LicenseTable.Column label="Issue date" property="issueDate" />
+      <LicenseTable.Column label="Expire date" property="expireDate" />
+      <LicenseTable.Column label="Expired" property="expired" />
+      <LicenseTable.Column label="Type" property="type" />
+    </LicenseTable>
+  )
+}
+
+const WithoutTitle = () => {
+  const { expandedRowIdSet, onExpandChange } = useExpandedRowIdSet()
+
+  const getDetailItems = (
+    license: MockLicense,
+  ): CosViewDetailsTableDetailItem[] => {
+    return [
+      {
+        title: 'Quantity',
+        value: license.quantity,
+      },
+      {
+        title: 'Support Plan',
+        value: license.supportPlan,
+      },
+      {
+        title: 'Feature',
+        value: capitalize(license.feature),
+      },
+    ]
+  }
+
+  return (
+    <LicenseTable
+      rows={mockLicenses}
+      expandedRowIdSet={expandedRowIdSet}
+      onExpandChange={onExpandChange}
+      getDetailItems={getDetailItems}
+    >
+      <LicenseTable.Column label="Product" property="product" />
+      <LicenseTable.Column label="License name" property="name" />
+      <LicenseTable.Column label="Hosts" property="hosts">
+        {(hosts) => hosts.join(', ')}
+      </LicenseTable.Column>
+      <LicenseTable.Column label="Issue date" property="issueDate" />
+      <LicenseTable.Column label="Expire date" property="expireDate" />
+      <LicenseTable.Column label="Expired" property="expired" />
+      <LicenseTable.Column label="Type" property="type" />
+    </LicenseTable>
+  )
+}
+
+const DynamicContent = () => {
+  const { expandedRowIdSet, onExpandChange } = useExpandedRowIdSet()
+
+  const getDetailTitle = (license: MockLicense): string => {
+    let title = 'License Detail'
+    if (isCmpLicense(license)) {
+      title += ' (I have extra details)'
+    }
+    return title
+  }
+
+  const getDetailItems = (
+    license: MockLicense,
+  ): CosViewDetailsTableDetailItem[] => {
+    const items: CosViewDetailsTableDetailItem[] = [
+      {
+        title: 'Quantity',
+        value: license.quantity,
+      },
+      {
+        title: 'Support Plan',
+        value: license.supportPlan,
+      },
+      {
+        title: 'Feature',
+        value: capitalize(license.feature),
+      },
+    ]
+
+    if (isCmpLicense(license)) {
+      items.push(
+        {
+          title: 'CMP Item A',
+          value: 'AAA',
+        },
+        {
+          title: 'CMP Item B',
+          value: 'BBB',
+        },
+        {
+          title: 'CMP Item C',
+          value: 'CCC',
+        },
+        {
+          title: 'CMP Item D',
+          value: 'DDD',
+        },
+      )
+    }
+
+    return items
+  }
+
+  return (
+    <LicenseTable
+      rows={mockLicenses}
+      expandedRowIdSet={expandedRowIdSet}
+      onExpandChange={onExpandChange}
+      detailTitle={getDetailTitle}
+      getDetailItems={getDetailItems}
+    >
+      <LicenseTable.Column label="Product" property="product" />
+      <LicenseTable.Column label="License name" property="name" />
+      <LicenseTable.Column label="Hosts" property="hosts">
+        {(hosts) => hosts.join(', ')}
+      </LicenseTable.Column>
+      <LicenseTable.Column label="Issue date" property="issueDate" />
+      <LicenseTable.Column label="Expire date" property="expireDate" />
+      <LicenseTable.Column label="Expired" property="expired" />
+      <LicenseTable.Column label="Type" property="type" />
+    </LicenseTable>
+  )
+}
+
+const Skeleton = () => {
+  const { expandedRowIdSet, onExpandChange } = useExpandedRowIdSet()
+
+  const getDetailItems = (
+    license: MockLicense,
+  ): CosViewDetailsTableDetailItem[] => {
+    return [
+      {
+        title: 'Quantity',
+        value: license.quantity,
+      },
+      {
+        title: 'Support Plan',
+        value: license.supportPlan,
+      },
+      {
+        title: 'Feature',
+        value: license.feature,
+      },
+    ]
+  }
+
+  return (
+    <LicenseTable
+      isLoading={true}
+      rows={mockLicenses}
+      expandedRowIdSet={expandedRowIdSet}
+      onExpandChange={onExpandChange}
+      detailTitle="License Detail"
+      getDetailItems={getDetailItems}
+    >
+      <LicenseTable.Column label="Product" property="product" />
+      <LicenseTable.Column label="License name" property="name" />
+      <LicenseTable.Column label="Hosts" property="hosts">
+        {(hosts) => hosts.join(', ')}
+      </LicenseTable.Column>
+      <LicenseTable.Column label="Issue date" property="issueDate" />
+      <LicenseTable.Column label="Expire date" property="expireDate" />
+      <LicenseTable.Column label="Expired" property="expired" />
+      <LicenseTable.Column label="Type" property="type" />
+    </LicenseTable>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTables/ViewDetails/cosViewDetailsTableStoryUtils.ts
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTables/ViewDetails/cosViewDetailsTableStoryUtils.ts
@@ -1,0 +1,50 @@
+import { GetCosViewDetailsTable } from '@cube-frontend/ui-library'
+
+export const LicenseTable = GetCosViewDetailsTable<MockLicense>()
+
+export type MockLicense = {
+  id: string
+  product: string
+  name: string
+  hosts: string[]
+  issueDate: string
+  expireDate: string
+  expired: string
+  type: string
+  quantity: number
+  supportPlan: string
+  feature: string
+}
+
+export const mockLicenses: MockLicense[] = [
+  {
+    id: '1',
+    product: 'CubeCOS',
+    name: 'License for COS',
+    hosts: ['Dell01', 'Dell02', 'Dell03'],
+    issueDate: '2025/04/17',
+    expireDate: '2025/05/16',
+    expired: 'in 30 days',
+    type: 'Trial',
+    quantity: 1,
+    supportPlan: 'Plan A',
+    feature: 'virtualization',
+  },
+  {
+    id: '2',
+    product: 'CubeCMP',
+    name: 'License for CMP',
+    hosts: ['Dell04', 'Dell05', 'Dell06'],
+    issueDate: '2025/04/17',
+    expireDate: '2025/05/16',
+    expired: 'in 30 days',
+    type: 'Trial',
+    quantity: 2,
+    supportPlan: 'Plan B',
+    feature: 'kubernetes',
+  },
+]
+
+export const isCmpLicense = (license: MockLicense): boolean => {
+  return license.product.toLowerCase().includes('cmp')
+}


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Implement the `CosViewDetailsTable` component.

#### Which issue(s) this PR fixes

#248

#### Special notes for your reviewer

https://github.com/user-attachments/assets/690ab2b4-bcbc-4467-a07e-2926d87876bf

1. Checkbox functionality is not implemented yet since there’s no actual use case at the moment. We can deal with that later.
2. The current implementation is a little bit different from the mockup:
   - Mockup:
      - <img width="583" alt="{088D3A87-E0BD-4C08-B003-13FCE547F3B8}" src="https://github.com/user-attachments/assets/9f3ab7d6-9c81-4ebb-aa24-a0e58679ed4a" />
   - Current implementation:
      - ![image](https://github.com/user-attachments/assets/667f264e-e46c-43f5-9c08-2e14184f2922)
   - As shown above, the expand button is designed to be embedded in the first column, with no extra column reserved for it. But in the current implementation, it is placed in a separate column at the start of the table. While it's possible to match the design, it would require more complex logic (modifying nested children), so I’ve decided to skip it for now.



