### PR TITLE
259 fix(web-app): create tunings page bool limitation type blank screen

### DIFF
--- a/packages/cube-frontend-api/sdk/api.ts
+++ b/packages/cube-frontend-api/sdk/api.ts
@@ -6487,7 +6487,7 @@ export const TuningLimitationType = {
     Str: 'str',
     Int: 'int',
     Uint: 'uint',
-    Boolean: 'boolean'
+    Bool: 'bool'
 } as const;
 
 export type TuningLimitationType = typeof TuningLimitationType[keyof typeof TuningLimitationType];

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/TuningValueControl.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/TuningValueControl.tsx
@@ -49,7 +49,7 @@ export const TuningValueControl = (props: TuningValueControlProps) => {
     str: renderInput,
     int: renderInput,
     uint: renderInput,
-    boolean: renderBoolControl,
+    bool: renderBoolControl,
   }
 
   return renderFnMap[limitation.type]()

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/formatLimitation.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/formatLimitation.ts
@@ -71,7 +71,7 @@ const formatFnMap: Record<TuningLimitationType, FormatFn> = {
   str: formatStringLimitation,
   int: formatNumberLimitation,
   uint: formatNumberLimitation,
-  boolean: () => 'Boolean',
+  bool: () => 'Boolean',
 }
 
 type Entry = {

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/validateTuningValue.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/validateTuningValue.ts
@@ -80,5 +80,5 @@ const validateFnMap: Record<TuningLimitationType, ValidateFn> = {
   str: validateString,
   int: validateInt,
   uint: validateFloat,
-  boolean: validateBool,
+  bool: validateBool,
 }


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix Create Tunings page blank screen caused by `bool` limitation type bug.

#### Which issue(s) this PR fixes

Close #259 

https://github.com/user-attachments/assets/f858f978-a770-4b98-9e99-f7fefa2ec87a
