### PR TITLE
Feat/182 invalid license nagging

### DIFF
--- a/packages/cube-frontend-api/sdk/api.ts
+++ b/packages/cube-frontend-api/sdk/api.ts
@@ -403,13 +403,13 @@ export interface EmailSenderPostRequest {
      * @type {string}
      * @memberof EmailSenderPostRequest
      */
-    'username': string;
+    'username'?: string;
     /**
      * 
      * @type {string}
      * @memberof EmailSenderPostRequest
      */
-    'password': string;
+    'password'?: string;
     /**
      * 
      * @type {string}
@@ -944,6 +944,37 @@ export interface GetDataCentersResponseDataInnerAdditional {
      * @memberof GetDataCentersResponseDataInnerAdditional
      */
     'helpUrl': string;
+    /**
+     * 
+     * @type {GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus}
+     * @memberof GetDataCentersResponseDataInnerAdditional
+     */
+    'nodeLicenseStatus': GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus;
+}
+/**
+ * 
+ * @export
+ * @interface GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus
+ */
+export interface GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus {
+    /**
+     * 
+     * @type {number}
+     * @memberof GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus
+     */
+    'valid': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus
+     */
+    'expired': number;
+    /**
+     * 
+     * @type {number}
+     * @memberof GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus
+     */
+    'unlicense': number;
 }
 /**
  * 
@@ -2401,10 +2432,10 @@ export interface GetLicensesResponseDataLicensesInner {
     'expiry': GetLicensesResponseDataLicensesInnerExpiry;
     /**
      * 
-     * @type {GetLicensesResponseDataLicensesInnerStatus}
+     * @type {ListLicenseStatus}
      * @memberof GetLicensesResponseDataLicensesInner
      */
-    'status': GetLicensesResponseDataLicensesInnerStatus;
+    'status': ListLicenseStatus;
 }
 /**
  * 
@@ -2475,33 +2506,6 @@ export interface GetLicensesResponseDataLicensesInnerProduct {
      */
     'feature': string;
 }
-/**
- * 
- * @export
- * @interface GetLicensesResponseDataLicensesInnerStatus
- */
-export interface GetLicensesResponseDataLicensesInnerStatus {
-    /**
-     * 
-     * @type {string}
-     * @memberof GetLicensesResponseDataLicensesInnerStatus
-     */
-    'current': GetLicensesResponseDataLicensesInnerStatusCurrentEnum;
-    /**
-     * 
-     * @type {boolean}
-     * @memberof GetLicensesResponseDataLicensesInnerStatus
-     */
-    'isExpiring': boolean;
-}
-
-export const GetLicensesResponseDataLicensesInnerStatusCurrentEnum = {
-    Ok: 'ok',
-    Expired: 'expired'
-} as const;
-
-export type GetLicensesResponseDataLicensesInnerStatusCurrentEnum = typeof GetLicensesResponseDataLicensesInnerStatusCurrentEnum[keyof typeof GetLicensesResponseDataLicensesInnerStatusCurrentEnum];
-
 /**
  * 
  * @export
@@ -4766,6 +4770,41 @@ export interface ImportClusterLicense500Response {
 /**
  * 
  * @export
+ * @enum {string}
+ */
+
+export const ListLicenseCurrentStatus = {
+    Valid: 'valid',
+    Expired: 'expired'
+} as const;
+
+export type ListLicenseCurrentStatus = typeof ListLicenseCurrentStatus[keyof typeof ListLicenseCurrentStatus];
+
+
+/**
+ * 
+ * @export
+ * @interface ListLicenseStatus
+ */
+export interface ListLicenseStatus {
+    /**
+     * 
+     * @type {ListLicenseCurrentStatus}
+     * @memberof ListLicenseStatus
+     */
+    'current': ListLicenseCurrentStatus;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof ListLicenseStatus
+     */
+    'isExpiring': boolean;
+}
+
+
+/**
+ * 
+ * @export
  * @interface ListTuningResponse
  */
 export interface ListTuningResponse {
@@ -5463,7 +5502,28 @@ export interface NodeLicense {
      * @memberof NodeLicense
      */
     'expiry': NodeLicenseExpiry;
+    /**
+     * 
+     * @type {NodeLicenseStatus}
+     * @memberof NodeLicense
+     */
+    'status': NodeLicenseStatus;
 }
+/**
+ * 
+ * @export
+ * @enum {string}
+ */
+
+export const NodeLicenseCurrentStatus = {
+    Unlicense: 'unlicense',
+    Valid: 'valid',
+    Expired: 'expired'
+} as const;
+
+export type NodeLicenseCurrentStatus = typeof NodeLicenseCurrentStatus[keyof typeof NodeLicenseCurrentStatus];
+
+
 /**
  * 
  * @export
@@ -5514,6 +5574,27 @@ export interface NodeLicenseIssue {
      */
     'date': string;
 }
+/**
+ * 
+ * @export
+ * @interface NodeLicenseStatus
+ */
+export interface NodeLicenseStatus {
+    /**
+     * 
+     * @type {NodeLicenseCurrentStatus}
+     * @memberof NodeLicenseStatus
+     */
+    'current': NodeLicenseCurrentStatus;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof NodeLicenseStatus
+     */
+    'isExpiring': boolean;
+}
+
+
 /**
  * 
  * @export
@@ -6946,10 +7027,10 @@ export interface VerifyLicenseResponseDataEffectNodesInner {
     'expiry': GetLicensesResponseDataLicensesInnerExpiry;
     /**
      * 
-     * @type {VerifyLicenseResponseDataLicenseStatus}
+     * @type {NodeLicenseStatus}
      * @memberof VerifyLicenseResponseDataEffectNodesInner
      */
-    'status': VerifyLicenseResponseDataLicenseStatus;
+    'status': NodeLicenseStatus;
 }
 /**
  * 
@@ -7001,38 +7082,40 @@ export interface VerifyLicenseResponseDataLicense {
     'expiry': GetLicensesResponseDataLicensesInnerExpiry;
     /**
      * 
-     * @type {VerifyLicenseResponseDataLicenseStatus}
+     * @type {VerifyLicenseStatus}
      * @memberof VerifyLicenseResponseDataLicense
      */
-    'status': VerifyLicenseResponseDataLicenseStatus;
+    'status': VerifyLicenseStatus;
 }
 /**
  * 
  * @export
- * @interface VerifyLicenseResponseDataLicenseStatus
+ * @interface VerifyLicenseStatus
  */
-export interface VerifyLicenseResponseDataLicenseStatus {
+export interface VerifyLicenseStatus {
     /**
      * 
      * @type {string}
-     * @memberof VerifyLicenseResponseDataLicenseStatus
+     * @memberof VerifyLicenseStatus
      */
-    'current': VerifyLicenseResponseDataLicenseStatusCurrentEnum;
+    'current': VerifyLicenseStatusCurrentEnum;
     /**
      * 
      * @type {boolean}
-     * @memberof VerifyLicenseResponseDataLicenseStatus
+     * @memberof VerifyLicenseStatus
      */
     'isExpiring': boolean;
 }
 
-export const VerifyLicenseResponseDataLicenseStatusCurrentEnum = {
-    Ok: 'ok',
-    Expiring: 'expiring',
+export const VerifyLicenseStatusCurrentEnum = {
+    Valid: 'valid',
+    UnmatchedHardware: 'unmatched hardware',
+    InvalidSignature: 'invalid signature',
+    SystemCompromised: 'system compromised',
     Expired: 'expired'
 } as const;
 
-export type VerifyLicenseResponseDataLicenseStatusCurrentEnum = typeof VerifyLicenseResponseDataLicenseStatusCurrentEnum[keyof typeof VerifyLicenseResponseDataLicenseStatusCurrentEnum];
+export type VerifyLicenseStatusCurrentEnum = typeof VerifyLicenseStatusCurrentEnum[keyof typeof VerifyLicenseStatusCurrentEnum];
 
 
 /**
@@ -9690,7 +9773,7 @@ export const LicensesApiAxiosParamCreator = function (configuration?: Configurat
          * @param {string} dataCenter The name of the data center to operate
          * @param {string} [keyword] The keyword to search, can be any string
          * @param {Array<GetLicensesProductsEnum>} [products] The product of the host
-         * @param {Array<GetLicensesStatusesEnum>} [statuses] The status of the host
+         * @param {Array<ListLicenseCurrentStatus>} [statuses] The status of the license
          * @param {Array<GetLicensesTypesEnum>} [types] The type of the license to query, click \&#39;try it out\&#39; to see a few options.
          * @param {number} [pageSize] The number of items per page (default is unlimit).
          * @param {number} [pageNum] The page number to retrieve
@@ -9698,7 +9781,7 @@ export const LicensesApiAxiosParamCreator = function (configuration?: Configurat
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getLicenses: async (dataCenter: string, keyword?: string, products?: Array<GetLicensesProductsEnum>, statuses?: Array<GetLicensesStatusesEnum>, types?: Array<GetLicensesTypesEnum>, pageSize?: number, pageNum?: number, watch?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getLicenses: async (dataCenter: string, keyword?: string, products?: Array<GetLicensesProductsEnum>, statuses?: Array<ListLicenseCurrentStatus>, types?: Array<GetLicensesTypesEnum>, pageSize?: number, pageNum?: number, watch?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'dataCenter' is not null or undefined
             assertParamExists('getLicenses', 'dataCenter', dataCenter)
             const localVarPath = `/api/v1/datacenters/{dataCenter}/licenses`
@@ -9908,7 +9991,7 @@ export const LicensesApiFp = function(configuration?: Configuration) {
          * @param {string} dataCenter The name of the data center to operate
          * @param {string} [keyword] The keyword to search, can be any string
          * @param {Array<GetLicensesProductsEnum>} [products] The product of the host
-         * @param {Array<GetLicensesStatusesEnum>} [statuses] The status of the host
+         * @param {Array<ListLicenseCurrentStatus>} [statuses] The status of the license
          * @param {Array<GetLicensesTypesEnum>} [types] The type of the license to query, click \&#39;try it out\&#39; to see a few options.
          * @param {number} [pageSize] The number of items per page (default is unlimit).
          * @param {number} [pageNum] The page number to retrieve
@@ -9916,7 +9999,7 @@ export const LicensesApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getLicenses(dataCenter: string, keyword?: string, products?: Array<GetLicensesProductsEnum>, statuses?: Array<GetLicensesStatusesEnum>, types?: Array<GetLicensesTypesEnum>, pageSize?: number, pageNum?: number, watch?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetLicensesResponse>> {
+        async getLicenses(dataCenter: string, keyword?: string, products?: Array<GetLicensesProductsEnum>, statuses?: Array<ListLicenseCurrentStatus>, types?: Array<GetLicensesTypesEnum>, pageSize?: number, pageNum?: number, watch?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetLicensesResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getLicenses(dataCenter, keyword, products, statuses, types, pageSize, pageNum, watch, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['LicensesApi.getLicenses']?.[localVarOperationServerIndex]?.url;
@@ -10046,11 +10129,11 @@ export interface LicensesApiGetLicensesRequest {
     readonly products?: Array<GetLicensesProductsEnum>
 
     /**
-     * The status of the host
-     * @type {Array<'ok' | 'expiring' | 'expired' | 'error'>}
+     * The status of the license
+     * @type {Array<ListLicenseCurrentStatus>}
      * @memberof LicensesApiGetLicenses
      */
-    readonly statuses?: Array<GetLicensesStatusesEnum>
+    readonly statuses?: Array<ListLicenseCurrentStatus>
 
     /**
      * The type of the license to query, click \&#39;try it out\&#39; to see a few options.
@@ -10215,16 +10298,6 @@ export const GetLicensesProductsEnum = {
     CubeCmp: 'cubeCMP'
 } as const;
 export type GetLicensesProductsEnum = typeof GetLicensesProductsEnum[keyof typeof GetLicensesProductsEnum];
-/**
- * @export
- */
-export const GetLicensesStatusesEnum = {
-    Ok: 'ok',
-    Expiring: 'expiring',
-    Expired: 'expired',
-    Error: 'error'
-} as const;
-export type GetLicensesStatusesEnum = typeof GetLicensesStatusesEnum[keyof typeof GetLicensesStatusesEnum];
 /**
  * @export
  */
@@ -10945,7 +11018,7 @@ export const NodesApiAxiosParamCreator = function (configuration?: Configuration
          * @param {string} dataCenter The name of the data center to operate
          * @param {string} [keyword] The keyword to search, can be any string
          * @param {Array<GetNodesRolesEnum>} [roles] The role of the host
-         * @param {Array<GetNodesLicenseStatusesEnum>} [licenseStatuses] The status of the host
+         * @param {Array<NodeLicenseCurrentStatus>} [licenseStatuses] The license status of the host
          * @param {Array<GetNodesProductsEnum>} [products] The product of the host
          * @param {number} [pageSize] The number of items per page (default is unlimit).
          * @param {number} [pageNum] The page number to retrieve
@@ -10953,7 +11026,7 @@ export const NodesApiAxiosParamCreator = function (configuration?: Configuration
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        getNodes: async (dataCenter: string, keyword?: string, roles?: Array<GetNodesRolesEnum>, licenseStatuses?: Array<GetNodesLicenseStatusesEnum>, products?: Array<GetNodesProductsEnum>, pageSize?: number, pageNum?: number, watch?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        getNodes: async (dataCenter: string, keyword?: string, roles?: Array<GetNodesRolesEnum>, licenseStatuses?: Array<NodeLicenseCurrentStatus>, products?: Array<GetNodesProductsEnum>, pageSize?: number, pageNum?: number, watch?: boolean, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'dataCenter' is not null or undefined
             assertParamExists('getNodes', 'dataCenter', dataCenter)
             const localVarPath = `/api/v1/datacenters/{dataCenter}/nodes`
@@ -11039,7 +11112,7 @@ export const NodesApiFp = function(configuration?: Configuration) {
          * @param {string} dataCenter The name of the data center to operate
          * @param {string} [keyword] The keyword to search, can be any string
          * @param {Array<GetNodesRolesEnum>} [roles] The role of the host
-         * @param {Array<GetNodesLicenseStatusesEnum>} [licenseStatuses] The status of the host
+         * @param {Array<NodeLicenseCurrentStatus>} [licenseStatuses] The license status of the host
          * @param {Array<GetNodesProductsEnum>} [products] The product of the host
          * @param {number} [pageSize] The number of items per page (default is unlimit).
          * @param {number} [pageNum] The page number to retrieve
@@ -11047,7 +11120,7 @@ export const NodesApiFp = function(configuration?: Configuration) {
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async getNodes(dataCenter: string, keyword?: string, roles?: Array<GetNodesRolesEnum>, licenseStatuses?: Array<GetNodesLicenseStatusesEnum>, products?: Array<GetNodesProductsEnum>, pageSize?: number, pageNum?: number, watch?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetNodesResponse>> {
+        async getNodes(dataCenter: string, keyword?: string, roles?: Array<GetNodesRolesEnum>, licenseStatuses?: Array<NodeLicenseCurrentStatus>, products?: Array<GetNodesProductsEnum>, pageSize?: number, pageNum?: number, watch?: boolean, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetNodesResponse>> {
             const localVarAxiosArgs = await localVarAxiosParamCreator.getNodes(dataCenter, keyword, roles, licenseStatuses, products, pageSize, pageNum, watch, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['NodesApi.getNodes']?.[localVarOperationServerIndex]?.url;
@@ -11142,11 +11215,11 @@ export interface NodesApiGetNodesRequest {
     readonly roles?: Array<GetNodesRolesEnum>
 
     /**
-     * The status of the host
-     * @type {Array<'ok' | 'expiring' | 'expired' | 'error'>}
+     * The license status of the host
+     * @type {Array<NodeLicenseCurrentStatus>}
      * @memberof NodesApiGetNodes
      */
-    readonly licenseStatuses?: Array<GetNodesLicenseStatusesEnum>
+    readonly licenseStatuses?: Array<NodeLicenseCurrentStatus>
 
     /**
      * The product of the host
@@ -11221,16 +11294,6 @@ export const GetNodesRolesEnum = {
     Moderator: 'moderator'
 } as const;
 export type GetNodesRolesEnum = typeof GetNodesRolesEnum[keyof typeof GetNodesRolesEnum];
-/**
- * @export
- */
-export const GetNodesLicenseStatusesEnum = {
-    Ok: 'ok',
-    Expiring: 'expiring',
-    Expired: 'expired',
-    Error: 'error'
-} as const;
-export type GetNodesLicenseStatusesEnum = typeof GetNodesLicenseStatusesEnum[keyof typeof GetNodesLicenseStatusesEnum];
 /**
  * @export
  */

--- a/packages/cube-frontend-ui-library/src/components/CosNagging/CosNagging.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNagging/CosNagging.tsx
@@ -1,26 +1,34 @@
+import { isArray } from 'lodash'
 import WarningFilled from '../../components/CosIcon/monochrome/warning_filled.svg?react'
 import WarningAltFilled from '../../components/CosIcon/monochrome/warning_alt_filled.svg?react'
+import XSmallIcon from '@cube-frontend/ui-library/icons/monochrome/x_small.svg?react'
 import { PropsWithClassName } from '@cube-frontend/utils'
 import { cva } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
-import { CosHyperlink } from '../CosHyperlink/CosHyperlink'
+import { CosHyperlink, CosHyperlinkProps } from '../CosHyperlink/CosHyperlink'
 import { SvgElement } from '../CosIcon/CosIcon'
 
 export type CosNaggingType = 'error' | 'warning'
 
 export type CosNaggingVariant = 'sidebar' | 'top'
 
+export type CosNaggingLink = Pick<CosHyperlinkProps, 'href' | 'onClick'> & {
+  text: CosHyperlinkProps['children']
+}
+
 export type CosNaggingProps = PropsWithClassName & {
   type: CosNaggingType
   title: string
+  description?: string | string[]
+  link?: CosNaggingLink
 } & (
-    | { variant: Extract<CosNaggingVariant, 'sidebar'>; description?: string }
-    | { variant: Extract<CosNaggingVariant, 'top'> }
-  ) & { link?: { href: string; text: string } }
+    | { variant: Extract<CosNaggingVariant, 'sidebar'> }
+    | { variant: Extract<CosNaggingVariant, 'top'>; onClose?: () => void }
+  )
 
 const nagging = cva(
   [
-    'flex gap-[6px] self-start rounded-md border bg-yellow-50 p-3',
+    'flex flex-col gap-[6px] self-start rounded-md border bg-yellow-50 p-3',
     'shadow-[0_0_2px_0_rgba(0,0,0,0.2)]',
   ],
   {
@@ -29,30 +37,27 @@ const nagging = cva(
         error: 'border-status-negative',
         warning: 'border-status-warning',
       },
-      variant: {
-        sidebar: 'flex-col',
-        top: '',
-      },
     },
   },
 )
 
+const descriptionContainerClass = twMerge('primary-body4 text-functional-text')
 const typeIconBaseClass = twMerge('icon-md shrink-0')
 const typeIcons: Record<CosNaggingType, SvgElement> = {
   error: (
-    <WarningAltFilled
+    <WarningFilled
       className={twMerge(typeIconBaseClass, 'text-status-negative')}
     />
   ),
   warning: (
-    <WarningFilled
+    <WarningAltFilled
       className={twMerge(typeIconBaseClass, 'text-status-warning')}
     />
   ),
 }
 
 export const CosNagging = (props: CosNaggingProps) => {
-  const { className, type, variant, title } = props
+  const { className, type, variant, title, description, link } = props
 
   const isVariantSidebar = variant === 'sidebar'
 
@@ -71,7 +76,12 @@ export const CosNagging = (props: CosNaggingProps) => {
         <div className="flex flex-wrap items-center gap-2">
           {titleElement}
           {link && (
-            <CosHyperlink variant="text-inline" size="sm" href={link.href}>
+            <CosHyperlink
+              variant="text-inline"
+              size="sm"
+              href={link.href}
+              onClick={link.onClick}
+            >
               {link.text}
             </CosHyperlink>
           )}
@@ -82,22 +92,59 @@ export const CosNagging = (props: CosNaggingProps) => {
     }
   }
 
-  const renderDescription = () => {
+  const renderCloseIcon = () => {
     if (isVariantSidebar) {
-      const { description } = props
+      return undefined
+    }
+
+    const { onClose } = props
+
+    if (!onClose) {
+      return null
+    }
+
+    return (
+      <XSmallIcon
+        className="icon-md cursor-pointer text-functional-text"
+        onClick={onClose}
+      />
+    )
+  }
+
+  const renderDescription = () => {
+    if (!description) {
+      return null
+    }
+
+    if (isArray(description)) {
+      if (description.length === 0) {
+        return null
+      }
+
       return (
-        <div className="primary-body4 text-functional-text">{description}</div>
+        <div className={descriptionContainerClass}>
+          <ul className="list-outside list-disc pl-4">
+            {description.map((item) => (
+              <li key={item}>{item}</li>
+            ))}
+          </ul>
+        </div>
       )
     }
-    return undefined
+
+    return <div className={descriptionContainerClass}>{description}</div>
   }
 
   const renderBottomLink = () => {
     if (isVariantSidebar) {
-      const { link } = props
       return (
         link && (
-          <CosHyperlink variant="text-inline" size="sm" href={link.href}>
+          <CosHyperlink
+            variant="text-inline"
+            size="sm"
+            href={link.href}
+            onClick={link.onClick}
+          >
             {link.text}
           </CosHyperlink>
         )
@@ -107,10 +154,13 @@ export const CosNagging = (props: CosNaggingProps) => {
   }
 
   return (
-    <div className={twMerge(nagging({ variant, type }), className)}>
-      <div className="flex items-start gap-2">
-        {icon}
-        {renderTitle()}
+    <div className={twMerge(nagging({ type }), className)}>
+      <div className="flex items-center justify-between">
+        <div className="flex items-start gap-2">
+          {icon}
+          {renderTitle()}
+        </div>
+        {renderCloseIcon()}
       </div>
       {renderDescription()}
       {renderBottomLink()}

--- a/packages/cube-frontend-ui-library/src/components/CosSideBar/CosSideBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSideBar/CosSideBar.tsx
@@ -9,8 +9,15 @@ export type CosSideBarProps = SideBarTitleProps &
   SideBarBottomProps
 
 export const CosSideBar = (props: CosSideBarProps) => {
-  const { LogoContainer, isLoading, dataCenter, username, options, links } =
-    props
+  const {
+    LogoContainer,
+    isLoading,
+    dataCenter,
+    username,
+    options,
+    links,
+    naggingProps,
+  } = props
 
   return (
     <div
@@ -22,6 +29,7 @@ export const CosSideBar = (props: CosSideBarProps) => {
         isLoading={isLoading}
         dataCenter={dataCenter}
         username={username}
+        naggingProps={naggingProps}
       />
       <SideBarCombobox options={options} />
       <SideBarBottom links={links} />

--- a/packages/cube-frontend-ui-library/src/components/CosSideBar/SideBarUserInfo.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSideBar/SideBarUserInfo.tsx
@@ -1,3 +1,4 @@
+import { CosNagging, CosNaggingProps } from '../CosNagging/CosNagging'
 import { CosSkeleton } from '../CosSkeleton/CosSkeleton'
 import { SideBarBlock } from './SideBarBlock'
 import { UserNameTag } from './UserNameTag'
@@ -14,10 +15,11 @@ export type SideBarUserInfoProps = {
       }
     | undefined
   username: string | undefined
+  naggingProps?: Omit<CosNaggingProps, 'variant'>
 }
 
 const SideBarUserInfo = (props: SideBarUserInfoProps) => {
-  const { isLoading = false, dataCenter, username } = props
+  const { isLoading = false, dataCenter, username, naggingProps } = props
 
   const renderDataCenter = () => {
     if (isLoading) {
@@ -55,6 +57,7 @@ const SideBarUserInfo = (props: SideBarUserInfoProps) => {
         {renderUserName()}
       </div>
       {renderVersion()}
+      {naggingProps && <CosNagging {...naggingProps} variant="sidebar" />}
     </SideBarBlock>
   )
 }

--- a/packages/cube-frontend-ui-library/src/stories/components/CosNagging/CosNagging.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosNagging/CosNagging.stories.tsx
@@ -6,6 +6,7 @@ import {
   NaggingBoxForTop,
   NaggingRowForTop,
 } from './NaggingBox'
+import { noop } from 'lodash'
 
 const meta = {
   title: 'Molecules/Nagging',
@@ -20,6 +21,11 @@ const naggingContent = {
   longerTitle:
     'Two-line title will look like this two-line title will look like this two-line title will look like this two-line title will look like this two-line title will look like this two-line title will look like this two-line title will look like this two-line title will look like this two-line title will look like this',
   description: 'Text goes here. Text goes here. (Optional)',
+  multilineDescription: [
+    'Text goes here. Text goes here. (Optional)',
+    'Text goes here. Text goes here. (Optional)',
+    'Text goes here. Text goes here. (Optional)',
+  ],
   createLink: () => ({
     text: 'Call to action',
     href: `/#${Math.random()}`,
@@ -107,6 +113,21 @@ export const Sidebar: StoryObj = {
               description={naggingContent.description}
             />
           </NaggingBoxForSidebar>
+          <NaggingBoxForSidebar title="Multiple descriptions">
+            <CosNagging
+              type="error"
+              variant="sidebar"
+              title={naggingContent.title}
+              description={naggingContent.multilineDescription}
+              link={naggingContent.createLink()}
+            />
+            <CosNagging
+              type="error"
+              variant="sidebar"
+              title={naggingContent.title}
+              description={naggingContent.multilineDescription}
+            />
+          </NaggingBoxForSidebar>
         </div>
       </StoryLayout.Section>
     </StoryLayout>
@@ -140,6 +161,7 @@ export const Top: StoryObj = {
                 variant="top"
                 title={naggingContent.title}
                 link={naggingContent.createLink()}
+                description={naggingContent.description}
               />
             </NaggingRowForTop>
             <NaggingRowForTop title="Without link">
@@ -147,6 +169,7 @@ export const Top: StoryObj = {
                 type="error"
                 variant="top"
                 title={naggingContent.title}
+                description={naggingContent.description}
               />
             </NaggingRowForTop>
           </NaggingBoxForTop>
@@ -157,6 +180,7 @@ export const Top: StoryObj = {
                 variant="top"
                 title={naggingContent.title}
                 link={naggingContent.createLink()}
+                description={naggingContent.description}
               />
             </NaggingRowForTop>
             <NaggingRowForTop title="Without link">
@@ -164,6 +188,28 @@ export const Top: StoryObj = {
                 type="warning"
                 variant="top"
                 title={naggingContent.title}
+                description={naggingContent.description}
+              />
+            </NaggingRowForTop>
+          </NaggingBoxForTop>
+          <NaggingBoxForTop title="With close button">
+            <NaggingRowForTop title="With link">
+              <CosNagging
+                type="error"
+                variant="top"
+                title={naggingContent.title}
+                link={naggingContent.createLink()}
+                description={naggingContent.description}
+                onClose={noop}
+              />
+            </NaggingRowForTop>
+            <NaggingRowForTop title="Without link">
+              <CosNagging
+                type="warning"
+                variant="top"
+                title={naggingContent.title}
+                description={naggingContent.description}
+                onClose={noop}
               />
             </NaggingRowForTop>
           </NaggingBoxForTop>
@@ -202,6 +248,25 @@ export const Top: StoryObj = {
                 type="warning"
                 variant="top"
                 title={naggingContent.longerTitle}
+              />
+            </NaggingRowForTop>
+          </NaggingBoxForTop>
+          <NaggingBoxForTop title="Multiple descriptions">
+            <NaggingRowForTop title="With link">
+              <CosNagging
+                type="error"
+                variant="top"
+                title={naggingContent.title}
+                link={naggingContent.createLink()}
+                description={naggingContent.multilineDescription}
+              />
+            </NaggingRowForTop>
+            <NaggingRowForTop title="Without link">
+              <CosNagging
+                type="error"
+                variant="top"
+                title={naggingContent.title}
+                description={naggingContent.multilineDescription}
               />
             </NaggingRowForTop>
           </NaggingBoxForTop>

--- a/packages/cube-frontend-ui-library/src/stories/components/CosSideBar/CosSideBar.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosSideBar/CosSideBar.stories.tsx
@@ -1,9 +1,10 @@
 import type { Meta, StoryObj } from '@storybook/react'
+import { noop } from 'lodash'
 import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
 import {
   CosSideBar,
   CosSideBarProps,
-} from '../../..//components/CosSideBar/CosSideBar'
+} from '../../../components/CosSideBar/CosSideBar'
 import HomeIcon from '../../../components/CosIcon/monochrome/home_01.svg?react'
 import NodeIcon from '../../../components/CosIcon/monochrome/node.svg?react'
 import IntegrationsIcon from '../../../components/CosIcon/monochrome/integration.svg?react'
@@ -31,46 +32,54 @@ const defaultArgs = {
     version: 'Cube Appliance 2.3.3',
   },
   username: 'Admin',
+  naggingProps: {
+    type: 'error',
+    title: '3 hosts license verification failed.',
+    link: {
+      text: 'Go to License',
+      onClick: noop,
+    },
+  },
   options: [
     {
       Icon: HomeIcon,
       label: 'Home',
       notificationCount: 1,
       isSelected: true,
-      onClick: () => {},
+      onClick: noop,
     },
     {
       Icon: NodeIcon,
       label: 'Nodes',
       notificationCount: 99,
       isSelected: false,
-      onClick: () => {},
+      onClick: noop,
     },
     {
       Icon: IntegrationsIcon,
       label: 'Integrations',
       notificationCount: 100,
       isSelected: false,
-      onClick: () => {},
+      onClick: noop,
     },
     {
       Icon: MaintenanceIcon,
       label: 'Maintenance',
       notificationCount: 0,
       isSelected: false,
-      onClick: () => {},
+      onClick: noop,
     },
     {
       Icon: EventsIcon,
       label: 'Events',
       isSelected: false,
-      onClick: () => {},
+      onClick: noop,
     },
     {
       Icon: SettingsIcon,
       label: 'Settings',
       isSelected: false,
-      onClick: () => {},
+      onClick: noop,
     },
   ],
   links: [

--- a/packages/cube-frontend-web-app/src/context/DataCenterProvider.tsx
+++ b/packages/cube-frontend-web-app/src/context/DataCenterProvider.tsx
@@ -16,6 +16,14 @@ export const DataCenterProvider = (props: PropsWithChildren) => {
     throw new Error('A data center is required.')
   }
 
+  if (dataCenter) {
+    dataCenter.additional.nodeLicenseStatus = {
+      expired: 10,
+      unlicense: 1,
+      valid: 0,
+    }
+  }
+
   return (
     <DataCenterContext.Provider value={{ dataCenter, isLoading }}>
       {children}

--- a/packages/cube-frontend-web-app/src/layout/Layout.tsx
+++ b/packages/cube-frontend-web-app/src/layout/Layout.tsx
@@ -12,6 +12,7 @@ import { UserContext } from '../context/UserContext'
 import Content from './Content'
 import { useSidebarOptions } from './useSidebarOptions'
 import { useSidebarBottomLinks } from './useSidebarBottomLinks'
+import { useSideBarNagging } from './useSideBarNagging'
 
 const integrationIcons = {
   keycloak: KeycloakIcon,
@@ -39,6 +40,10 @@ const Layout = (props: PropsWithChildren) => {
   const { integrations, isLoading: isIntegrationsLoading } =
     useContext(IntegrationsContext)
 
+  const sideBarNaggingProps = useSideBarNagging(
+    dataCenter?.additional.nodeLicenseStatus,
+  )
+
   const quickAccesses = integrations.map((integration) => {
     const Icon =
       integrationIcons[integration.name as keyof typeof integrationIcons]
@@ -48,6 +53,7 @@ const Layout = (props: PropsWithChildren) => {
 
     return { Icon, href: integration.url }
   })
+
   return (
     <div className="h-svh min-w-full overflow-hidden bg-scene-background">
       <div className="flex h-svh flex-row">
@@ -55,6 +61,7 @@ const Layout = (props: PropsWithChildren) => {
           LogoContainer={<Link to="/home"></Link>}
           isLoading={isDataCenterLoading || isUserInfoLoading}
           dataCenter={dataCenter}
+          naggingProps={sideBarNaggingProps}
           username={userInfo?.name}
           options={sideBarOptions}
           links={sideBarBottomLinks}

--- a/packages/cube-frontend-web-app/src/layout/useSideBarNagging.ts
+++ b/packages/cube-frontend-web-app/src/layout/useSideBarNagging.ts
@@ -1,0 +1,30 @@
+import { useNavigate } from 'react-router'
+import { GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus } from '@cube-frontend/api'
+import { CosSideBarProps } from '@cube-frontend/ui-library'
+import { getInvalidMessageList } from '../utils/license'
+import { links } from '../pages/maintenance/links'
+
+export const useSideBarNagging = (
+  nodeLicenseStatus:
+    | GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus
+    | undefined,
+): CosSideBarProps['naggingProps'] => {
+  const navigation = useNavigate()
+
+  const invalidMessageList = getInvalidMessageList(nodeLicenseStatus)
+
+  if (invalidMessageList.length === 0) {
+    return undefined
+  }
+
+  return {
+    type: 'error',
+    title: invalidMessageList[0],
+    link: {
+      text: 'Go to License',
+      onClick: () => {
+        navigation(links.license)
+      },
+    },
+  }
+}

--- a/packages/cube-frontend-web-app/src/layout/useSidebarBottomLinks.ts
+++ b/packages/cube-frontend-web-app/src/layout/useSidebarBottomLinks.ts
@@ -1,6 +1,7 @@
 import { useContext } from 'react'
 import { SideBarBottomLinkProps } from '@cube-frontend/ui-library'
 import { DataCenterContext } from '../context/DataCenterContext'
+import { quickStartUrl } from '../utils/help'
 
 export const useSidebarBottomLinks = (): SideBarBottomLinkProps[] => {
   const { dataCenter } = useContext(DataCenterContext)
@@ -8,9 +9,7 @@ export const useSidebarBottomLinks = (): SideBarBottomLinkProps[] => {
   const links: SideBarBottomLinkProps[] = [
     {
       text: 'Help',
-      href:
-        dataCenter?.additional.helpUrl ||
-        'https://docs.bigstack.co/docs/cubecos/quick_start/get_started',
+      href: dataCenter?.additional.helpUrl || quickStartUrl,
     },
   ]
 

--- a/packages/cube-frontend-web-app/src/pages/maintenance/MaintenanceLayout.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/MaintenanceLayout.tsx
@@ -1,12 +1,13 @@
-import { CosTabs } from '@cube-frontend/ui-library'
 import { Link, Outlet, useLocation } from 'react-router'
+import { CosTabs } from '@cube-frontend/ui-library'
 import { links } from './links'
+import { TopLicenseNagging } from './_components/TopLicenseNagging'
 
 export const MaintenanceLayout = () => {
   const location = useLocation()
-
   return (
     <div className="flex flex-col gap-y-4">
+      <TopLicenseNagging />
       <CosTabs>
         <Link to={links.supportFiles}>
           <CosTabs.Tab isActive={location.pathname === links.supportFiles}>

--- a/packages/cube-frontend-web-app/src/pages/maintenance/_components/TopLicenseNagging.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/_components/TopLicenseNagging.tsx
@@ -1,0 +1,41 @@
+import { useContext } from 'react'
+import { useLocation } from 'react-router'
+import { isNil } from 'lodash'
+import { CosNagging } from '@cube-frontend/ui-library'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { quickStartUrl } from '@cube-frontend/web-app/utils/help'
+import { getInvalidMessageList } from '@cube-frontend/web-app/utils/license'
+import { useTopLicenseNaggingStore } from '@cube-frontend/web-app/stores/topLicenseNaggingStore'
+import { links } from '../links'
+
+export const TopLicenseNagging = () => {
+  const { pathname } = useLocation()
+  const { dataCenter } = useContext(DataCenterContext)
+  const { isClosed, closeTopLicenseNagging } = useTopLicenseNaggingStore()
+
+  if (pathname !== links.license || isClosed || isNil(dataCenter)) {
+    return null
+  }
+
+  const { additional } = dataCenter
+  const errorMessageList = getInvalidMessageList(additional.nodeLicenseStatus)
+
+  if (errorMessageList.length === 0) {
+    return null
+  }
+
+  return (
+    <CosNagging
+      className="w-full"
+      variant="top"
+      type="error"
+      title="We have detected some issues with your license"
+      description={errorMessageList}
+      link={{
+        text: 'Go to Help',
+        href: additional.helpUrl || quickStartUrl,
+      }}
+      onClose={closeTopLicenseNagging}
+    />
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/MaintenanceLicensePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/MaintenanceLicensePage.tsx
@@ -1,3 +1,15 @@
+import { useTopLicenseNaggingStore } from '@cube-frontend/web-app/stores/topLicenseNaggingStore'
+import { useEffect } from 'react'
+
 export const MaintenanceLicensePage = () => {
+  const { restoreDefault: restoreTopLicenseNaggingStore } =
+    useTopLicenseNaggingStore()
+
+  useEffect(() => {
+    return () => {
+      restoreTopLicenseNaggingStore()
+    }
+  }, [restoreTopLicenseNaggingStore])
+
   return <div>License Page</div>
 }

--- a/packages/cube-frontend-web-app/src/stores/topLicenseNaggingStore.ts
+++ b/packages/cube-frontend-web-app/src/stores/topLicenseNaggingStore.ts
@@ -1,0 +1,22 @@
+import { create } from 'zustand'
+
+type TopLicenseNaggingStore = {
+  isClosed: boolean
+}
+
+type TopLicenseNaggingStoreActions = {
+  closeTopLicenseNagging: () => void
+  restoreDefault: () => void
+}
+
+const defaultState: TopLicenseNaggingStore = {
+  isClosed: false,
+}
+
+export const useTopLicenseNaggingStore = create<
+  TopLicenseNaggingStore & TopLicenseNaggingStoreActions
+>((set) => ({
+  isClosed: false,
+  closeTopLicenseNagging: () => set({ isClosed: true }),
+  restoreDefault: () => set(defaultState),
+}))

--- a/packages/cube-frontend-web-app/src/utils/help.ts
+++ b/packages/cube-frontend-web-app/src/utils/help.ts
@@ -1,0 +1,2 @@
+export const quickStartUrl =
+  'https://docs.bigstack.co/docs/cubecos/quick_start/get_started'

--- a/packages/cube-frontend-web-app/src/utils/license.ts
+++ b/packages/cube-frontend-web-app/src/utils/license.ts
@@ -1,0 +1,46 @@
+import { GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus } from '@cube-frontend/api'
+import { toPluralizeDisplay } from '@cube-frontend/utils'
+import { isNil } from 'lodash'
+
+export type InvalidLicenseMessageKey = Exclude<
+  keyof GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus,
+  'valid'
+>
+
+/**
+ * The most left item in the array has the highest priority
+ */
+export const invalidLicenseTypePriority = [
+  'unlicense',
+  'expired',
+] as const satisfies InvalidLicenseMessageKey[]
+
+export const invalidLicenseMessageMap: Record<
+  InvalidLicenseMessageKey,
+  (count: number) => string
+> = {
+  unlicense: (count) =>
+    `${toPluralizeDisplay(count, 'host')} ${toPluralizeDisplay(count, 'is')} unlicensed.`,
+  expired: (count) => `${toPluralizeDisplay(count, 'host')} license expired.`,
+}
+
+export const getInvalidMessageList = (
+  nodeLicenseStatus:
+    | GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus
+    | undefined,
+) => {
+  const errorMessageList: string[] = []
+  if (isNil(nodeLicenseStatus)) {
+    return errorMessageList
+  }
+
+  for (const invalidType of invalidLicenseTypePriority) {
+    const invalidCount = nodeLicenseStatus[invalidType]
+    if (invalidCount > 0) {
+      const invalidMessage = invalidLicenseMessageMap[invalidType](invalidCount)
+      errorMessageList.push(invalidMessage)
+    }
+  }
+
+  return errorMessageList
+}


### PR DESCRIPTION
## Main Feature

Implemented SideBar and Top License Nagging

<img width="1920" alt="Screenshot 2025-04-22 at 1 54 10 PM" src="https://github.com/user-attachments/assets/cc994062-2260-4eab-83d0-32c31d673941" />

### Notes

1. The Top License Nagging only appears when the user visists License Page and can be closed by clicking the close button.
2. The SideBar License Nagging displays title according to this [priority](https://docs.google.com/spreadsheets/d/1JDzkw_Ur3tZc0uZdRU6z8AQ1GfWAh12jAgaB33zb_gc/edit?pli=1&gid=).
3. The Top License Nagging displays description order according to this [priority](https://docs.google.com/spreadsheets/d/1JDzkw_Ur3tZc0uZdRU6z8AQ1GfWAh12jAgaB33zb_gc/edit?pli=1&gid=).

## Component Changes

### Nagging

1.) Implemented the close feature for Top Nagging

<img width="1593" alt="Screenshot 2025-04-22 at 2 12 30 PM" src="https://github.com/user-attachments/assets/8fec8b7b-fc7b-4843-bb3f-8fb68bc08cac" />

2.) Implement description list for both Top and SideBar Nagging

<img width="1920" alt="Screenshot 2025-04-22 at 2 13 09 PM" src="https://github.com/user-attachments/assets/50dd6b5a-9fb2-4c2e-b0d0-bf9d9674437f" />

<img width="1120" alt="Screenshot 2025-04-22 at 2 13 37 PM" src="https://github.com/user-attachments/assets/e0c0f68a-1e95-402b-8fb4-cb5a2d178eac" />

### SideBar

1.) Displays Nagging when the parent  component passes the `naggingProps` to `CosSideBar`.

<img width="870" alt="image" src="https://github.com/user-attachments/assets/61bc5982-03d9-4ca2-aefc-9c24ed3dbc52" />

## Testing Plan

1.) ui-library: Check `Nagging` and `SideBar` components in Storybook.
2.) web-app: Mock `nodeLicenseStatus` in `DataCenterProvider.tsx`

<img width="776" alt="image" src="https://github.com/user-attachments/assets/80cacf32-5651-4da2-b813-aa2571736202" />
