### PR TITLE
fix: events chart chart page issues

### DIFF
--- a/packages/cube-frontend-web-app/src/hooks/events/useEventsFilter.ts
+++ b/packages/cube-frontend-web-app/src/hooks/events/useEventsFilter.ts
@@ -12,16 +12,14 @@ import {
 
 export type UseEventsFilter = {
   isEventsFilterLoading: boolean
-  getEventsFilter: (
-    type: GetEventsTypeEnum,
-  ) =>
+  eventsFilter:
     | GetEventFilterConditionResponseDataSystem
     | GetEventFilterConditionResponseDataHost
     | GetEventFilterConditionResponseDataInstance
     | undefined
 }
 
-export const useEventsFilter = (): UseEventsFilter => {
+export const useEventsFilter = (type: GetEventsTypeEnum): UseEventsFilter => {
   const { dataCenter } = useContext(DataCenterContext)
 
   const { data, isLoading } = useCosGetRequest(
@@ -33,10 +31,8 @@ export const useEventsFilter = (): UseEventsFilter => {
     },
   )
 
-  const getEventsFilter = (type: GetEventsTypeEnum) => data?.[type]
-
   return {
     isEventsFilterLoading: isLoading,
-    getEventsFilter,
+    eventsFilter: data?.[type],
   }
 }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/EventsChartPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/EventsChartPage.tsx
@@ -5,24 +5,36 @@ import { useTimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdow
 import { useEventsChartQuery } from './_components/useEventsChartQuery'
 import { EventsChartProportion } from './_components/EventsChartProportion/EventsChartProportion'
 import { EventsChartComparison } from './_components/EventsChartComparison/EventsChartComparison'
+import { ChartTimeRanges, chartTimeRanges } from './_components/utils'
 
 export const EventsChartPage = () => {
   const {
+    past,
     eventsType,
     handleEventsTypeChange,
+    handleTimeRangeChange: onTimeRangeQueryChange,
     handleEventsQueryChange,
     getCurrentQuery,
     getRedirectQuery,
   } = useEventsChartQuery()
 
-  const { timeRanges, timeRange, onTimeRangeChange } = useTimeRange({
-    includes: ['1h', '24h', '7d', '14d'],
-    defaultValue: '24h',
+  const {
+    timeRanges,
+    timeRange,
+    onTimeRangeChange: onTimeRangeDropdownChange,
+  } = useTimeRange({
+    includes: chartTimeRanges,
+    defaultValue: past,
   })
 
   const { isEventsFilterLoading, getEventsFilter } = useEventsFilter()
 
   const eventsFilter = getEventsFilter(eventsType)
+
+  const onTimeRangeChange = (newTimeRange: ChartTimeRanges) => {
+    onTimeRangeQueryChange(newTimeRange)
+    onTimeRangeDropdownChange(newTimeRange)
+  }
 
   return (
     <div className="flex flex-col gap-4">

--- a/packages/cube-frontend-web-app/src/pages/events/chart/EventsChartPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/EventsChartPage.tsx
@@ -6,6 +6,7 @@ import { useEventsChartQuery } from './_components/useEventsChartQuery'
 import { EventsChartProportion } from './_components/EventsChartProportion/EventsChartProportion'
 import { EventsChartComparison } from './_components/EventsChartComparison/EventsChartComparison'
 import { ChartTimeRanges, chartTimeRanges } from './_components/timeRangeUtils'
+import { GetEventsTypeEnum } from '@cube-frontend/api'
 
 export const EventsChartPage = () => {
   const {
@@ -24,13 +25,25 @@ export const EventsChartPage = () => {
     defaultValue: chartQuery.past,
   })
 
-  const { isEventsFilterLoading, getEventsFilter } = useEventsFilter()
-
-  const eventsFilter = getEventsFilter(chartQuery.type)
+  const { isEventsFilterLoading, eventsFilter } = useEventsFilter(
+    chartQuery.type,
+  )
 
   const onTimeRangeChange = (newTimeRange: ChartTimeRanges) => {
     onTimeRangeQueryChange(newTimeRange)
     onTimeRangeDropdownChange(newTimeRange)
+  }
+
+  const onEventsTypeChange = (type: GetEventsTypeEnum) => {
+    onTypeChange(type)
+    onFieldChange('comparisonCategory', undefined)
+    onFieldChange('comparisonHost', undefined)
+    onFieldChange('comparisonInstance', undefined)
+    onFieldChange('comparisonSeverity', undefined)
+    onFieldChange('proportionCategory', undefined)
+    onFieldChange('proportionHost', undefined)
+    onFieldChange('proportionInstance', undefined)
+    onFieldChange('proportionSeverity', undefined)
   }
 
   return (
@@ -38,10 +51,9 @@ export const EventsChartPage = () => {
       <div className="flex items-center justify-between">
         <EventsContentSwitcher
           activeTab={chartQuery.type}
-          onEventsTypeChange={onTypeChange}
+          onEventsTypeChange={onEventsTypeChange}
         />
         <TimeRangeDropdown
-          disabled={false}
           selectedItem={timeRange}
           timeRanges={timeRanges}
           onChange={onTimeRangeChange}

--- a/packages/cube-frontend-web-app/src/pages/events/chart/EventsChartPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/EventsChartPage.tsx
@@ -5,17 +5,14 @@ import { useTimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdow
 import { useEventsChartQuery } from './_components/useEventsChartQuery'
 import { EventsChartProportion } from './_components/EventsChartProportion/EventsChartProportion'
 import { EventsChartComparison } from './_components/EventsChartComparison/EventsChartComparison'
-import { ChartTimeRanges, chartTimeRanges } from './_components/utils'
+import { ChartTimeRanges, chartTimeRanges } from './_components/timeRangeUtils'
 
 export const EventsChartPage = () => {
   const {
-    past,
-    eventsType,
-    handleEventsTypeChange,
-    handleTimeRangeChange: onTimeRangeQueryChange,
-    handleEventsQueryChange,
-    getCurrentQuery,
-    getRedirectQuery,
+    chartQuery,
+    onTypeChange,
+    onTimeRangeChange: onTimeRangeQueryChange,
+    onFieldChange,
   } = useEventsChartQuery()
 
   const {
@@ -24,12 +21,12 @@ export const EventsChartPage = () => {
     onTimeRangeChange: onTimeRangeDropdownChange,
   } = useTimeRange({
     includes: chartTimeRanges,
-    defaultValue: past,
+    defaultValue: chartQuery.past,
   })
 
   const { isEventsFilterLoading, getEventsFilter } = useEventsFilter()
 
-  const eventsFilter = getEventsFilter(eventsType)
+  const eventsFilter = getEventsFilter(chartQuery.type)
 
   const onTimeRangeChange = (newTimeRange: ChartTimeRanges) => {
     onTimeRangeQueryChange(newTimeRange)
@@ -40,8 +37,8 @@ export const EventsChartPage = () => {
     <div className="flex flex-col gap-4">
       <div className="flex items-center justify-between">
         <EventsContentSwitcher
-          activeTab={eventsType}
-          onEventsTypeChange={handleEventsTypeChange}
+          activeTab={chartQuery.type}
+          onEventsTypeChange={onTypeChange}
         />
         <TimeRangeDropdown
           disabled={false}
@@ -53,20 +50,14 @@ export const EventsChartPage = () => {
       <EventsChartProportion
         isEventsFilterLoading={isEventsFilterLoading}
         eventsFilter={eventsFilter}
-        eventsType={eventsType}
-        handleEventsQueryChange={handleEventsQueryChange}
-        currentQuery={getCurrentQuery('proportion').eventsFilter}
-        getRedirectQuery={getRedirectQuery}
-        past={timeRange}
+        chartQuery={chartQuery}
+        onFieldChange={onFieldChange}
       />
       <EventsChartComparison
         isEventsFilterLoading={isEventsFilterLoading}
         eventsFilter={eventsFilter}
-        eventsType={eventsType}
-        handleEventsQueryChange={handleEventsQueryChange}
-        currentQuery={getCurrentQuery('comparison').eventsFilter}
-        getRedirectQuery={getRedirectQuery}
-        past={timeRange}
+        chartQuery={chartQuery}
+        onFieldChange={onFieldChange}
       />
     </div>
   )

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/ChartEmpty.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/ChartEmpty.tsx
@@ -1,0 +1,10 @@
+import Chart from '@cube-frontend/ui-library/icons/monochrome/chart.svg?react'
+
+export const ChartEmpty = () => {
+  return (
+    <div className="flex w-full flex-col items-center px-4 py-6">
+      <Chart className="icon-xl m-2.5 text-functional-text" />
+      <p className="primary-body2 text-functional-text-light">No Data</p>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/BarChart/BarChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/BarChart/BarChart.tsx
@@ -9,31 +9,36 @@ import {
 } from 'chart.js'
 import { Bar } from 'react-chartjs-2'
 import { GetRankedEventsResponseDataEventsInner } from '@cube-frontend/api'
-import { ChartType } from '../../utils'
+import { ChartType, getRedirectUrl } from '../../utils'
 import { BarChartSkeleton } from './BarChartSkeleton'
 import { drawValuePlugin, getChartData, getChartOptions } from './barChartUtils'
+import { ChartQuery } from '../../useEventsChartQuery'
+import { ChartEmpty } from '../../ChartEmpty'
 
 ChartJS.register(BarElement, ArcElement, Tooltip, Legend)
 
 type BarChartProps = {
-  chartType: ChartType
-  getRedirectQuery: (chartType: ChartType, eventId: string) => string
-  rankedEvents: GetRankedEventsResponseDataEventsInner[] | undefined
   isRankedEventsLoading: boolean
+  rankedEvents: GetRankedEventsResponseDataEventsInner[] | undefined
+  chartType: ChartType
+  chartQuery: ChartQuery
 }
 
 export const BarChart = (props: BarChartProps) => {
-  const { chartType, getRedirectQuery, rankedEvents, isRankedEventsLoading } =
-    props
+  const { rankedEvents, isRankedEventsLoading, chartType, chartQuery } = props
 
   const navigate = useNavigate()
 
   const handleClick = useCallback(
-    (key: string) => {
-      const redirectQuery = getRedirectQuery(chartType, key)
+    (selectedEventId: string) => {
+      const redirectQuery = getRedirectUrl(
+        chartType,
+        chartQuery,
+        selectedEventId,
+      )
       navigate(redirectQuery)
     },
-    [chartType, getRedirectQuery, navigate],
+    [chartQuery, chartType, navigate],
   )
 
   const chartData = useMemo(() => getChartData(rankedEvents), [rankedEvents])
@@ -45,7 +50,7 @@ export const BarChart = (props: BarChartProps) => {
 
   if (isRankedEventsLoading) return <BarChartSkeleton />
 
-  if (!chartData) return <p>No data available</p>
+  if (!chartData) return <ChartEmpty />
 
   return (
     <Bar data={chartData} options={chartOptions} plugins={[drawValuePlugin]} />

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/EventsChartComparison.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/EventsChartComparison.tsx
@@ -9,8 +9,9 @@ import { CosGeneralPanel } from '@cube-frontend/ui-library'
 import { BarChart } from './BarChart/BarChart'
 import { FilterDropdown } from '../FilterDropdown'
 import { useRankedEvents } from '../useRankedEvents'
-import { mockRankedEvents } from '../mockData'
 import { ChartType, mapToDropdownFilterValues } from '../utils'
+import { ChartEmpty } from '../ChartEmpty'
+import { FilterEmpty } from '../FilterEmpty'
 
 type EventsChartComparisonProps = {
   isEventsFilterLoading: boolean
@@ -39,48 +40,61 @@ export const EventsChartComparison = (props: EventsChartComparisonProps) => {
 
   const chartType: ChartType = 'comparison'
 
-  const { isRankedEventsLoading } = useRankedEvents({
+  const { isRankedEventsLoading, rankedEvents } = useRankedEvents({
     eventsType,
     chartType,
     past,
   })
 
-  if (!eventsFilter) return
+  const hasFilter = !!eventsFilter
+
+  const isChartEmpty = !rankedEvents || rankedEvents.length === 0
+
+  const renderFilters = () => {
+    if (!hasFilter) return <FilterEmpty />
+
+    return Object.entries(eventsFilter).map(([key, options]) => {
+      const { dropdownFilterLabel, queryKey } = mapToDropdownFilterValues(
+        chartType,
+        key,
+      )
+      return (
+        <FilterDropdown
+          key={key}
+          isLoading={isEventsFilterLoading}
+          filterKey={queryKey}
+          filterLabel={dropdownFilterLabel}
+          options={options}
+          selectedValue={currentQuery?.[queryKey]}
+          onChange={handleEventsQueryChange}
+        />
+      )
+    })
+  }
+
+  const renderChart = () => {
+    if (isChartEmpty) return <ChartEmpty />
+
+    return (
+      <div className="w-full px-5 py-3">
+        <BarChart
+          chartType={chartType}
+          getRedirectQuery={getRedirectQuery}
+          rankedEvents={rankedEvents}
+          isRankedEventsLoading={isRankedEventsLoading}
+        />
+      </div>
+    )
+  }
 
   return (
     <CosGeneralPanel
       topic="Event ID Comparison (Top 24)"
       dropdown={
-        <div className="flex items-center gap-2">
-          {Object.entries(eventsFilter).map(([key, options]) => {
-            const { dropdownFilterLabel, queryKey } = mapToDropdownFilterValues(
-              chartType,
-              key,
-            )
-            return (
-              <FilterDropdown
-                key={key}
-                isLoading={isEventsFilterLoading}
-                filterKey={queryKey}
-                filterLabel={dropdownFilterLabel}
-                options={options}
-                selectedValue={currentQuery?.[queryKey]}
-                onChange={handleEventsQueryChange}
-              />
-            )
-          })}
-        </div>
+        <div className="flex items-center gap-2">{renderFilters()}</div>
       }
     >
-      <div className="w-full px-5 py-3">
-        {/** TODO: Replace `rankedEvents` with `rankedEvents` from useRankedEvents */}
-        <BarChart
-          chartType={chartType}
-          getRedirectQuery={getRedirectQuery}
-          rankedEvents={mockRankedEvents()}
-          isRankedEventsLoading={isRankedEventsLoading}
-        />
-      </div>
+      {renderChart()}
     </CosGeneralPanel>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/EventsChartComparison.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/EventsChartComparison.tsx
@@ -2,16 +2,22 @@ import {
   GetEventFilterConditionResponseDataHost,
   GetEventFilterConditionResponseDataInstance,
   GetEventFilterConditionResponseDataSystem,
-  GetEventsTypeEnum,
-  GetRankedEventsPastEnum,
 } from '@cube-frontend/api'
 import { CosGeneralPanel } from '@cube-frontend/ui-library'
 import { BarChart } from './BarChart/BarChart'
 import { FilterDropdown } from '../FilterDropdown'
 import { useRankedEvents } from '../useRankedEvents'
-import { ChartType, mapToDropdownFilterValues } from '../utils'
+import {
+  ChartType,
+  FilterKeysResponse,
+  getFilterKeyByChartType,
+  getFilterLabel,
+} from '../utils'
 import { ChartEmpty } from '../ChartEmpty'
 import { FilterEmpty } from '../FilterEmpty'
+import { ChartQuery, FilterOptions } from '../useEventsChartQuery'
+
+const chartType: ChartType = 'comparison'
 
 type EventsChartComparisonProps = {
   isEventsFilterLoading: boolean
@@ -20,68 +26,58 @@ type EventsChartComparisonProps = {
     | GetEventFilterConditionResponseDataHost
     | GetEventFilterConditionResponseDataInstance
     | undefined
-  eventsType: GetEventsTypeEnum
-  handleEventsQueryChange: (updates: Record<string, string | null>) => void
-  currentQuery: Record<string, string>
-  getRedirectQuery: (chartType: ChartType, eventId: string) => string
-  past: GetRankedEventsPastEnum
+
+  chartQuery: ChartQuery
+  onFieldChange: <Key extends keyof FilterOptions>(
+    key: Key,
+    value: FilterOptions[Key] | undefined,
+  ) => void
 }
 
 export const EventsChartComparison = (props: EventsChartComparisonProps) => {
-  const {
-    isEventsFilterLoading,
-    eventsFilter,
-    eventsType,
-    handleEventsQueryChange,
-    currentQuery,
-    getRedirectQuery,
-    past,
-  } = props
+  const { isEventsFilterLoading, eventsFilter, chartQuery, onFieldChange } =
+    props
 
-  const chartType: ChartType = 'comparison'
-
-  const { isRankedEventsLoading, rankedEvents } = useRankedEvents({
-    eventsType,
+  const { isRankedEventsLoading, rankedEvents } = useRankedEvents(
     chartType,
-    past,
-  })
-
-  const hasFilter = !!eventsFilter
-
-  const isChartEmpty = !rankedEvents || rankedEvents.length === 0
+    chartQuery,
+  )
 
   const renderFilters = () => {
-    if (!hasFilter) return <FilterEmpty />
+    if (!eventsFilter) return <FilterEmpty />
 
     return Object.entries(eventsFilter).map(([key, options]) => {
-      const { dropdownFilterLabel, queryKey } = mapToDropdownFilterValues(
+      const filterLabel = getFilterLabel(key as FilterKeysResponse)
+      const filterKey = getFilterKeyByChartType(
         chartType,
-        key,
+        key as FilterKeysResponse,
       )
+
+      if (!filterKey) return null
       return (
         <FilterDropdown
-          key={key}
+          key={`${chartQuery.type}-${chartType}-${filterKey}`}
           isLoading={isEventsFilterLoading}
-          filterKey={queryKey}
-          filterLabel={dropdownFilterLabel}
+          filterKey={filterKey}
+          filterLabel={filterLabel}
           options={options}
-          selectedValue={currentQuery?.[queryKey]}
-          onChange={handleEventsQueryChange}
+          selectedValue={chartQuery[filterKey]}
+          onFieldChange={onFieldChange}
         />
       )
     })
   }
 
   const renderChart = () => {
-    if (isChartEmpty) return <ChartEmpty />
+    if (!rankedEvents || rankedEvents.length === 0) return <ChartEmpty />
 
     return (
       <div className="w-full px-5 py-3">
         <BarChart
-          chartType={chartType}
-          getRedirectQuery={getRedirectQuery}
-          rankedEvents={rankedEvents}
           isRankedEventsLoading={isRankedEventsLoading}
+          rankedEvents={rankedEvents}
+          chartType={chartType}
+          chartQuery={chartQuery}
         />
       </div>
     )

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/EventsChartProportion.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/EventsChartProportion.tsx
@@ -2,16 +2,22 @@ import {
   GetEventFilterConditionResponseDataHost,
   GetEventFilterConditionResponseDataInstance,
   GetEventFilterConditionResponseDataSystem,
-  GetEventsTypeEnum,
-  GetRankedEventsPastEnum,
 } from '@cube-frontend/api'
 import { CosGeneralPanel } from '@cube-frontend/ui-library'
 import { PieChart } from './PieChart/PieChart'
 import { FilterDropdown } from '../FilterDropdown'
 import { FilterEmpty } from '../FilterEmpty'
 import { useRankedEvents } from '../useRankedEvents'
-import { ChartType, mapToDropdownFilterValues } from '../utils'
+import {
+  ChartType,
+  FilterKeysResponse,
+  getFilterKeyByChartType,
+  getFilterLabel,
+} from '../utils'
 import { ChartEmpty } from '../ChartEmpty'
+import { ChartQuery, FilterOptions } from '../useEventsChartQuery'
+
+const chartType: ChartType = 'proportion'
 
 type EventsChartProportionProps = {
   isEventsFilterLoading: boolean
@@ -20,67 +26,56 @@ type EventsChartProportionProps = {
     | GetEventFilterConditionResponseDataHost
     | GetEventFilterConditionResponseDataInstance
     | undefined
-  eventsType: GetEventsTypeEnum
-  handleEventsQueryChange: (updates: Record<string, string | null>) => void
-  currentQuery: Record<string, string>
-  getRedirectQuery: (chartType: ChartType, eventId: string) => string
-  past: GetRankedEventsPastEnum
+  chartQuery: ChartQuery
+  onFieldChange: <Key extends keyof FilterOptions>(
+    key: Key,
+    value: FilterOptions[Key] | undefined,
+  ) => void
 }
 
 export const EventsChartProportion = (props: EventsChartProportionProps) => {
-  const {
-    isEventsFilterLoading,
-    eventsFilter,
-    eventsType,
-    handleEventsQueryChange,
-    currentQuery,
-    getRedirectQuery,
-    past,
-  } = props
+  const { isEventsFilterLoading, eventsFilter, chartQuery, onFieldChange } =
+    props
 
-  const chartType: ChartType = 'proportion'
-
-  const { isRankedEventsLoading, rankedEvents } = useRankedEvents({
-    eventsType,
+  const { isRankedEventsLoading, rankedEvents } = useRankedEvents(
     chartType,
-    past,
-  })
-
-  const hasFilter = !!eventsFilter
-
-  const isChartEmpty = !rankedEvents || rankedEvents.length === 0
+    chartQuery,
+  )
 
   const renderFilters = () => {
-    if (!hasFilter) return <FilterEmpty />
+    if (!eventsFilter) return <FilterEmpty />
 
     return Object.entries(eventsFilter).map(([key, options]) => {
-      const { dropdownFilterLabel, queryKey } = mapToDropdownFilterValues(
+      const filterLabel = getFilterLabel(key as FilterKeysResponse)
+      const filterKey = getFilterKeyByChartType(
         chartType,
-        key,
+        key as FilterKeysResponse,
       )
+
+      if (!filterKey) return null
       return (
         <FilterDropdown
-          key={`${eventsType}-${key}`}
+          key={`${chartQuery.type}-${chartType}-${filterKey}`}
           isLoading={isEventsFilterLoading}
-          filterKey={queryKey}
-          filterLabel={dropdownFilterLabel}
+          filterKey={filterKey}
+          filterLabel={filterLabel}
           options={options}
-          selectedValue={currentQuery?.[queryKey]}
-          onChange={handleEventsQueryChange}
+          selectedValue={chartQuery[filterKey]}
+          onFieldChange={onFieldChange}
         />
       )
     })
   }
 
   const renderChart = () => {
-    if (isChartEmpty) return <ChartEmpty />
+    if (!rankedEvents || rankedEvents.length === 0) return <ChartEmpty />
 
     return (
       <PieChart
-        chartType={chartType}
-        getRedirectQuery={getRedirectQuery}
-        rankedEvents={rankedEvents}
         isRankedEventsLoading={isRankedEventsLoading}
+        rankedEvents={rankedEvents}
+        chartType={chartType}
+        chartQuery={chartQuery}
       />
     )
   }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/EventsChartProportion.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/EventsChartProportion.tsx
@@ -8,9 +8,10 @@ import {
 import { CosGeneralPanel } from '@cube-frontend/ui-library'
 import { PieChart } from './PieChart/PieChart'
 import { FilterDropdown } from '../FilterDropdown'
+import { FilterEmpty } from '../FilterEmpty'
 import { useRankedEvents } from '../useRankedEvents'
 import { ChartType, mapToDropdownFilterValues } from '../utils'
-import { mockRankedEvents } from '../mockData'
+import { ChartEmpty } from '../ChartEmpty'
 
 type EventsChartProportionProps = {
   isEventsFilterLoading: boolean
@@ -39,46 +40,59 @@ export const EventsChartProportion = (props: EventsChartProportionProps) => {
 
   const chartType: ChartType = 'proportion'
 
-  const { isRankedEventsLoading } = useRankedEvents({
+  const { isRankedEventsLoading, rankedEvents } = useRankedEvents({
     eventsType,
     chartType,
     past,
   })
 
-  if (!eventsFilter) return
+  const hasFilter = !!eventsFilter
+
+  const isChartEmpty = !rankedEvents || rankedEvents.length === 0
+
+  const renderFilters = () => {
+    if (!hasFilter) return <FilterEmpty />
+
+    return Object.entries(eventsFilter).map(([key, options]) => {
+      const { dropdownFilterLabel, queryKey } = mapToDropdownFilterValues(
+        chartType,
+        key,
+      )
+      return (
+        <FilterDropdown
+          key={key}
+          isLoading={isEventsFilterLoading}
+          filterKey={queryKey}
+          filterLabel={dropdownFilterLabel}
+          options={options}
+          selectedValue={currentQuery?.[queryKey]}
+          onChange={handleEventsQueryChange}
+        />
+      )
+    })
+  }
+
+  const renderChart = () => {
+    if (isChartEmpty) return <ChartEmpty />
+
+    return (
+      <PieChart
+        chartType={chartType}
+        getRedirectQuery={getRedirectQuery}
+        rankedEvents={rankedEvents}
+        isRankedEventsLoading={isRankedEventsLoading}
+      />
+    )
+  }
 
   return (
     <CosGeneralPanel
       topic="Event ID Proportion"
       dropdown={
-        <div className="flex items-center gap-2">
-          {Object.entries(eventsFilter).map(([key, options]) => {
-            const { dropdownFilterLabel, queryKey } = mapToDropdownFilterValues(
-              chartType,
-              key,
-            )
-            return (
-              <FilterDropdown
-                key={key}
-                isLoading={isEventsFilterLoading}
-                filterKey={queryKey}
-                filterLabel={dropdownFilterLabel}
-                options={options}
-                selectedValue={currentQuery?.[queryKey]}
-                onChange={handleEventsQueryChange}
-              />
-            )
-          })}
-        </div>
+        <div className="flex items-center gap-2">{renderFilters()}</div>
       }
     >
-      {/** TODO: Replace `rankedEvents` with `rankedEvents` from useRankedEvents */}
-      <PieChart
-        chartType={chartType}
-        getRedirectQuery={getRedirectQuery}
-        rankedEvents={mockRankedEvents()}
-        isRankedEventsLoading={isRankedEventsLoading}
-      />
+      {renderChart()}
     </CosGeneralPanel>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/EventsChartProportion.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/EventsChartProportion.tsx
@@ -60,7 +60,7 @@ export const EventsChartProportion = (props: EventsChartProportionProps) => {
       )
       return (
         <FilterDropdown
-          key={key}
+          key={`${eventsType}-${key}`}
           isLoading={isEventsFilterLoading}
           filterKey={queryKey}
           filterLabel={dropdownFilterLabel}

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/PieChart/PieChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/PieChart/PieChart.tsx
@@ -3,34 +3,37 @@ import { useNavigate } from 'react-router'
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js'
 import { Pie } from 'react-chartjs-2'
 import { GetRankedEventsResponseDataEventsInner } from '@cube-frontend/api'
-import { ChartType } from '../../utils'
 import { PieChartLabel } from './PieChartLabel'
 import { PieChartSkeleton } from './PieChartSkeleton'
 import { getChartData, getChartOptions } from './pieChartUtils'
+import { ChartType, getRedirectUrl } from '../../utils'
+import { ChartQuery } from '../../useEventsChartQuery'
+import { ChartEmpty } from '../../ChartEmpty'
 
 ChartJS.register(ArcElement, Tooltip, Legend)
 
 type PieChartProps = {
-  chartType: ChartType
-  getRedirectQuery: (chartType: ChartType, eventId: string) => string
-  rankedEvents: GetRankedEventsResponseDataEventsInner[] | undefined
   isRankedEventsLoading: boolean
+  rankedEvents: GetRankedEventsResponseDataEventsInner[] | undefined
+  chartType: ChartType
+  chartQuery: ChartQuery
 }
 
 export const PieChart = (props: PieChartProps) => {
-  const { chartType, getRedirectQuery, rankedEvents, isRankedEventsLoading } =
-    props
+  const { rankedEvents, isRankedEventsLoading, chartType, chartQuery } = props
+
+  const [targetEventId, setTargetEventId] = useState<string>()
 
   const navigate = useNavigate()
 
-  const [targetEventKey, setTargetEventKey] = useState<string>()
+  const redirectUrl = getRedirectUrl(chartType, chartQuery, targetEventId ?? '')
 
   const handleMouseEnter = (key: string) => {
-    setTargetEventKey(key)
+    setTargetEventId(key)
   }
 
   const handleMouseLeave = () => {
-    setTargetEventKey(undefined)
+    setTargetEventId(undefined)
   }
 
   /**
@@ -38,25 +41,23 @@ export const PieChart = (props: PieChartProps) => {
    * Navigate to `/events` page with the current filters
    */
   const handleClick = useCallback(() => {
-    if (!targetEventKey) return
-
-    const redirectQuery = getRedirectQuery(chartType, targetEventKey)
-    navigate(redirectQuery)
-  }, [chartType, getRedirectQuery, navigate, targetEventKey])
+    if (!targetEventId) return
+    navigate(redirectUrl)
+  }, [navigate, redirectUrl, targetEventId])
 
   const chartData = useMemo(
-    () => getChartData(rankedEvents, targetEventKey),
-    [rankedEvents, targetEventKey],
+    () => getChartData(rankedEvents, targetEventId),
+    [rankedEvents, targetEventId],
   )
 
   const chartOptions = useMemo(
-    () => getChartOptions(chartData, setTargetEventKey, handleClick),
+    () => getChartOptions(chartData, setTargetEventId, handleClick),
     [chartData, handleClick],
   )
 
   if (isRankedEventsLoading) return <PieChartSkeleton />
 
-  if (!chartData) return <p>No data available</p>
+  if (!chartData) return <ChartEmpty />
 
   return (
     <div className="flex items-center justify-center gap-11 px-5 py-3">
@@ -72,10 +73,10 @@ export const PieChart = (props: PieChartProps) => {
               eventId={id}
               color={color}
               percentage={percentage}
-              isBlur={!!targetEventKey && targetEventKey !== id}
+              isBlur={!!targetEventId && targetEventId !== id}
               onMouseEnter={() => handleMouseEnter(id)}
               onMouseLeave={handleMouseLeave}
-              redirectUrl={getRedirectQuery(chartType, id)}
+              redirectUrl={redirectUrl}
             />
           )
         })}

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/FilterDropdown.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/FilterDropdown.tsx
@@ -1,3 +1,4 @@
+import { useEffect, useState } from 'react'
 import { upperFirst } from 'lodash'
 import { CosDropdown } from '@cube-frontend/ui-library'
 
@@ -20,15 +21,35 @@ export const FilterDropdown = (props: FilterDropdownProps) => {
     onChange: onDropdownChange,
   } = props
 
-  const selectedItem = selectedValue ? [selectedValue] : []
+  const [selectedItem, setSelectedItem] = useState<string[]>(
+    selectedValue ? [selectedValue] : [],
+  )
+
+  useEffect(() => {
+    if (selectedValue) {
+      setSelectedItem([selectedValue])
+    }
+  }, [selectedValue])
+
+  const modifiedOptions = ['All', ...options]
+
+  const handleItemClick = (option: string) => {
+    if (option === 'All') {
+      onDropdownChange({ [filterKey]: null })
+      setSelectedItem([option])
+      return
+    }
+
+    onDropdownChange({ [filterKey]: option })
+  }
 
   const renderOptions = () => {
-    return options.map((option) => {
+    return modifiedOptions.map((option) => {
       return (
         <CosDropdown.Item
           key={option}
           item={option}
-          onClick={() => onDropdownChange({ [filterKey]: option })}
+          onClick={() => handleItemClick(option)}
         >
           {option}
         </CosDropdown.Item>

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/FilterDropdown.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/FilterDropdown.tsx
@@ -1,24 +1,27 @@
 import { useEffect, useState } from 'react'
 import { upperFirst } from 'lodash'
 import { CosDropdown } from '@cube-frontend/ui-library'
+import { FilterOptions } from './useEventsChartQuery'
 
-type FilterDropdownProps = {
+type FilterDropdownProps<Key extends keyof FilterOptions> = {
   isLoading: boolean
-  filterKey: string
+  filterKey: Key
   filterLabel: string
-  options: string[]
-  selectedValue: string | undefined
-  onChange: (updates: Record<string, string | null>) => void
+  options: FilterOptions[Key][]
+  selectedValue: FilterOptions[Key] | undefined
+  onFieldChange: (key: Key, value: FilterOptions[Key] | undefined) => void
 }
 
-export const FilterDropdown = (props: FilterDropdownProps) => {
+export const FilterDropdown = <Key extends keyof FilterOptions>(
+  props: FilterDropdownProps<Key>,
+) => {
   const {
     isLoading,
     filterKey,
     filterLabel,
     options,
     selectedValue,
-    onChange: onDropdownChange,
+    onFieldChange,
   } = props
 
   const [selectedItem, setSelectedItem] = useState<string[]>(
@@ -33,14 +36,14 @@ export const FilterDropdown = (props: FilterDropdownProps) => {
 
   const modifiedOptions = ['All', ...options]
 
-  const handleItemClick = (option: string) => {
-    if (option === 'All') {
-      onDropdownChange({ [filterKey]: null })
-      setSelectedItem([option])
+  const handleItemClick = (selectedItem: string) => {
+    if (selectedItem === 'All') {
+      onFieldChange(filterKey, undefined)
+      setSelectedItem([selectedItem])
       return
     }
 
-    onDropdownChange({ [filterKey]: option })
+    onFieldChange(filterKey, selectedItem)
   }
 
   const renderOptions = () => {

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/FilterEmpty.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/FilterEmpty.tsx
@@ -1,0 +1,5 @@
+import { CosSkeleton } from '@cube-frontend/ui-library'
+
+export const FilterEmpty = () => {
+  return <CosSkeleton className="h-[34px] w-[80px]" />
+}

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/timeRangeUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/timeRangeUtils.ts
@@ -11,13 +11,6 @@ export type ChartTimeRanges = (typeof chartTimeRanges)[number]
 
 export const DEFAULT_TIME_RANGE = '24h' satisfies ChartTimeRanges
 
-export const timeRangeToDaysMapping: Record<ChartTimeRanges, number> = {
-  '1h': 0,
-  '24h': 0,
-  '7d': 7,
-  '14d': 14,
-}
-
 export const isChartTimeRange = (value: string): value is ChartTimeRanges => {
   return ['1h', '24h', '7d', '14d'].includes(value)
 }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/timeRangeUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/timeRangeUtils.ts
@@ -1,0 +1,33 @@
+import { TimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/timeRangeUtils'
+
+export const chartTimeRanges = [
+  '1h',
+  '24h',
+  '7d',
+  '14d',
+] as const satisfies TimeRange[]
+
+export type ChartTimeRanges = (typeof chartTimeRanges)[number]
+
+export const DEFAULT_TIME_RANGE = '24h' satisfies ChartTimeRanges
+
+export const timeRangeToDaysMapping: Record<ChartTimeRanges, number> = {
+  '1h': 0,
+  '24h': 0,
+  '7d': 7,
+  '14d': 14,
+}
+
+export const isChartTimeRange = (value: string): value is ChartTimeRanges => {
+  return ['1h', '24h', '7d', '14d'].includes(value)
+}
+
+export const getValidTimeRange = (past: string): ChartTimeRanges => {
+  if (!past) return DEFAULT_TIME_RANGE
+
+  if (isChartTimeRange(past)) {
+    return past
+  }
+
+  return DEFAULT_TIME_RANGE
+}

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/useEventsChartQuery.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/useEventsChartQuery.ts
@@ -49,7 +49,7 @@ type UseEventsChartQuery = {
 export const useEventsChartQuery = (): UseEventsChartQuery => {
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const [chartQuery, setChartQuery] = useState<ChartQuery>(
+  const [chartQuery, setChartQuery] = useState<ChartQuery>(() =>
     initChartQuery(searchParams),
   )
 

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/useEventsChartQuery.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/useEventsChartQuery.ts
@@ -1,138 +1,103 @@
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
-import { isEmpty } from 'lodash'
 import { GetEventsTypeEnum } from '@cube-frontend/api'
-import {
-  ChartType,
-  ChartTimeRanges,
-  getValidTimeRange,
-  getValidEventsType,
-  getMatchedFilterByPrefix,
-  mapToTimeRangeQuery,
-  mapToRedirectQuery,
-} from './utils'
+import { initChartQuery } from './utils'
+import { ChartTimeRanges } from './timeRangeUtils'
 
-export type UseEventsChartQuery = {
+export type FilterKeys = Extract<
+  keyof ChartQuery,
+  | 'proportionCategory'
+  | 'comparisonCategory'
+  | 'proportionSeverity'
+  | 'comparisonSeverity'
+  | 'proportionHost'
+  | 'comparisonHost'
+  | 'proportionInstance'
+  | 'comparisonInstance'
+>
+
+export type FilterOptions = {
+  [K in FilterKeys]: NonNullable<ChartQuery[K]>
+}
+
+export type ChartQuery = {
+  type: GetEventsTypeEnum
   past: ChartTimeRanges
-  eventsType: GetEventsTypeEnum
-  handleEventsTypeChange: (eventsType: GetEventsTypeEnum) => void
-  handleTimeRangeChange: (timeRange: ChartTimeRanges) => void
-  handleEventsQueryChange: (updates: Record<string, string | null>) => void
-  getCurrentQuery: (chartType: ChartType) => {
-    eventsFilter: Record<string, string>
-    /**
-     * Checks whether the filter is empty, excluding the `eventsType` field.
-     */
-    isEventsFilterEmpty: boolean
-  }
-  getRedirectQuery: (chartType: ChartType, eventId: string) => string
+  proportionCategory: string | undefined
+  comparisonCategory: string | undefined
+  // System
+  proportionSeverity: string | undefined
+  comparisonSeverity: string | undefined
+  // Host
+  proportionHost: string | undefined
+  comparisonHost: string | undefined
+  // Instance
+  proportionInstance: string | undefined
+  comparisonInstance: string | undefined
+}
+
+type UseEventsChartQuery = {
+  chartQuery: ChartQuery
+  onTypeChange: (type: GetEventsTypeEnum) => void
+  onTimeRangeChange: (timeRange: ChartTimeRanges) => void
+  onFieldChange: <Key extends keyof FilterOptions>(
+    key: Key,
+    value: FilterOptions[Key] | undefined,
+  ) => void
 }
 
 export const useEventsChartQuery = (): UseEventsChartQuery => {
   const [searchParams, setSearchParams] = useSearchParams()
 
-  const [past, setPast] = useState<ChartTimeRanges>(
-    getValidTimeRange(searchParams),
-  )
-
-  const [eventsType, setEventsType] = useState<GetEventsTypeEnum>(
-    getValidEventsType(searchParams),
+  const [chartQuery, setChartQuery] = useState<ChartQuery>(
+    initChartQuery(searchParams),
   )
 
   useEffect(() => {
-    const currentPast = searchParams.get('past')
-    const currentEventsType = searchParams.get('eventsType')
+    const record = Object.entries(chartQuery).reduce(
+      (result, [key, value]) => {
+        const stringValue = value?.toString()
+        if (stringValue) {
+          result[key] = stringValue
+        }
+        return result
+      },
+      {} as Record<string, string>,
+    )
 
-    const validPast = getValidTimeRange(searchParams)
-    const validEventsType = getValidEventsType(searchParams)
-
-    const newParams = new URLSearchParams(searchParams)
-    let shouldUpdate = false
-
-    if (past !== currentPast) {
-      newParams.set('past', validPast)
-      setPast(validPast)
-      shouldUpdate = true
-    }
-
-    if (eventsType !== currentEventsType) {
-      newParams.set('eventsType', validEventsType)
-      setEventsType(validEventsType)
-      shouldUpdate = true
-    }
-
-    if (shouldUpdate) {
-      setSearchParams(newParams, { replace: true })
-    }
-  }, [eventsType, past, searchParams, setSearchParams])
-
-  const handleEventsTypeChange = (type: GetEventsTypeEnum) => {
-    const newParams = new URLSearchParams()
-    newParams.set('eventsType', type)
-    newParams.set('past', past)
-
-    setSearchParams(newParams, { replace: true })
-  }
-
-  const handleTimeRangeChange = (timeRange: ChartTimeRanges) => {
-    const newParams = new URLSearchParams()
-    newParams.set('past', timeRange)
-    newParams.set('eventsType', eventsType)
-
-    setSearchParams(newParams, { replace: true })
-  }
-
-  const handleEventsQueryChange = (updates: Record<string, string | null>) => {
-    const newParams = new URLSearchParams(searchParams)
-    Object.entries(updates).forEach(([key, value]) => {
-      if (value) {
-        newParams.set(key, value)
-      } else {
-        newParams.delete(key)
-      }
+    setSearchParams(record, {
+      replace: true,
     })
-    setSearchParams(newParams, { replace: true })
+  }, [chartQuery, setSearchParams])
+
+  const onTypeChange = (type: GetEventsTypeEnum): void => {
+    setChartQuery((prev) => ({
+      ...prev,
+      type,
+    }))
   }
 
-  const getCurrentQuery = (chartType: ChartType) => {
-    const rawFilter = Object.fromEntries(searchParams) as Record<string, string>
-
-    const eventsType = rawFilter.eventsType
-    const matchedFilter = getMatchedFilterByPrefix(chartType, rawFilter)
-
-    return {
-      eventsFilter: { ...matchedFilter, eventsType },
-      isEventsFilterEmpty: isEmpty(matchedFilter),
-    }
+  const onTimeRangeChange = (timeRange: ChartTimeRanges): void => {
+    setChartQuery((prev) => ({
+      ...prev,
+      past: timeRange,
+    }))
   }
 
-  const getRedirectQuery = (chartType: ChartType, eventId: string) => {
-    const rawFilter = Object.fromEntries(searchParams) as Record<string, string>
-    const eventsType = rawFilter.eventsType
-
-    const matchedFilter = getMatchedFilterByPrefix(chartType, rawFilter)
-    const { start, end } = mapToTimeRangeQuery(past)
-    const filteredQueryString = mapToRedirectQuery(matchedFilter, chartType)
-
-    const baseParams = new URLSearchParams({
-      eventsType,
-      keyword: eventId,
-      start,
-      end,
-    })
-
-    return filteredQueryString
-      ? `/events?${baseParams.toString()}&${filteredQueryString}`
-      : `/events?${baseParams.toString()}`
+  const onFieldChange = <Key extends keyof FilterOptions>(
+    key: Key,
+    value: FilterOptions[Key] | undefined,
+  ): void => {
+    setChartQuery((prev) => ({
+      ...prev,
+      [key]: value,
+    }))
   }
 
   return {
-    past,
-    eventsType,
-    handleEventsTypeChange,
-    handleTimeRangeChange,
-    handleEventsQueryChange,
-    getCurrentQuery,
-    getRedirectQuery,
+    chartQuery,
+    onTypeChange,
+    onTimeRangeChange,
+    onFieldChange,
   }
 }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/useEventsChartQuery.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/useEventsChartQuery.ts
@@ -2,45 +2,21 @@ import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router'
 import { isEmpty } from 'lodash'
 import { GetEventsTypeEnum } from '@cube-frontend/api'
-import { ChartType, removeQueryKeyPrefix } from './utils'
-
-const isValidEventsType = (type: string | null): boolean => {
-  return Object.values(GetEventsTypeEnum).includes(type as GetEventsTypeEnum)
-}
-
-const getValidEventsType = (
-  searchParams: URLSearchParams,
-): GetEventsTypeEnum => {
-  const urlEventsType = searchParams.get('eventsType')
-
-  return isValidEventsType(urlEventsType)
-    ? (urlEventsType as GetEventsTypeEnum)
-    : GetEventsTypeEnum.System
-}
-
-const getMatchedFilterByPrefix = (
-  chartType: ChartType,
-  filter: Record<string, string>,
-) => {
-  return Object.fromEntries(
-    Object.entries(filter).filter(([key]) => key.startsWith(chartType)),
-  )
-}
-
-const mapToRedirectQuery = (
-  currentQuery: Record<string, string>,
-  chartType: ChartType,
-): string => {
-  const params = new URLSearchParams()
-  Object.entries(currentQuery).forEach(([key, value]) => {
-    params.set(removeQueryKeyPrefix(chartType, key), value)
-  })
-  return params.toString()
-}
+import {
+  ChartType,
+  ChartTimeRanges,
+  getValidTimeRange,
+  getValidEventsType,
+  getMatchedFilterByPrefix,
+  mapToTimeRangeQuery,
+  mapToRedirectQuery,
+} from './utils'
 
 export type UseEventsChartQuery = {
+  past: ChartTimeRanges
   eventsType: GetEventsTypeEnum
   handleEventsTypeChange: (eventsType: GetEventsTypeEnum) => void
+  handleTimeRangeChange: (timeRange: ChartTimeRanges) => void
   handleEventsQueryChange: (updates: Record<string, string | null>) => void
   getCurrentQuery: (chartType: ChartType) => {
     eventsFilter: Record<string, string>
@@ -55,22 +31,55 @@ export type UseEventsChartQuery = {
 export const useEventsChartQuery = (): UseEventsChartQuery => {
   const [searchParams, setSearchParams] = useSearchParams()
 
+  const [past, setPast] = useState<ChartTimeRanges>(
+    getValidTimeRange(searchParams),
+  )
+
   const [eventsType, setEventsType] = useState<GetEventsTypeEnum>(
     getValidEventsType(searchParams),
   )
 
   useEffect(() => {
-    const urlEventsType = searchParams.get('eventsType')
+    const currentPast = searchParams.get('past')
+    const currentEventsType = searchParams.get('eventsType')
 
-    if (urlEventsType !== eventsType) {
-      const validEventsType = getValidEventsType(searchParams)
-      setEventsType(validEventsType)
-      setSearchParams({ eventsType: validEventsType }, { replace: true })
+    const validPast = getValidTimeRange(searchParams)
+    const validEventsType = getValidEventsType(searchParams)
+
+    const newParams = new URLSearchParams(searchParams)
+    let shouldUpdate = false
+
+    if (past !== currentPast) {
+      newParams.set('past', validPast)
+      setPast(validPast)
+      shouldUpdate = true
     }
-  }, [eventsType, searchParams, setSearchParams])
 
-  const handleEventsTypeChange = (eventsType: GetEventsTypeEnum) => {
-    setSearchParams({ eventsType }, { replace: true })
+    if (eventsType !== currentEventsType) {
+      newParams.set('eventsType', validEventsType)
+      setEventsType(validEventsType)
+      shouldUpdate = true
+    }
+
+    if (shouldUpdate) {
+      setSearchParams(newParams, { replace: true })
+    }
+  }, [eventsType, past, searchParams, setSearchParams])
+
+  const handleEventsTypeChange = (type: GetEventsTypeEnum) => {
+    const newParams = new URLSearchParams()
+    newParams.set('eventsType', type)
+    newParams.set('past', past)
+
+    setSearchParams(newParams, { replace: true })
+  }
+
+  const handleTimeRangeChange = (timeRange: ChartTimeRanges) => {
+    const newParams = new URLSearchParams()
+    newParams.set('past', timeRange)
+    newParams.set('eventsType', eventsType)
+
+    setSearchParams(newParams, { replace: true })
   }
 
   const handleEventsQueryChange = (updates: Record<string, string | null>) => {
@@ -99,17 +108,29 @@ export const useEventsChartQuery = (): UseEventsChartQuery => {
 
   const getRedirectQuery = (chartType: ChartType, eventId: string) => {
     const rawFilter = Object.fromEntries(searchParams) as Record<string, string>
-
     const eventsType = rawFilter.eventsType
-    const matchedFilter = getMatchedFilterByPrefix(chartType, rawFilter)
 
-    const newQueryString = mapToRedirectQuery(matchedFilter, chartType)
-    return `/events?eventsType=${encodeURIComponent(eventsType)}&keyword=${encodeURIComponent(eventId)}&${newQueryString}`
+    const matchedFilter = getMatchedFilterByPrefix(chartType, rawFilter)
+    const { start, end } = mapToTimeRangeQuery(past)
+    const filteredQueryString = mapToRedirectQuery(matchedFilter, chartType)
+
+    const baseParams = new URLSearchParams({
+      eventsType,
+      keyword: eventId,
+      start,
+      end,
+    })
+
+    return filteredQueryString
+      ? `/events?${baseParams.toString()}&${filteredQueryString}`
+      : `/events?${baseParams.toString()}`
   }
 
   return {
+    past,
     eventsType,
     handleEventsTypeChange,
+    handleTimeRangeChange,
     handleEventsQueryChange,
     getCurrentQuery,
     getRedirectQuery,

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/useRankedEvents.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/useRankedEvents.ts
@@ -1,52 +1,13 @@
 import { useContext } from 'react'
 import {
   EventsApiGetRankedEventsRequest,
-  GetEventsTypeEnum,
-  GetRankedEventsPastEnum,
   GetRankedEventsResponseDataEventsInner,
 } from '@cube-frontend/api'
 import { eventsApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
-import { useEventsChartQuery } from './useEventsChartQuery'
-import { ChartType, removeQueryKeyPrefix } from './utils'
-
-const eventsChartRequestKeyMapping: Record<
-  string,
-  keyof EventsApiGetRankedEventsRequest
-> = {
-  category: 'category',
-  severity: 'severity',
-  name: 'host',
-  id: 'instance',
-}
-
-const mapFilterToRequestParams = (
-  chartType: ChartType,
-  filter: Record<string, string>,
-) => {
-  return Object.entries(filter).reduce(
-    (acc, [key, value]) => {
-      const revertedKey = removeQueryKeyPrefix(chartType, key)
-
-      if (value && revertedKey in eventsChartRequestKeyMapping) {
-        const mappedKey =
-          eventsChartRequestKeyMapping[
-            revertedKey as keyof typeof eventsChartRequestKeyMapping
-          ]
-        acc[mappedKey] = value
-      }
-      return acc
-    },
-    {} as Record<string, string>,
-  )
-}
-
-type UseRankedEventsOptions = {
-  eventsType: GetEventsTypeEnum
-  chartType: ChartType
-  past: GetRankedEventsPastEnum
-}
+import { ChartQuery } from './useEventsChartQuery'
+import { ChartType, getRequestQueryByChartType } from './utils'
 
 type UseRankedEvents = {
   rankedEvents: GetRankedEventsResponseDataEventsInner[] | undefined
@@ -54,27 +15,20 @@ type UseRankedEvents = {
 }
 
 export const useRankedEvents = (
-  options: UseRankedEventsOptions,
+  chartType: ChartType,
+  chartQuery: ChartQuery,
 ): UseRankedEvents => {
-  const { eventsType, chartType, past } = options
-
   const { dataCenter } = useContext(DataCenterContext)
 
-  const { getCurrentQuery } = useEventsChartQuery()
+  const requestQuery = getRequestQueryByChartType(chartType, chartQuery)
 
   const { data, isLoading } = useCosGetRequest(
     eventsApi.getRankedEvents,
     () => {
-      const { eventsFilter } = getCurrentQuery(chartType)
-
-      const requestParams = mapFilterToRequestParams(chartType, eventsFilter)
-
       return {
-        ...requestParams,
+        ...requestQuery,
         dataCenter: dataCenter!.name,
-        type: eventsType,
         limit: 24,
-        past,
       } satisfies EventsApiGetRankedEventsRequest
     },
   )

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/utils.ts
@@ -1,4 +1,7 @@
+import dayjs from 'dayjs'
 import { lowerFirst, upperFirst } from 'lodash'
+import { TimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/timeRangeUtils'
+import { GetEventsTypeEnum } from '@cube-frontend/api'
 
 export type ChartType = 'proportion' | 'comparison'
 
@@ -39,4 +42,82 @@ export const mapToDropdownFilterValues = (
   const queryKey = chartType + dropdownFilterLabel
 
   return { dropdownFilterLabel, queryKey }
+}
+
+export const chartTimeRanges = [
+  '1h',
+  '24h',
+  '7d',
+  '14d',
+] as const satisfies TimeRange[]
+
+export type ChartTimeRanges = (typeof chartTimeRanges)[number]
+
+const timeRangeToDays: Record<ChartTimeRanges, number> = {
+  '1h': 0,
+  '24h': 0,
+  '7d': 7,
+  '14d': 14,
+}
+
+export const mapToTimeRangeQuery = (past: ChartTimeRanges) => {
+  const end = dayjs()
+  const start = end.subtract(timeRangeToDays[past], 'day')
+
+  return {
+    start: start.format('YYYY-MM-DD'),
+    end: end.format('YYYY-MM-DD'),
+  }
+}
+
+const isValidEventsType = (type: string | null): boolean => {
+  return Object.values(GetEventsTypeEnum).includes(type as GetEventsTypeEnum)
+}
+
+export const getValidEventsType = (
+  searchParams: URLSearchParams,
+): GetEventsTypeEnum => {
+  const urlEventsType = searchParams.get('eventsType')
+
+  return isValidEventsType(urlEventsType)
+    ? (urlEventsType as GetEventsTypeEnum)
+    : GetEventsTypeEnum.System
+}
+
+const DEFAULT_TIME_RANGE = '24h' satisfies ChartTimeRanges
+
+const isChartTimeRange = (
+  timeRange: string | null,
+): timeRange is ChartTimeRanges => {
+  return (
+    timeRange !== null &&
+    (chartTimeRanges as readonly string[]).includes(timeRange)
+  )
+}
+
+export const getValidTimeRange = (
+  searchParams: URLSearchParams,
+): ChartTimeRanges => {
+  const urlTimeRange = searchParams.get('past')
+  return isChartTimeRange(urlTimeRange) ? urlTimeRange : DEFAULT_TIME_RANGE
+}
+
+export const getMatchedFilterByPrefix = (
+  chartType: ChartType,
+  filter: Record<string, string>,
+) => {
+  return Object.fromEntries(
+    Object.entries(filter).filter(([key]) => key.startsWith(chartType)),
+  )
+}
+
+export const mapToRedirectQuery = (
+  currentQuery: Record<string, string>,
+  chartType: ChartType,
+): string => {
+  const params = new URLSearchParams()
+  Object.entries(currentQuery).forEach(([key, value]) => {
+    params.set(removeQueryKeyPrefix(chartType, key), value)
+  })
+  return params.toString()
 }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/utils.ts
@@ -1,9 +1,108 @@
 import dayjs from 'dayjs'
-import { lowerFirst, upperFirst } from 'lodash'
-import { TimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/timeRangeUtils'
-import { GetEventsTypeEnum } from '@cube-frontend/api'
+import { lowerFirst } from 'lodash'
+import {
+  EventsApiGetRankedEventsRequest,
+  GetEventFilterConditionResponseDataHost,
+  GetEventFilterConditionResponseDataInstance,
+  GetEventFilterConditionResponseDataSystem,
+  GetEventsTypeEnum,
+} from '@cube-frontend/api'
+import { ChartQuery, FilterKeys } from './useEventsChartQuery'
+import { getValidTimeRange, timeRangeToDaysMapping } from './timeRangeUtils'
 
 export type ChartType = 'proportion' | 'comparison'
+
+export type FilterKeysResponse =
+  | keyof GetEventFilterConditionResponseDataSystem
+  | keyof GetEventFilterConditionResponseDataHost
+  | keyof GetEventFilterConditionResponseDataInstance
+
+const filterKeyMapping: Record<
+  FilterKeysResponse,
+  Record<ChartType, FilterKeys>
+> = {
+  categories: {
+    proportion: 'proportionCategory',
+    comparison: 'comparisonCategory',
+  },
+  severities: {
+    proportion: 'proportionSeverity',
+    comparison: 'comparisonSeverity',
+  },
+  names: {
+    proportion: 'proportionHost',
+    comparison: 'comparisonHost',
+  },
+  ids: {
+    proportion: 'proportionInstance',
+    comparison: 'comparisonInstance',
+  },
+}
+
+export const getFilterKeyByChartType = (
+  chartType: ChartType,
+  key: FilterKeysResponse,
+): FilterKeys | undefined => {
+  return filterKeyMapping[key][chartType] || undefined
+}
+
+const filterLabelMapping: Record<FilterKeysResponse, string> = {
+  categories: 'Category',
+  severities: 'Severity',
+  names: 'Host',
+  ids: 'Instance',
+}
+
+export const getFilterLabel = (key: FilterKeysResponse) => {
+  return filterLabelMapping[key] || ''
+}
+
+const getValidType = (type: string): GetEventsTypeEnum => {
+  const defaultType = GetEventsTypeEnum.System
+
+  if (!type) {
+    return defaultType
+  }
+
+  const validTypes = Object.values(GetEventsTypeEnum) as string[]
+
+  if (validTypes.includes(type)) {
+    return type as GetEventsTypeEnum
+  }
+
+  return defaultType
+}
+
+export const initChartQuery = (searchParams: URLSearchParams): ChartQuery => {
+  const type = getValidType(searchParams.get('type') ?? '')
+
+  const past = getValidTimeRange(searchParams.get('past') ?? '')
+
+  const proportionCategory = searchParams.get('proportionCategory') ?? undefined
+  const comparisonCategory = searchParams.get('comparisonCategory') ?? undefined
+
+  const proportionSeverity = searchParams.get('proportionSeverity') ?? undefined
+  const comparisonSeverity = searchParams.get('comparisonSeverity') ?? undefined
+
+  const proportionHost = searchParams.get('proportionHost') ?? undefined
+  const comparisonHost = searchParams.get('comparisonHost') ?? undefined
+
+  const proportionInstance = searchParams.get('proportionInstance') ?? undefined
+  const comparisonInstance = searchParams.get('comparisonInstance') ?? undefined
+
+  return {
+    type,
+    past,
+    proportionCategory,
+    comparisonCategory,
+    proportionSeverity,
+    comparisonSeverity,
+    proportionHost,
+    comparisonHost,
+    proportionInstance,
+    comparisonInstance,
+  }
+}
 
 export const removeQueryKeyPrefix = (
   chartType: ChartType,
@@ -12,112 +111,55 @@ export const removeQueryKeyPrefix = (
   return lowerFirst(queryKey.replace(chartType, ''))
 }
 
-const dropdownFilterKeyMapping: Record<string, string> = {
-  severities: 'severity',
-  categories: 'category',
-  ids: 'id',
-  names: 'name',
-}
-
-type DropdownFilterValues = {
-  dropdownFilterLabel: string
-  queryKey: string
-}
-
-export const mapToDropdownFilterValues = (
+const getQueryValue = (
   chartType: ChartType,
-  key: string,
-): DropdownFilterValues => {
-  const dropdownFilterKey = dropdownFilterKeyMapping[key]
-
-  if (!dropdownFilterKey) {
-    console.warn('Not a valid filter key')
-  }
-
-  /**
-   * The current implementation is not yet compatible with i18n.
-   */
-  const dropdownFilterLabel = upperFirst(dropdownFilterKey) ?? ''
-
-  const queryKey = chartType + dropdownFilterLabel
-
-  return { dropdownFilterLabel, queryKey }
-}
-
-export const chartTimeRanges = [
-  '1h',
-  '24h',
-  '7d',
-  '14d',
-] as const satisfies TimeRange[]
-
-export type ChartTimeRanges = (typeof chartTimeRanges)[number]
-
-const timeRangeToDays: Record<ChartTimeRanges, number> = {
-  '1h': 0,
-  '24h': 0,
-  '7d': 7,
-  '14d': 14,
-}
-
-export const mapToTimeRangeQuery = (past: ChartTimeRanges) => {
-  const end = dayjs()
-  const start = end.subtract(timeRangeToDays[past], 'day')
-
-  return {
-    start: start.format('YYYY-MM-DD'),
-    end: end.format('YYYY-MM-DD'),
-  }
-}
-
-const isValidEventsType = (type: string | null): boolean => {
-  return Object.values(GetEventsTypeEnum).includes(type as GetEventsTypeEnum)
-}
-
-export const getValidEventsType = (
-  searchParams: URLSearchParams,
-): GetEventsTypeEnum => {
-  const urlEventsType = searchParams.get('eventsType')
-
-  return isValidEventsType(urlEventsType)
-    ? (urlEventsType as GetEventsTypeEnum)
-    : GetEventsTypeEnum.System
-}
-
-const DEFAULT_TIME_RANGE = '24h' satisfies ChartTimeRanges
-
-const isChartTimeRange = (
-  timeRange: string | null,
-): timeRange is ChartTimeRanges => {
-  return (
-    timeRange !== null &&
-    (chartTimeRanges as readonly string[]).includes(timeRange)
-  )
-}
-
-export const getValidTimeRange = (
-  searchParams: URLSearchParams,
-): ChartTimeRanges => {
-  const urlTimeRange = searchParams.get('past')
-  return isChartTimeRange(urlTimeRange) ? urlTimeRange : DEFAULT_TIME_RANGE
-}
-
-export const getMatchedFilterByPrefix = (
-  chartType: ChartType,
-  filter: Record<string, string>,
+  queryKey: keyof EventsApiGetRankedEventsRequest,
+  chartQuery: ChartQuery,
 ) => {
-  return Object.fromEntries(
-    Object.entries(filter).filter(([key]) => key.startsWith(chartType)),
-  )
+  const dynamicKey =
+    `${chartType}${queryKey.charAt(0).toUpperCase()}${queryKey.slice(1)}` as keyof ChartQuery
+  return chartQuery[dynamicKey]
 }
 
-export const mapToRedirectQuery = (
-  currentQuery: Record<string, string>,
+export const getRequestQueryByChartType = (
   chartType: ChartType,
+  chartQuery: ChartQuery,
+): Pick<
+  EventsApiGetRankedEventsRequest,
+  'type' | 'past' | 'category' | 'severity' | 'host' | 'instance'
+> => {
+  return {
+    type: chartQuery.type,
+    past: chartQuery.past,
+    category: getQueryValue(chartType, 'category', chartQuery),
+    severity: getQueryValue(chartType, 'severity', chartQuery),
+    host: getQueryValue(chartType, 'host', chartQuery),
+    instance: getQueryValue(chartType, 'instance', chartQuery),
+  }
+}
+
+export const getRedirectUrl = (
+  chartType: ChartType,
+  chartQuery: ChartQuery,
+  eventId: string,
 ): string => {
-  const params = new URLSearchParams()
-  Object.entries(currentQuery).forEach(([key, value]) => {
-    params.set(removeQueryKeyPrefix(chartType, key), value)
+  const { type, past, category, severity, host, instance } =
+    getRequestQueryByChartType(chartType, chartQuery)
+
+  const endDate = dayjs()
+  const startDate = endDate.subtract(timeRangeToDaysMapping[past!], 'day')
+
+  const searchParams = new URLSearchParams({
+    type,
+    keyword: eventId,
+    start: startDate?.toString() || '',
+    stop: endDate?.toString() || '',
   })
-  return params.toString()
+
+  if (category) searchParams.set('category', category)
+  if (severity) searchParams.set('severity', severity)
+  if (host) searchParams.set('host', host)
+  if (instance) searchParams.set('instance', instance)
+
+  return `/events?${searchParams.toString()}`
 }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/utils.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs'
-import { lowerFirst } from 'lodash'
+import { lowerFirst, upperFirst } from 'lodash'
 import {
   EventsApiGetRankedEventsRequest,
   GetEventFilterConditionResponseDataHost,
@@ -7,8 +7,9 @@ import {
   GetEventFilterConditionResponseDataSystem,
   GetEventsTypeEnum,
 } from '@cube-frontend/api'
+import { timeRangeDelta } from '@cube-frontend/web-app/hooks/useTimeFrame/timeFrameUtils'
 import { ChartQuery, FilterKeys } from './useEventsChartQuery'
-import { getValidTimeRange, timeRangeToDaysMapping } from './timeRangeUtils'
+import { getValidTimeRange } from './timeRangeUtils'
 
 export type ChartType = 'proportion' | 'comparison'
 
@@ -116,8 +117,7 @@ const getQueryValue = (
   queryKey: keyof EventsApiGetRankedEventsRequest,
   chartQuery: ChartQuery,
 ) => {
-  const dynamicKey =
-    `${chartType}${queryKey.charAt(0).toUpperCase()}${queryKey.slice(1)}` as keyof ChartQuery
+  const dynamicKey = `${chartType}${upperFirst(queryKey)}` as keyof ChartQuery
   return chartQuery[dynamicKey]
 }
 
@@ -143,18 +143,21 @@ export const getRedirectUrl = (
   chartQuery: ChartQuery,
   eventId: string,
 ): string => {
-  const { type, past, category, severity, host, instance } =
-    getRequestQueryByChartType(chartType, chartQuery)
-
+  const { value, unit } = timeRangeDelta[chartQuery.past]
   const endDate = dayjs()
-  const startDate = endDate.subtract(timeRangeToDaysMapping[past!], 'day')
+  const startDate = endDate.add(value, unit)
 
   const searchParams = new URLSearchParams({
-    type,
+    type: chartQuery.type,
     keyword: eventId,
-    start: startDate?.toString() || '',
-    stop: endDate?.toString() || '',
+    start: startDate.toString(),
+    stop: endDate.toString(),
   })
+
+  const category = getQueryValue(chartType, 'category', chartQuery)
+  const severity = getQueryValue(chartType, 'severity', chartQuery)
+  const host = getQueryValue(chartType, 'host', chartQuery)
+  const instance = getQueryValue(chartType, 'instance', chartQuery)
 
   if (category) searchParams.set('category', category)
   if (severity) searchParams.set('severity', severity)


### PR DESCRIPTION
### ⚠️ The PR is based on #257

#### What type of PR is this?

- Feature
- Fix

#### What this PR does / why we need it

##### 1) Display data from the API on `Events Chart` page ➡️ commit [4292623](https://github.com/bigstack-oss/cube-cos-ui/pull/263/commits/4292623f8bee09e93f2dc7859197f0628329934b)
- Remove `mockData`
- Apply `No Data` status to Charts

https://github.com/user-attachments/assets/08104f93-060e-4526-b3a5-a372b0c7257d

##### 2) Add an 'All' option to the filter ➡️ commit [40d1bb1](https://github.com/bigstack-oss/cube-cos-ui/pull/263/commits/40d1bb131247917b63824cd3a86bacad156e68a8)

https://github.com/user-attachments/assets/64e2940f-d6ad-477f-85db-0dd7163570ae

##### 3) Record the time range in the URL query on the `Events Chart` page ➡️ [88b3985](https://github.com/bigstack-oss/cube-cos-ui/pull/263/commits/88b39850db197b7eba48a0dc5699ea446e9d4540)

https://github.com/user-attachments/assets/f414daf7-cf62-4fb3-b60b-315a8d35dc92

#### Which issue(s) this PR fixes

Fixes #233 ➡️ commit [4292623](https://github.com/bigstack-oss/cube-cos-ui/pull/263/commits/4292623f8bee09e93f2dc7859197f0628329934b)

Fixes #255 ➡️ commit [40d1bb1](https://github.com/bigstack-oss/cube-cos-ui/pull/263/commits/40d1bb131247917b63824cd3a86bacad156e68a8)

Fixes #262 ➡️ commit [88b3985](https://github.com/bigstack-oss/cube-cos-ui/pull/263/commits/88b39850db197b7eba48a0dc5699ea446e9d4540)

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
