### PR TITLE
267 error pages

### DIFF
--- a/packages/cube-frontend-ui-theme/src/plugins/backgroundGradientPlugin.ts
+++ b/packages/cube-frontend-ui-theme/src/plugins/backgroundGradientPlugin.ts
@@ -11,5 +11,8 @@ export const backgroundGradientPlugin: PluginCreator = ({
     '.background-scene-gradient': {
       background: theme('colors.scene.gradient'),
     },
+    '.bg-image-scene-gradient': {
+      backgroundImage: theme('colors.scene.gradient'),
+    },
   })
 }

--- a/packages/cube-frontend-web-app/package.json
+++ b/packages/cube-frontend-web-app/package.json
@@ -29,6 +29,7 @@
     "react": "catalog:",
     "react-chartjs-2": "^5.3.0",
     "react-dom": "catalog:",
+    "react-error-boundary": "^5.0.0",
     "react-router": "^7.1.5",
     "vitest": "catalog:",
     "zod": "^3.24.2",

--- a/packages/cube-frontend-web-app/src/CosRoutes.tsx
+++ b/packages/cube-frontend-web-app/src/CosRoutes.tsx
@@ -23,6 +23,7 @@ import { MaintenanceSupportFilesPage } from './pages/maintenance/supportFiles/Ma
 import { MaintenanceLicensePage } from './pages/maintenance/license/MaintenanceLicensePage'
 import { NodeListPage } from './pages/node/NodeListPage'
 import { NodeDetailsPage } from './pages/node/[name]/NodeDetailsPage'
+import { HttpErrorDisplay } from './components/ErrorDisplay/HttpErrorDisplay'
 
 // TODO: extract all links to CosRoutesEnum.
 export const CosRoutes = () => {
@@ -85,7 +86,14 @@ export const CosRoutes = () => {
         path={CosRoutesEnum.EVENTS_TRIGGERS_CREATE_PAGE}
         element={<TriggersCreatePage />}
       />
-      <Route path="*" element={<div>TODO: Not Found Page</div>} />
+      <Route
+        path="*"
+        element={
+          <div className="flex size-full items-center justify-center">
+            <HttpErrorDisplay statusCode={404} />
+          </div>
+        }
+      />
     </Routes>
   )
 }

--- a/packages/cube-frontend-web-app/src/components/ErrorDisplay/CosErrorBoundary.tsx
+++ b/packages/cube-frontend-web-app/src/components/ErrorDisplay/CosErrorBoundary.tsx
@@ -1,0 +1,49 @@
+import { AxiosError } from 'axios'
+import { ReactNode } from 'react'
+import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
+import { ClassNameValue, twMerge } from 'tailwind-merge'
+import { GeneralErrorDisplay } from './GeneralErrorDisplay'
+import { HttpErrorDisplay } from './HttpErrorDisplay'
+
+type CosErrorBoundaryProps = {
+  containerClassName?: ClassNameValue
+  children: ReactNode
+}
+
+export const CosErrorBoundary = (props: CosErrorBoundaryProps) => {
+  const { containerClassName, children } = props
+
+  const renderErrorDisplay = (fallbackProps: FallbackProps) => {
+    const { error } = fallbackProps
+
+    let errorDisplay: ReactNode
+    if (error instanceof AxiosError) {
+      errorDisplay = (
+        <HttpErrorDisplay statusCode={error.response?.status ?? 0} />
+      )
+    } else {
+      errorDisplay = <GeneralErrorDisplay />
+    }
+
+    return (
+      <div
+        className={twMerge(
+          'flex size-full items-center justify-center',
+          containerClassName,
+        )}
+      >
+        {errorDisplay}
+      </div>
+    )
+  }
+
+  const onError = (error: Error): void => {
+    console.error('Error caught by error boundary: ', error)
+  }
+
+  return (
+    <ErrorBoundary fallbackRender={renderErrorDisplay} onError={onError}>
+      {children}
+    </ErrorBoundary>
+  )
+}

--- a/packages/cube-frontend-web-app/src/components/ErrorDisplay/ErrorDisplay.tsx
+++ b/packages/cube-frontend-web-app/src/components/ErrorDisplay/ErrorDisplay.tsx
@@ -1,0 +1,36 @@
+import { CosButton } from '@cube-frontend/ui-library'
+import { useErrorBoundary } from 'react-error-boundary'
+import { twMerge } from 'tailwind-merge'
+
+type ErrorDisplayProps = {
+  title: string
+  message: string
+}
+
+export const ErrorDisplay = (props: ErrorDisplayProps) => {
+  const { title, message } = props
+
+  const { resetBoundary } = useErrorBoundary()
+
+  const onGoBackClick = (): void => {
+    history.back()
+    resetBoundary()
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-y-6">
+      <div
+        className={twMerge([
+          'h-36 font-urbanist text-[120px] font-semibold leading-[normal]',
+          'bg-clip-text text-transparent bg-image-scene-gradient',
+        ])}
+      >
+        {title}
+      </div>
+      <div className="primary-body3 w-[600px] text-center text-functional-text">
+        {message}
+      </div>
+      <CosButton onClick={onGoBackClick}>Go back</CosButton>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/components/ErrorDisplay/GeneralErrorDisplay.tsx
+++ b/packages/cube-frontend-web-app/src/components/ErrorDisplay/GeneralErrorDisplay.tsx
@@ -1,0 +1,8 @@
+import { ErrorDisplay } from './ErrorDisplay'
+
+export const GeneralErrorDisplay = () => {
+  return (
+    // TODO: i18n.
+    <ErrorDisplay title="Oops!" message="Error occurred. Try again later." />
+  )
+}

--- a/packages/cube-frontend-web-app/src/components/ErrorDisplay/HttpErrorDisplay.tsx
+++ b/packages/cube-frontend-web-app/src/components/ErrorDisplay/HttpErrorDisplay.tsx
@@ -1,0 +1,20 @@
+import { ErrorDisplay } from './ErrorDisplay'
+
+type HttpErrorDisplayProps = {
+  statusCode: number
+}
+
+// TODO: i18n.
+const messages: Partial<Record<number, string>> = {
+  403: 'Forbidden. You don’t have permission to access this page or resource.',
+  404: "Page Not Found. The page you're looking for doesn't exist or has been moved.",
+}
+
+export const HttpErrorDisplay = (props: HttpErrorDisplayProps) => {
+  const { statusCode } = props
+
+  // TODO: i18n.
+  const message = messages[statusCode] ?? 'Error occurred. Try again later.'
+
+  return <ErrorDisplay title={statusCode.toString()} message={message} />
+}

--- a/packages/cube-frontend-web-app/src/layout/Content.tsx
+++ b/packages/cube-frontend-web-app/src/layout/Content.tsx
@@ -1,5 +1,6 @@
 import { UseFloatingExternalContextProvider } from '@cube-frontend/ui-library'
 import { PropsWithChildren } from 'react'
+import { CosErrorBoundary } from '../components/ErrorDisplay/CosErrorBoundary'
 
 const containerId = 'cos-content-container'
 
@@ -14,7 +15,9 @@ const Content = (props: PropsWithChildren) => {
       <UseFloatingExternalContextProvider
         scrollableRootSelector={`#${containerId}`}
       >
-        {children}
+        {/* Page content level error boundary. This ensures sidebar and navbar
+        remain visible if an uncaught error is thrown by the page content. */}
+        <CosErrorBoundary>{children}</CosErrorBoundary>
       </UseFloatingExternalContextProvider>
     </div>
   )

--- a/packages/cube-frontend-web-app/src/main.tsx
+++ b/packages/cube-frontend-web-app/src/main.tsx
@@ -8,6 +8,7 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { BrowserRouter } from 'react-router'
 import App from './App.tsx'
+import { CosErrorBoundary } from './components/ErrorDisplay/CosErrorBoundary.tsx'
 
 dayjs.extend(duration)
 dayjs.extend(isBetween)
@@ -18,7 +19,10 @@ dayjs.extend(respectTz)
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      {/* App-level error boundary. */}
+      <CosErrorBoundary containerClassName="min-h-dvh">
+        <App />
+      </CosErrorBoundary>
     </BrowserRouter>
   </StrictMode>,
 )

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,7 +118,7 @@ importers:
         version: 8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3)
       vite-tsconfig-paths:
         specifier: ^5.1.4
-        version: 5.1.4(typescript@5.6.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2))
+        version: 5.1.4(typescript@5.6.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.7.0))
 
   packages/cube-frontend-api:
     dependencies:
@@ -357,6 +357,9 @@ importers:
       react-dom:
         specifier: 'catalog:'
         version: 19.0.0(react@19.0.0)
+      react-error-boundary:
+        specifier: ^5.0.0
+        version: 5.0.0(react@19.0.0)
       react-router:
         specifier: ^7.1.5
         version: 7.1.5(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -2939,6 +2942,11 @@ packages:
     peerDependencies:
       react: ^19.0.0
 
+  react-error-boundary@5.0.0:
+    resolution: {integrity: sha512-tnjAxG+IkpLephNcePNA7v6F/QpWLH8He65+DmedchDwg162JZqx4NmbXj0mlAYVVEd81OW7aFhmbsScYfiAFQ==}
+    peerDependencies:
+      react: '>=16.13.1'
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -5306,7 +5314,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2)):
+  eslint-module-utils@2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@2.4.2)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
@@ -5328,7 +5336,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.17.0(jiti@2.4.2)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0(eslint-plugin-import@2.31.0)(eslint@9.17.0(jiti@2.4.2)))(eslint@9.17.0(jiti@2.4.2))
+      eslint-module-utils: 2.12.0(@typescript-eslint/parser@8.19.1(eslint@9.17.0(jiti@2.4.2))(typescript@5.6.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.7.0)(eslint@9.17.0(jiti@2.4.2))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -6215,6 +6223,11 @@ snapshots:
       react: 19.0.0
       scheduler: 0.25.0
 
+  react-error-boundary@5.0.0(react@19.0.0):
+    dependencies:
+      '@babel/runtime': 7.26.0
+      react: 19.0.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -6751,7 +6764,7 @@ snapshots:
       - supports-color
       - typescript
 
-  vite-tsconfig-paths@5.1.4(typescript@5.6.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)):
+  vite-tsconfig-paths@5.1.4(typescript@5.6.3)(vite@6.0.7(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.7.0)):
     dependencies:
       debug: 4.4.0
       globrex: 0.1.2


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Implement Error Pages in web-app.

#### Which issue(s) this PR fixes

Close #267 

#### Special notes for your reviewer

As mentioned in #267:

> According to the [React official docs](https://react.dev/reference/react/Component#catching-rendering-errors-with-an-error-boundary), there's currently no way to write an error boundary as a function component. That said, the docs recommend using [react-error-boundary](https://github.com/bvaughn/react-error-boundary) rather than building our own from scratch.

So I installed `react-error-boundary` and put 2 error boundaries in web-app. One in `cube-frontend-web-app/src/main.tsx` and the other in `cube-frontend-web-app/src/layout/Content.tsx`.

1. App-level error boundary (full page):
   - <img width="1280" alt="chrome_rpYH8AYubR" src="https://github.com/user-attachments/assets/e19cad4d-85cc-454b-8733-fe0fabeba415" />
2. Page-level error boundary (replace page content):
   - <img width="1280" alt="chrome_Pg9r3J8TxW" src="https://github.com/user-attachments/assets/7e3ca983-3729-4678-bf3e-bf92a919a6b6" />
3. Not found:
   - <img width="1280" alt="chrome_SHVH9ciAtu" src="https://github.com/user-attachments/assets/ffbe8187-d059-459a-81a1-3142cab681fd" />

https://github.com/user-attachments/assets/c439793c-1424-4928-b482-d50b515f17ec
