### PR TITLE
134 header sidebar skeleton

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosHeader/CosHeader.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosHeader/CosHeader.tsx
@@ -6,11 +6,11 @@ export type CosHeaderProps = QuickAccessBarProps & FunctionBarProps
 
 // TODO: implement notification and logout overflow menu.
 export const CosHeader = (props: CosHeaderProps) => {
-  const { quickAccesses, onLogout } = props
+  const { isLoading, quickAccesses, onLogout } = props
 
   return (
     <div className="relative flex h-[54px] flex-row items-center justify-end gap-x-2.5 px-5">
-      <QuickAccessBar quickAccesses={quickAccesses} />
+      <QuickAccessBar isLoading={isLoading} quickAccesses={quickAccesses} />
       <div className="h-6 w-px bg-functional-border-divider" />
       <FunctionBar onLogout={onLogout} />
       <div className="absolute bottom-0 left-0 w-full px-5">

--- a/packages/cube-frontend-ui-library/src/components/CosHeader/QuickAccessBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosHeader/QuickAccessBar.tsx
@@ -1,7 +1,13 @@
+import { range } from 'lodash'
 import { SvgComponent } from '../CosIcon/CosIcon'
 import { CosButton } from '../CosButton/CosButton'
+import { CosSkeleton } from '../CosSkeleton/CosSkeleton'
 
 export type QuickAccessBarProps = {
+  /**
+   * @default false
+   */
+  isLoading?: boolean
   quickAccesses: {
     Icon: SvgComponent
     href: string
@@ -9,20 +15,29 @@ export type QuickAccessBarProps = {
 }
 
 export const QuickAccessBar = (props: QuickAccessBarProps) => {
-  const { quickAccesses } = props
+  const { isLoading = false, quickAccesses } = props
+
+  const renderQuickAccesses = () => {
+    if (isLoading) {
+      return range(0, 4).map((_, index) => (
+        <span className="p-2">
+          <CosSkeleton key={index} className="size-[18px]" />
+        </span>
+      ))
+    }
+    return quickAccesses.map((quickAccess, index) => (
+      <a key={index} href={quickAccess.href} target="_blank">
+        <CosButton
+          size="md"
+          type="ghost"
+          usage="icon-only"
+          Icon={quickAccess.Icon}
+        />
+      </a>
+    ))
+  }
 
   return (
-    <div className="flex flex-row items-center">
-      {quickAccesses.map((quickAccess, index) => (
-        <a key={index} href={quickAccess.href} target="_blank">
-          <CosButton
-            size="md"
-            type="ghost"
-            usage="icon-only"
-            Icon={quickAccess.Icon}
-          />
-        </a>
-      ))}
-    </div>
+    <div className="flex flex-row items-center">{renderQuickAccesses()}</div>
   )
 }

--- a/packages/cube-frontend-ui-library/src/components/CosHeader/QuickAccessBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosHeader/QuickAccessBar.tsx
@@ -20,8 +20,8 @@ export const QuickAccessBar = (props: QuickAccessBarProps) => {
   const renderQuickAccesses = () => {
     if (isLoading) {
       return range(0, 4).map((_, index) => (
-        <span className="p-2">
-          <CosSkeleton key={index} className="size-[18px]" />
+        <span className="p-2" key={index}>
+          <CosSkeleton className="size-[18px]" />
         </span>
       ))
     }

--- a/packages/cube-frontend-ui-library/src/components/CosSideBar/CosSideBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSideBar/CosSideBar.tsx
@@ -9,7 +9,8 @@ export type CosSideBarProps = SideBarTitleProps &
   SideBarBottomProps
 
 export const CosSideBar = (props: CosSideBarProps) => {
-  const { LogoContainer, dataCenter, username, options, links } = props
+  const { LogoContainer, isLoading, dataCenter, username, options, links } =
+    props
 
   return (
     <div
@@ -17,7 +18,11 @@ export const CosSideBar = (props: CosSideBarProps) => {
       style={{ boxShadow: '0px 0px 2px 0px rgba(0, 0, 0, 0.20)' }}
     >
       <SideBarTitle LogoContainer={LogoContainer} />
-      <SideBarUserInfo dataCenter={dataCenter} username={username} />
+      <SideBarUserInfo
+        isLoading={isLoading}
+        dataCenter={dataCenter}
+        username={username}
+      />
       <SideBarCombobox options={options} />
       <SideBarBottom links={links} />
     </div>

--- a/packages/cube-frontend-ui-library/src/components/CosSideBar/SideBarUserInfo.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSideBar/SideBarUserInfo.tsx
@@ -1,28 +1,60 @@
+import { CosSkeleton } from '../CosSkeleton/CosSkeleton'
 import { SideBarBlock } from './SideBarBlock'
 import { UserNameTag } from './UserNameTag'
 
 export type SideBarUserInfoProps = {
-  dataCenter: {
-    name: string
-    version: string
-  }
-  username: string
+  /**
+   * @default false
+   */
+  isLoading?: boolean
+  dataCenter:
+    | {
+        name: string
+        version: string
+      }
+    | undefined
+  username: string | undefined
 }
 
 const SideBarUserInfo = (props: SideBarUserInfoProps) => {
-  const { dataCenter, username } = props
+  const { isLoading = false, dataCenter, username } = props
+
+  const renderDataCenter = () => {
+    if (isLoading) {
+      return <CosSkeleton className="h-[18px] w-[38px]" />
+    }
+    return (
+      <span className="secondary-body2 font-medium text-functional-text">
+        {dataCenter?.name || '-'}
+      </span>
+    )
+  }
+
+  const renderUserName = () => {
+    if (isLoading) {
+      return <CosSkeleton className="h-[18px] w-[42px]" />
+    }
+    return <UserNameTag>{username || '-'}</UserNameTag>
+  }
+
+  const renderVersion = () => {
+    if (isLoading) {
+      return <CosSkeleton className="h-[16px] w-[156px]" />
+    }
+    return (
+      <span className="primary-body4 font-medium text-functional-text">
+        {dataCenter?.version || '-'}
+      </span>
+    )
+  }
 
   return (
     <SideBarBlock className="flex flex-col gap-y-3 px-[22px] py-4">
       <div className="flex items-center justify-between">
-        <span className="secondary-body2 font-medium text-functional-text">
-          {dataCenter.name}
-        </span>
-        <UserNameTag>{username}</UserNameTag>
+        {renderDataCenter()}
+        {renderUserName()}
       </div>
-      <span className="primary-body4 font-medium text-functional-text">
-        {dataCenter.version}
-      </span>
+      {renderVersion()}
     </SideBarBlock>
   )
 }

--- a/packages/cube-frontend-ui-library/src/stories/components/CosHeader/CosHeader.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosHeader/CosHeader.stories.tsx
@@ -37,6 +37,7 @@ export const Group: Story = {
     return (
       <StoryLayout title="Header - Group" useSceneBgColor={false}>
         <CosHeader {...props} />
+        <CosHeader {...props} isLoading={true} />
       </StoryLayout>
     )
   },

--- a/packages/cube-frontend-ui-library/src/stories/components/CosSideBar/CosSideBar.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosSideBar/CosSideBar.stories.tsx
@@ -84,7 +84,10 @@ export const Group: Story = {
   render: (props) => {
     return (
       <StoryLayout title="Sidebar - Group" useSceneBgColor={true}>
-        <CosSideBar {...props} />
+        <div className="flex gap-10">
+          <CosSideBar {...props} />
+          <CosSideBar {...props} isLoading={true} />
+        </div>
       </StoryLayout>
     )
   },

--- a/packages/cube-frontend-web-app/src/components/TimeRangeDropdown/useTimeRange.ts
+++ b/packages/cube-frontend-web-app/src/components/TimeRangeDropdown/useTimeRange.ts
@@ -24,11 +24,11 @@ export const useTimeRange = <T extends readonly TimeRange[]>(
 ): UseTimeRange<T> => {
   const { includes, defaultValue } = option
 
-  const { utcTimeZone } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const getNow = useCallback(() => {
-    return dayjs.utc().utcOffset(utcTimeZone)
-  }, [utcTimeZone])
+    return dayjs.utc().utcOffset(dataCenter!.utcTimeZone)
+  }, [dataCenter])
 
   const [timeRange, setTimeRange] = useState<TimeRange>(defaultValue)
 

--- a/packages/cube-frontend-web-app/src/components/TimeRangeDropdown/useTimeRange.ts
+++ b/packages/cube-frontend-web-app/src/components/TimeRangeDropdown/useTimeRange.ts
@@ -19,6 +19,10 @@ export type UseTimeRange<T extends readonly TimeRange[]> = {
   onTimeRangeChange: (newTimeRange: T[number]) => void
 }
 
+/**
+ * This hook has a dependency on the data center.
+ * Do not use it outside of `<Content>`.
+ */
 export const useTimeRange = <T extends readonly TimeRange[]>(
   option: UseTimeRangeOption<T>,
 ): UseTimeRange<T> => {

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/CreateTunings.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/CreateTunings.tsx
@@ -26,19 +26,19 @@ type CreateTuningsProps = {
 export const CreateTunings = (props: CreateTuningsProps) => {
   const { errorMessage, onPublishClick } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data: specs } = useCosGetRequest(
     tuningsApi.listTuningSpecs,
     (): TuningsApiListTuningSpecsRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 
   const { data: listNodesResponse } = useCosGetRequest(
     nodesApi.getNodes,
     (): NodesApiGetNodesRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/EditTunings.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/EditTunings.tsx
@@ -27,19 +27,19 @@ type EditTuningsProps = {
 export const EditTunings = (props: EditTuningsProps) => {
   const { defaultData, errorMessage, onPublishClick } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data: specs } = useCosGetRequest(
     tuningsApi.listTuningSpecs,
     (): TuningsApiListTuningSpecsRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 
   const { data: listNodesResponse } = useCosGetRequest(
     nodesApi.getNodes,
     (): NodesApiGetNodesRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 

--- a/packages/cube-frontend-web-app/src/context/DataCenterContext.ts
+++ b/packages/cube-frontend-web-app/src/context/DataCenterContext.ts
@@ -1,6 +1,12 @@
-import { GetDataCentersResponseDataInner } from '@cube-frontend/api'
 import { createContext } from 'react'
+import { GetDataCentersResponseDataInner } from '@cube-frontend/api'
 
-export const DataCenterContext = createContext<GetDataCentersResponseDataInner>(
-  null as unknown as GetDataCentersResponseDataInner,
-)
+type DataCenterContextValue = {
+  dataCenter: GetDataCentersResponseDataInner | undefined
+  isLoading: boolean
+}
+
+export const DataCenterContext = createContext<DataCenterContextValue>({
+  dataCenter: undefined,
+  isLoading: false,
+})

--- a/packages/cube-frontend-web-app/src/context/DataCenterProvider.tsx
+++ b/packages/cube-frontend-web-app/src/context/DataCenterProvider.tsx
@@ -10,17 +10,14 @@ export const DataCenterProvider = (props: PropsWithChildren) => {
     dataCentersApi.getDataCenters,
   )
 
-  if (isLoading || !dataCenters) {
-    return null
-  }
+  const dataCenter = dataCenters?.[0]
 
-  const dataCenter = dataCenters[0]
-  if (!dataCenter) {
-    return null
+  if (!isLoading && !dataCenter) {
+    throw new Error('A data center is required.')
   }
 
   return (
-    <DataCenterContext.Provider value={dataCenter}>
+    <DataCenterContext.Provider value={{ dataCenter, isLoading }}>
       {children}
     </DataCenterContext.Provider>
   )

--- a/packages/cube-frontend-web-app/src/context/IntegrationsContext.ts
+++ b/packages/cube-frontend-web-app/src/context/IntegrationsContext.ts
@@ -1,6 +1,12 @@
-import { GetIntegrationsResponse } from '@cube-frontend/api'
 import { createContext } from 'react'
+import { GetIntegrationsResponse } from '@cube-frontend/api'
 
-export const IntegrationsContext = createContext<
-  GetIntegrationsResponse['data']
->([])
+type IntegrationsContextValue = {
+  integrations: GetIntegrationsResponse['data']
+  isLoading: boolean
+}
+
+export const IntegrationsContext = createContext<IntegrationsContextValue>({
+  integrations: [],
+  isLoading: false,
+})

--- a/packages/cube-frontend-web-app/src/context/IntegrationsContextProvider.tsx
+++ b/packages/cube-frontend-web-app/src/context/IntegrationsContextProvider.tsx
@@ -11,7 +11,7 @@ export const IntegrationsContextProvider = (props: PropsWithChildren) => {
   const { dataCenter, isLoading: isDataCenterLoading } =
     useContext(DataCenterContext)
 
-  const { data: integrations, isLoading: isIntegrationsLoading } =
+  const { data: integrations = [], isLoading: isIntegrationsLoading } =
     useCosGetRequest(integrationsApi.getIntegrations, () => {
       if (!dataCenter) {
         return null
@@ -25,7 +25,7 @@ export const IntegrationsContextProvider = (props: PropsWithChildren) => {
   return (
     <IntegrationsContext.Provider
       value={{
-        integrations: integrations || [],
+        integrations,
         isLoading: isDataCenterLoading || isIntegrationsLoading,
       }}
     >

--- a/packages/cube-frontend-web-app/src/context/IntegrationsContextProvider.tsx
+++ b/packages/cube-frontend-web-app/src/context/IntegrationsContextProvider.tsx
@@ -8,25 +8,27 @@ import { IntegrationsApiGetIntegrationsRequest } from '@cube-frontend/api'
 export const IntegrationsContextProvider = (props: PropsWithChildren) => {
   const { children } = props
 
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter, isLoading: isDataCenterLoading } =
+    useContext(DataCenterContext)
 
-  const { data: integrations, isLoading } = useCosGetRequest(
-    integrationsApi.getIntegrations,
-    () => {
-      if (!dataCenter.name) return null
+  const { data: integrations, isLoading: isIntegrationsLoading } =
+    useCosGetRequest(integrationsApi.getIntegrations, () => {
+      if (!dataCenter) {
+        return null
+      }
       const req: IntegrationsApiGetIntegrationsRequest = {
         dataCenter: dataCenter.name,
       }
       return req
-    },
-  )
-
-  if (isLoading || !integrations) {
-    return null
-  }
+    })
 
   return (
-    <IntegrationsContext.Provider value={integrations}>
+    <IntegrationsContext.Provider
+      value={{
+        integrations: integrations || [],
+        isLoading: isDataCenterLoading || isIntegrationsLoading,
+      }}
+    >
       {children}
     </IntegrationsContext.Provider>
   )

--- a/packages/cube-frontend-web-app/src/context/UserContext.ts
+++ b/packages/cube-frontend-web-app/src/context/UserContext.ts
@@ -1,4 +1,12 @@
-import { GetMeResponseData } from '@cube-frontend/api'
 import { createContext } from 'react'
+import { GetMeResponseData } from '@cube-frontend/api'
 
-export const UserContext = createContext(null as unknown as GetMeResponseData)
+type UserContextValue = {
+  userInfo: GetMeResponseData | undefined
+  isLoading: boolean
+}
+
+export const UserContext = createContext<UserContextValue>({
+  userInfo: undefined,
+  isLoading: false,
+})

--- a/packages/cube-frontend-web-app/src/context/UserContextProvider.tsx
+++ b/packages/cube-frontend-web-app/src/context/UserContextProvider.tsx
@@ -8,12 +8,15 @@ import { UserInfoApiGetMeRequest } from '@cube-frontend/api'
 export const UserContextProvider = (props: PropsWithChildren) => {
   const { children } = props
 
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter, isLoading: isDataCenterLoading } =
+    useContext(DataCenterContext)
 
-  const { data: userInfo, isLoading } = useCosGetRequest(
+  const { data: userInfo, isLoading: isUserInfoLoading } = useCosGetRequest(
     userInfoApi.getMe,
     () => {
-      if (!dataCenter.name) return null
+      if (!dataCenter) {
+        return null
+      }
       const req: UserInfoApiGetMeRequest = {
         dataCenter: dataCenter.name,
       }
@@ -21,11 +24,11 @@ export const UserContextProvider = (props: PropsWithChildren) => {
     },
   )
 
-  if (isLoading || !userInfo) {
-    return null
-  }
+  const isLoading = isDataCenterLoading || isUserInfoLoading
 
   return (
-    <UserContext.Provider value={userInfo}>{children}</UserContext.Provider>
+    <UserContext.Provider value={{ userInfo, isLoading }}>
+      {children}
+    </UserContext.Provider>
   )
 }

--- a/packages/cube-frontend-web-app/src/hooks/events/useEventsFilter.ts
+++ b/packages/cube-frontend-web-app/src/hooks/events/useEventsFilter.ts
@@ -22,13 +22,13 @@ export type UseEventsFilter = {
 }
 
 export const useEventsFilter = (): UseEventsFilter => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data, isLoading } = useCosGetRequest(
     eventsApi.getEventFilterConditions,
     () => {
       return {
-        dataCenter: dataCenter,
+        dataCenter: dataCenter!.name,
       } satisfies EventsApiGetEventFilterConditionsRequest
     },
   )

--- a/packages/cube-frontend-web-app/src/hooks/useServices/useServices.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useServices/useServices.ts
@@ -21,13 +21,13 @@ export type ModuleMetadata = {
 }
 
 export const useServices = (): UseServices => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data: services = [], isLoading } = useCosGetRequest(
     servicesApi.getServices,
     () =>
       ({
-        dataCenter,
+        dataCenter: dataCenter!.name,
       }) satisfies ServicesApiGetServicesRequest,
   )
 

--- a/packages/cube-frontend-web-app/src/hooks/useShowErrorToast/useShowErrorToast.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useShowErrorToast/useShowErrorToast.ts
@@ -7,6 +7,10 @@ import { useContext } from 'react'
 
 type UseShowErrorToast = (error: unknown) => void
 
+/**
+ * This hook has a dependency on the data center.
+ * Do not use it outside of `<Content>`.
+ */
 export const useShowErrorToast = (): UseShowErrorToast => {
   const { addToast, removeToast } = useToast()
 

--- a/packages/cube-frontend-web-app/src/hooks/useShowErrorToast/useShowErrorToast.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useShowErrorToast/useShowErrorToast.ts
@@ -10,7 +10,7 @@ type UseShowErrorToast = (error: unknown) => void
 export const useShowErrorToast = (): UseShowErrorToast => {
   const { addToast, removeToast } = useToast()
 
-  const { utcTimeZone } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const showErrorToast = (error: unknown): void => {
     const errorMessage =
@@ -19,7 +19,7 @@ export const useShowErrorToast = (): UseShowErrorToast => {
       'Unknown error occurred, please try again.'
 
     const toastId = uniqueId('error-toast')
-    const now = dayjs.utc().utcOffset(utcTimeZone)
+    const now = dayjs.utc().utcOffset(dataCenter!.utcTimeZone)
 
     addToast({
       id: toastId,

--- a/packages/cube-frontend-web-app/src/layout/Layout.tsx
+++ b/packages/cube-frontend-web-app/src/layout/Layout.tsx
@@ -1,16 +1,16 @@
+import { PropsWithChildren, useContext } from 'react'
+import { Link } from 'react-router'
 import { CosHeader, CosSideBar } from '@cube-frontend/ui-library'
 import CephIcon from '@cube-frontend/ui-library/icons/colored/ceph.svg?react'
 import KeycloakIcon from '@cube-frontend/ui-library/icons/colored/keyclock.svg?react'
 import OpenStackIcon from '@cube-frontend/ui-library/icons/colored/openstack.svg?react'
 import RancherIcon from '@cube-frontend/ui-library/icons/colored/rancher.svg?react'
-import { PropsWithChildren, useContext } from 'react'
 import { logoutApi } from '../api/cosApi'
 import { DataCenterContext } from '../context/DataCenterContext'
 import { IntegrationsContext } from '../context/IntegrationsContext'
 import { UserContext } from '../context/UserContext'
 import Content from './Content'
 import { useSidebarOptions } from './useSidebarOptions'
-import { Link } from 'react-router'
 import { useSidebarBottomLinks } from './useSidebarBottomLinks'
 
 const integrationIcons = {
@@ -31,9 +31,13 @@ const Layout = (props: PropsWithChildren) => {
     logoutApi.logout()
   }
 
-  const dataCenter = useContext(DataCenterContext)
-  const user = useContext(UserContext)
-  const integrations = useContext(IntegrationsContext)
+  const { dataCenter, isLoading: isDataCenterLoading } =
+    useContext(DataCenterContext)
+
+  const { userInfo, isLoading: isUserInfoLoading } = useContext(UserContext)
+
+  const { integrations, isLoading: isIntegrationsLoading } =
+    useContext(IntegrationsContext)
 
   const quickAccesses = integrations.map((integration) => {
     const Icon =
@@ -49,14 +53,23 @@ const Layout = (props: PropsWithChildren) => {
       <div className="flex h-svh flex-row">
         <CosSideBar
           LogoContainer={<Link to="/home"></Link>}
+          isLoading={isDataCenterLoading || isUserInfoLoading}
           dataCenter={dataCenter}
-          username={user.name}
+          username={userInfo?.name}
           options={sideBarOptions}
           links={sideBarBottomLinks}
         />
         <div className="max-w-[calc(100svw_-_200px)] flex-1">
-          <CosHeader quickAccesses={quickAccesses} onLogout={handleLogout} />
-          <Content>{children}</Content>
+          <CosHeader
+            isLoading={isIntegrationsLoading}
+            quickAccesses={quickAccesses}
+            onLogout={handleLogout}
+          />
+          {/**
+           * Only render <Content> when `dataCenter` is available,
+           * ensuring it always has access to a valid `dataCenter` value.
+           */}
+          {dataCenter && <Content>{children}</Content>}
         </div>
       </div>
     </div>

--- a/packages/cube-frontend-web-app/src/layout/useSidebarBottomLinks.ts
+++ b/packages/cube-frontend-web-app/src/layout/useSidebarBottomLinks.ts
@@ -1,15 +1,15 @@
-import { SideBarBottomLinkProps } from '@cube-frontend/ui-library'
 import { useContext } from 'react'
+import { SideBarBottomLinkProps } from '@cube-frontend/ui-library'
 import { DataCenterContext } from '../context/DataCenterContext'
 
 export const useSidebarBottomLinks = (): SideBarBottomLinkProps[] => {
-  const { additional } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const links: SideBarBottomLinkProps[] = [
     {
       text: 'Help',
       href:
-        additional.helpUrl ||
+        dataCenter?.additional.helpUrl ||
         'https://docs.bigstack.co/docs/cubecos/quick_start/get_started',
     },
   ]

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/useRankedEvents.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/useRankedEvents.ts
@@ -58,22 +58,20 @@ export const useRankedEvents = (
 ): UseRankedEvents => {
   const { eventsType, chartType, past } = options
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { getCurrentQuery } = useEventsChartQuery()
 
   const { data, isLoading } = useCosGetRequest(
     eventsApi.getRankedEvents,
     () => {
-      if (!dataCenter) return null
-
       const { eventsFilter } = getCurrentQuery(chartType)
 
       const requestParams = mapFilterToRequestParams(chartType, eventsFilter)
 
       return {
         ...requestParams,
-        dataCenter,
+        dataCenter: dataCenter!.name,
         type: eventsType,
         limit: 24,
         past,

--- a/packages/cube-frontend-web-app/src/pages/events/index/_components/EventsTable/useEvents.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/index/_components/EventsTable/useEvents.ts
@@ -42,7 +42,7 @@ export const useEvents = (options: UseEventsOptions): UseEvents => {
     DEFAULT_ITEMS_PER_PAGE,
   )
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { getCurrentQuery } = useEventsQuery()
 
@@ -55,13 +55,11 @@ export const useEvents = (options: UseEventsOptions): UseEvents => {
   const { data, isLoading, getResource } = useCosGetRequest(
     eventsApi.getEvents,
     () => {
-      if (!dataCenter) return null
-
       const requestParams = mapFilterToRequestParams(currentQuery.eventsFilter)
 
       return {
         ...requestParams,
-        dataCenter: dataCenter,
+        dataCenter: dataCenter!.name,
         type: eventsType,
         pageSize: currentPageSize,
         pageNum: currentPageNum,

--- a/packages/cube-frontend-web-app/src/pages/events/index/_components/EventsTable/useEventsFilter.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/index/_components/EventsTable/useEventsFilter.ts
@@ -22,13 +22,13 @@ export type UseEventsFilter = {
 }
 
 export const useEventsFilter = (): UseEventsFilter => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data, isLoading } = useCosGetRequest(
     eventsApi.getEventFilterConditions,
     () => {
       return {
-        dataCenter: dataCenter,
+        dataCenter: dataCenter!.name,
       } satisfies EventsApiGetEventFilterConditionsRequest
     },
   )

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/useTemplateTable.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/useTemplateTable.ts
@@ -23,7 +23,7 @@ export const useTemplateTable = (): UseTemplateTable => {
 
   const urlTemplateName = searchParams.get('name')
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   /**
    * When editing a trigger, the URL will include a name corresponding to the default `selectedTemplateName`.
@@ -41,9 +41,8 @@ export const useTemplateTable = (): UseTemplateTable => {
   const { isLoading, data: templatesFromApi } = useCosGetRequest(
     triggersApi.getTriggers,
     () => {
-      if (!dataCenter) return
       return {
-        dataCenter,
+        dataCenter: dataCenter!.name,
       }
     },
   )

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/useUpdateTrigger.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/useUpdateTrigger.ts
@@ -33,7 +33,7 @@ export const useUpdateTrigger = (
 
   const navigate = useNavigate()
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const {
     isLoading: isUpdating,
@@ -49,11 +49,6 @@ export const useUpdateTrigger = (
   const handleTriggerUpdate = async () => {
     clearError()
 
-    if (!dataCenter) {
-      console.warn('No valid data center.')
-      return
-    }
-
     if (!selectedTemplate) {
       console.warn('Please select a trigger template.')
       return
@@ -66,7 +61,7 @@ export const useUpdateTrigger = (
 
     try {
       await updateTrigger({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         triggerName: selectedTemplate.name,
         updateTriggerRequest: formValueToRequest(formValue),
       })

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/useTriggerRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/useTriggerRows.ts
@@ -26,7 +26,7 @@ export const useTriggerRows = (
 
   const navigate = useNavigate()
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [rows, setRows] = useState<TriggerRow[]>([])
 
@@ -37,7 +37,7 @@ export const useTriggerRows = (
   } = useCosGetRequest(
     triggersApi.getTriggers,
     (): TriggersApiGetTriggersRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 
@@ -87,7 +87,7 @@ export const useTriggerRows = (
 
     try {
       await triggersApi.enableOrDisableTrigger({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         triggerName,
         enableOrDisableTriggerRequest: {
           enable: newEnabled,

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/HostDropdown.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/HostDropdown.tsx
@@ -18,14 +18,14 @@ export const HostDropdown = (props: HostDropdownProps) => {
     onAllCheckChange: onAllCheckChangeProp,
   } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [searchValue, setSearchValue] = useState('')
 
   const { isLoading, data: getNodesData } = useCosGetRequest(
     nodesApi.getNodes,
     (): NodesApiGetNodesRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/create/CreateTuningsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/create/CreateTuningsPage.tsx
@@ -13,7 +13,7 @@ import { Link, useNavigate } from 'react-router'
 export const CreateTuningsPage = () => {
   const navigate = useNavigate()
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const {
     mutateResource: updateTuning,
@@ -30,7 +30,7 @@ export const CreateTuningsPage = () => {
     clearError()
     try {
       await updateTuning({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         parameterName: selectedSpecName,
         updateTuningRequest: {
           value,

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/edit/EditTuningsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/edit/EditTuningsPage.tsx
@@ -16,7 +16,7 @@ export const EditTuningsPage = () => {
 
   const defaultData = useEditTuningsStore((store) => store.defaultData)
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const {
     mutateResource: updateTuning,
@@ -33,7 +33,7 @@ export const EditTuningsPage = () => {
     clearError()
     try {
       await updateTuning({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         parameterName: selectedSpecName,
         updateTuningRequest: {
           value,

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/useTuningRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/useTuningRows.ts
@@ -21,7 +21,7 @@ export const useTuningRows = (
   query: ListTuningsQuery,
   onOperationErrorOccur: (errorMessage: string) => void,
 ): UseTuningRows => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [rows, setRows] = useState<TuningRow[]>([])
 
@@ -32,7 +32,7 @@ export const useTuningRows = (
   } = useCosGetRequest(
     tuningsApi.listTunings,
     (): TuningsApiListTuningsRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
       host: query.hosts,
       keyword: query.keyword,
       modified: query.selectedModified[0],
@@ -92,7 +92,7 @@ export const useTuningRows = (
 
     try {
       await tuningsApi.enableOrDisableTuning({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         parameterName: row.name,
         enableOrDisableTuningRequest: {
           enable: enabled,
@@ -130,7 +130,7 @@ export const useTuningRows = (
 
     try {
       await tuningsApi.resetTuning({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         parameterName: row.name,
         resetTuningRequest: {
           hosts: row.hosts.map((host) => host.name),

--- a/packages/cube-frontend-web-app/src/pages/home/chart/HomeChartPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/HomeChartPage.tsx
@@ -13,7 +13,7 @@ import { defaultMetrics } from '../overview/_components/ChartPanel/utils'
 import { CHART_PAGE_POLLING_INTERVAL } from './_components/utils'
 
 export const HomeChartPage = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const {
     data: metrics = defaultMetrics,
@@ -22,7 +22,7 @@ export const HomeChartPage = () => {
     getResource: getMetrics,
   } = useCosGetRequest(metricsApi.getMetricsOverview, () => {
     return {
-      dataCenter: dataCenter.name,
+      dataCenter: dataCenter!.name,
     } satisfies MetricsApiGetMetricsOverviewRequest
   })
 

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/ExtraInformationPanel/ExtraInformationPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/ExtraInformationPanel/ExtraInformationPanel.tsx
@@ -9,19 +9,19 @@ import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/use
 import { useContext } from 'react'
 
 export const ExtraInformationPanel = () => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data: networkGrafanaLinkResponse } = useCosGetRequest(
     grafanaApi.getGrafanaNetworks,
     (): GrafanaApiGetGrafanaNetworksRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 
   const { data: deviceGrafanaLinkResponse } = useCosGetRequest(
     grafanaApi.getGrafanaNetworkDevices,
     (): GrafanaApiGetGrafanaNetworkDevicesRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/RankingPanels/HostRankingPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/RankingPanels/HostRankingPanel.tsx
@@ -45,7 +45,7 @@ const hostRankingOptions = [
 ] satisfies HostRankingItem[]
 
 export const HostRankingPanel = () => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [selectedItems, setSelectedItems] = useState<HostRankingItem[]>([
     hostRankingOptions[0],
@@ -80,7 +80,7 @@ export const HostRankingPanel = () => {
   const { data: grafanaLinkResponse } = useCosGetRequest(
     grafanaApi.getGrafanaTopHosts,
     (): GrafanaApiGetGrafanaTopHostsRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/RankingPanels/VmRankingPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/RankingPanels/VmRankingPanel.tsx
@@ -49,7 +49,7 @@ const vmRankingOptions = [
 ] satisfies VmRankingItem[]
 
 export const VmRankingPanel = () => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [selectedItems, setSelectedItems] = useState<VmRankingItem[]>([
     vmRankingOptions[0],
@@ -84,7 +84,7 @@ export const VmRankingPanel = () => {
   const { data: grafanaLinkResponse } = useCosGetRequest(
     grafanaApi.getGrafanaTopInstances,
     (): GrafanaApiGetGrafanaTopInstancesRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/StoragePanels/StoragePanels.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/StoragePanels/StoragePanels.tsx
@@ -10,12 +10,12 @@ import { GrafanaApiGetGrafanaStoragesRequest } from '@cube-frontend/api'
 import { computeTitleBarHyperlinkProps } from '../utils'
 
 export const StoragePanels = () => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data: grafanaLinkResponse } = useCosGetRequest(
     grafanaApi.getGrafanaStorages,
     (): GrafanaApiGetGrafanaStoragesRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/StoragePanels/useMetricsParams.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/StoragePanels/useMetricsParams.ts
@@ -6,7 +6,7 @@ import { GetParamFn } from '@cube-frontend/web-app/hooks/useCosRequest/cosReques
 import { TypeParams } from '../utils'
 
 export const useMetricsParams = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const currentTime = useRef(dayjs())
 
@@ -22,7 +22,7 @@ export const useMetricsParams = () => {
   ): GetParamFn<MetricsApiGetMetricByTypesRequest> => {
     return () => {
       return {
-        dataCenter: dataCenter.name,
+        dataCenter: dataCenter!.name,
         ...getTimeRangeParams(),
         ...typeParams,
       } satisfies MetricsApiGetMetricByTypesRequest

--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanelHeader.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanelHeader.tsx
@@ -24,7 +24,7 @@ export const HealthHistoryPanelHeader = (
   const { module, selectedTimeRange, onTimeRangeChange, onToggleDetailPanel } =
     props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { isLoading: isCallingRepairApi, mutateResource: repairModuleHealth } =
     useCosMutationRequest(
@@ -39,7 +39,7 @@ export const HealthHistoryPanelHeader = (
     }
     try {
       await repairModuleHealth({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         serviceType: module.service,
         moduleType: module.name,
       })

--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/useModuleHealthHistory.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/useModuleHealthHistory.tsx
@@ -22,14 +22,14 @@ export const useModuleHealthHistory = (
 ): GetModuleHealthHistoryResponseDataHistoryInner[] | undefined => {
   const { module, past, autoRefresh: shouldUseStreamData } = options
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const getRequestParams = (): HealthApiGetHealthHistoryRequest | undefined => {
     if (!module) {
       return undefined
     }
     return {
-      dataCenter,
+      dataCenter: dataCenter!.name,
       serviceType: module.service,
       moduleType: module.name,
       past,

--- a/packages/cube-frontend-web-app/src/pages/home/health/_components/healthAccordion/ServiceHealth.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/_components/healthAccordion/ServiceHealth.tsx
@@ -30,7 +30,7 @@ export type ServiceHealthProps = {
 export const ServiceHealth = (props: ServiceHealthProps) => {
   const { service, timeRange, now, past } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { elementRef, isVisible } = useIsVisible<HTMLDivElement>()
 
@@ -44,7 +44,7 @@ export const ServiceHealth = (props: ServiceHealthProps) => {
           return undefined
         }
         return {
-          dataCenter,
+          dataCenter: dataCenter!.name,
           serviceType: service.name as GetServiceHealthHistoryServiceTypeEnum,
           past,
         }

--- a/packages/cube-frontend-web-app/src/pages/home/health/_components/healthCheck/HealthCheck.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/_components/healthCheck/HealthCheck.tsx
@@ -15,13 +15,13 @@ import { AvailableStatus, HealthStatusBadge } from './HealthStatusBadge'
 import { NgService } from './NgService'
 
 export const HealthCheck = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data: overallHealth, getResource: getHealths } = useCosGetRequest(
     healthApi.getHealths,
     () =>
       ({
-        dataCenter: dataCenter.name,
+        dataCenter: dataCenter!.name,
       }) satisfies HealthApiGetHealthsRequest,
   )
 
@@ -58,7 +58,7 @@ export const HealthCheck = () => {
 
   const onRepairClick = async () => {
     try {
-      await repairHealth({ dataCenter: dataCenter.name })
+      await repairHealth({ dataCenter: dataCenter!.name })
     } catch (error) {
       console.error('Repair data center health error: ', error)
     }

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/ChartPanel/ChartPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/ChartPanel/ChartPanel.tsx
@@ -19,7 +19,7 @@ import { noop } from 'lodash'
 import { Link } from 'react-router'
 
 const ChartPanel = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const {
     data: metrics = defaultMetrics,
@@ -27,7 +27,7 @@ const ChartPanel = () => {
     getResource: getMetricsOverview,
   } = useCosGetRequest(metricsApi.getMetricsOverview, () => {
     return {
-      dataCenter: dataCenter.name,
+      dataCenter: dataCenter!.name,
     } satisfies MetricsApiGetMetricsOverviewRequest
   })
 

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/EventPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/EventPanel.tsx
@@ -38,7 +38,7 @@ const mapToTableEvent = (e: ResponseEvent, index: number): TableEvent => ({
 })
 
 export const EventPanel = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [eventType, setEventType] =
     useState<GetAbstractedEventsTypeEnum>('system')
@@ -49,7 +49,7 @@ export const EventPanel = () => {
     getResource: getAbstractedEvents,
   } = useCosGetRequest(eventsApi.getAbstractedEvents, () => {
     return {
-      dataCenter: dataCenter.name,
+      dataCenter: dataCenter!.name,
       type: eventType,
       limit: HOME_PAGE_EVENT_ROW_LIMIT,
     } satisfies EventsApiGetAbstractedEventsRequest

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthPanel.tsx
@@ -20,7 +20,7 @@ import { noop } from 'lodash'
 import { Link } from 'react-router'
 
 const HealthPanel = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const {
     data: healths,
@@ -28,7 +28,7 @@ const HealthPanel = () => {
     getResource: getHealths,
   } = useCosGetRequest(healthApi.getHealths, () => {
     return {
-      dataCenter: dataCenter.name,
+      dataCenter: dataCenter!.name,
     } satisfies HealthApiGetHealthsRequest
   })
 
@@ -54,7 +54,7 @@ const HealthPanel = () => {
   const handleRepair = async () => {
     try {
       await repairHealth({
-        dataCenter: dataCenter.name,
+        dataCenter: dataCenter!.name,
       })
     } catch (error) {
       console.error('Repair data center health error: ', error)

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodePanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodePanel.tsx
@@ -14,7 +14,7 @@ import { Link } from 'react-router'
 const HOME_PAGE_NODE_ROW_LIMIT = 5
 
 export const NodePanel = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const {
     data: nodesData,
@@ -22,7 +22,7 @@ export const NodePanel = () => {
     getResource: getNodes,
   } = useCosGetRequest(nodesApi.getNodes, () => {
     return {
-      dataCenter: dataCenter.name,
+      dataCenter: dataCenter!.name,
       pageNum: 1,
       pageSize: HOME_PAGE_NODE_ROW_LIMIT,
     } satisfies NodesApiGetNodesRequest

--- a/packages/cube-frontend-web-app/src/pages/integrations/IntegrationsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/integrations/IntegrationsPage.tsx
@@ -21,11 +21,13 @@ const integrationToRow = (item: GetIntegrationsResponseDataInner) => ({
 })
 
 export const IntegrationsPage = () => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data, isLoading } = useCosGetRequest(
     integrationsApi.getIntegrations,
-    () => ({ dataCenter }),
+    () => ({
+      dataCenter: dataCenter!.name,
+    }),
   )
 
   const rows = useMemo(() => data?.map(integrationToRow) || [], [data])

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/MaintenanceSupportFilesPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/MaintenanceSupportFilesPage.tsx
@@ -27,7 +27,7 @@ import { SupportFilesTable } from './_components/SupportFilesTable'
 export type SupportFileRow = SupportFileSet & CosTableRow
 
 export const MaintenanceSupportFilesPage = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [searchKeyword, setSearchKeyword] = useState<string>('')
   const [selectedRoles, setSelectedRoles] = useState<GetNodesRolesEnum[]>([])
@@ -45,7 +45,7 @@ export const MaintenanceSupportFilesPage = () => {
     supportFilesApi.getSupportFiles,
     () => {
       return {
-        dataCenter: dataCenter.name,
+        dataCenter: dataCenter!.name,
         pageNum,
         pageSize,
         keyword: debouncedSearchKeyword,

--- a/packages/cube-frontend-web-app/src/pages/node/NodeListPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/NodeListPage.tsx
@@ -22,7 +22,7 @@ import { NodeFilters } from './_components/NodeFilters'
 import { CreateSupportFilesModal } from './_components/CreateSupportFilesModal'
 
 export const NodeListPage = () => {
-  const dataCenter = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [searchKeyword, setSearchKeyword] = useState('')
   const [selectedRoles, setSelectedRoles] = useState<GetNodesRolesEnum[]>([])
@@ -38,7 +38,7 @@ export const NodeListPage = () => {
     nodesApi.getNodes,
     () => {
       return {
-        dataCenter: dataCenter.name,
+        dataCenter: dataCenter!.name,
         pageNum,
         pageSize,
         roles: selectedRoles,
@@ -89,7 +89,7 @@ export const NodeListPage = () => {
   const handleConfirmCreateSupportFiles = async () => {
     try {
       await createSupportFiles({
-        dataCenter: dataCenter.name,
+        dataCenter: dataCenter!.name,
         createSupportFilesRequest: {
           description: comments,
           hosts: selectedNodes.map((node) => node.hostname),

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/NodeDetailsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/NodeDetailsPage.tsx
@@ -15,7 +15,7 @@ import { NodeSummary } from './_components/NodeSummary'
 export const NodeDetailsPage = () => {
   const { name: nodeName } = useParams()
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   if (!nodeName) {
     throw new Error('Cannot find node name in the URL')
@@ -28,7 +28,7 @@ export const NodeDetailsPage = () => {
   } = useCosGetRequest(
     nodesApi.getNode,
     (): NodesApiGetNodeRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
       nodeName,
     }),
   )

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/CpuPerformanceChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/CpuPerformanceChart.tsx
@@ -21,7 +21,7 @@ type CpuPerformanceChartProps = {
 export const CpuPerformanceChart = (props: CpuPerformanceChartProps) => {
   const { node } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { timeRange, onTimeRangeChange } = useTimeRange({
     includes: chartTimeRanges,
@@ -33,7 +33,7 @@ export const CpuPerformanceChart = (props: CpuPerformanceChartProps) => {
     (): MetricsApiGetMetricByHostOrVmRequest | undefined => {
       if (!node) return undefined
       return {
-        dataCenter,
+        dataCenter: dataCenter!.name,
         metricType: 'cpuUsage',
         viewType: 'history',
         entityType: 'hosts',

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/MemoryPerformanceChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/MemoryPerformanceChart.tsx
@@ -22,7 +22,7 @@ type MemoryPerformanceChartProps = {
 export const MemoryPerformanceChart = (props: MemoryPerformanceChartProps) => {
   const { node } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { timeRange, onTimeRangeChange } = useTimeRange({
     includes: chartTimeRanges,
@@ -34,7 +34,7 @@ export const MemoryPerformanceChart = (props: MemoryPerformanceChartProps) => {
     (): MetricsApiGetMetricByHostOrVmRequest | undefined => {
       if (!node) return undefined
       return {
-        dataCenter,
+        dataCenter: dataCenter!.name,
         metricType: 'memoryUsage',
         viewType: 'history',
         entityType: 'hosts',

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDetailsHeader.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDetailsHeader.tsx
@@ -20,14 +20,14 @@ const VerticalBar = () => {
 export const NodeDetailsHeader = (props: NodeDetailsHeaderProps) => {
   const { node } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data: grafanaLinkResponse } = useCosGetRequest(
     grafanaApi.getGrafanaHosts,
     (): GrafanaApiGetGrafanaHostsRequest | undefined => {
       if (!node) return undefined
       return {
-        dataCenter,
+        dataCenter: dataCenter!.name,
         hostname: node.hostname,
       }
     },

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeEvents.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeEvents.tsx
@@ -29,7 +29,7 @@ const EventTable = GetCosBasicTable<GetEventsResponseDataEventsInner>()
 export const NodeEvents = (props: NodeEventsProps) => {
   const { node } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { timeRange, onTimeRangeChange } = useTimeRange({
     includes: chartTimeRanges,
@@ -60,7 +60,7 @@ export const NodeEvents = (props: NodeEventsProps) => {
     (): EventsApiGetEventsRequest | undefined => {
       if (!node) return undefined
       return {
-        dataCenter,
+        dataCenter: dataCenter!.name,
         type: 'host',
         host: node.hostname,
         past: timeRange,

--- a/packages/cube-frontend-web-app/src/pages/settings/ManageContact.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/ManageContact.tsx
@@ -19,7 +19,7 @@ type ManageContactProps = {
 export const ManageContact = (props: ManageContactProps) => {
   const { titlePrefixFromApi } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const showErrorToast = useShowErrorToast()
 
@@ -70,7 +70,7 @@ export const ManageContact = (props: ManageContactProps) => {
         },
       }))
       updateTitlePrefixApi({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         updateTitlePrefixRequest: {
           value: titlePrefix!.value,
         },

--- a/packages/cube-frontend-web-app/src/pages/settings/SettingsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/SettingsPage.tsx
@@ -11,12 +11,12 @@ import { ManageContact } from './ManageContact'
 import { SettingsSection } from './SettingsSection'
 
 export const SettingsPage = () => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const { data: settingsData, getResource: getSettings } = useCosGetRequest(
     settingsApi.getSettings,
     (): SettingsApiGetSettingsRequest => ({
-      dataCenter,
+      dataCenter: dataCenter!.name,
     }),
   )
 

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/SlackChannels/useSlackChannelRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/SlackChannels/useSlackChannelRows.ts
@@ -24,7 +24,7 @@ type UseSlackChannelRows = {
 export const useSlackChannelRows = (
   initialChannels: SlackChannelPostRequest[] | undefined,
 ): UseSlackChannelRows => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const showErrorToast = useShowErrorToast()
 
@@ -94,7 +94,7 @@ export const useSlackChannelRows = (
       return
     }
     await trySlackChannel({
-      dataCenter,
+      dataCenter: dataCenter!.name,
       row,
       patchRow,
       onError: showErrorToast,
@@ -109,14 +109,14 @@ export const useSlackChannelRows = (
 
     if (row.isNew) {
       await createSlackChannel({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         row,
         patchRow,
         onError: showErrorToast,
       })
     } else {
       await updateSlackChannel({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         row,
         patchRow,
         onError: showErrorToast,
@@ -130,7 +130,7 @@ export const useSlackChannelRows = (
       return
     }
     await deleteSlackChannelAction({
-      dataCenter,
+      dataCenter: dataCenter!.name,
       row: targetRow,
       patchRow,
       onSuccess: () => {

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useEmailRecipientRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useEmailRecipientRows.ts
@@ -25,7 +25,7 @@ type UseEmailRecipientRows = {
 export const useEmailRecipientRows = (
   recipientsFromApi?: EmailRecipientResponse[] | undefined,
 ): UseEmailRecipientRows => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const showErrorToast = useShowErrorToast()
 
@@ -84,7 +84,7 @@ export const useEmailRecipientRows = (
     if (!row) return
 
     await tryEmailRecipient({
-      dataCenter,
+      dataCenter: dataCenter!.name,
       row,
       patchRow,
       onError: showErrorToast,
@@ -97,14 +97,14 @@ export const useEmailRecipientRows = (
 
     if (row.isNew) {
       await createEmailRecipient({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         row,
         patchRow,
         onError: showErrorToast,
       })
     } else {
       await updateEmailRecipient({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         row,
         patchRow,
         onError: showErrorToast,
@@ -117,7 +117,7 @@ export const useEmailRecipientRows = (
     if (!row) return
 
     await deleteEmailRecipientAction({
-      dataCenter,
+      dataCenter: dataCenter!.name,
       row,
       patchRow,
       onSuccess: () => {

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/VerifyEmailSenderModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/VerifyEmailSenderModal.tsx
@@ -27,7 +27,7 @@ const emailSchema = z.string().email()
 export const VerifyEmailSenderModal = (props: VerifyEmailSenderModalProps) => {
   const { isOpen, toBeVerifiedRow, onSenderVerified, onClose } = props
 
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const [sendTo, setSendTo] = useState('')
 
@@ -61,7 +61,7 @@ export const VerifyEmailSenderModal = (props: VerifyEmailSenderModalProps) => {
 
     try {
       await tryEmailSender({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         senderHost: toBeVerifiedRow.host,
         tryEmailSender: {
           email: sendTo,

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/useEmailSenderRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/useEmailSenderRows.ts
@@ -21,7 +21,7 @@ export type UseEmailSenderRows = {
 export const useEmailSenderRows = (
   sendersFromApi: EmailSenderResponse[] | undefined,
 ): UseEmailSenderRows => {
-  const { name: dataCenter } = useContext(DataCenterContext)
+  const { dataCenter } = useContext(DataCenterContext)
 
   const showErrorToast = useShowErrorToast()
 
@@ -69,14 +69,14 @@ export const useEmailSenderRows = (
 
     if (row.isNew) {
       await createEmailSender({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         row,
         patchRow,
         onError: showErrorToast,
       })
     } else {
       await updateEmailSender({
-        dataCenter,
+        dataCenter: dataCenter!.name,
         row,
         patchRow,
         onError: showErrorToast,


### PR DESCRIPTION
#### What type of PR is this?

- Feat

#### What this PR does / why we need it

1) Add a loading state to `Sidebar` and `Header` ➡️ commit [c6e9f26](https://github.com/bigstack-oss/cube-cos-ui/pull/273/commits/c6e9f26027446ff7d52958e6e8cb62ee7170014a)

<img width="1201" alt="Screenshot 2025-04-23 at 4 48 39 PM" src="https://github.com/user-attachments/assets/7570e2c2-c4f2-43e1-8954-89694483f8aa" />

<img width="1189" alt="Screenshot 2025-04-23 at 4 48 49 PM" src="https://github.com/user-attachments/assets/884ac7f1-1833-4960-9fff-93dbfe5707e7" />

2) Apply the changes in `web-app`

- Update the `dataCenter`, `user`, and `integration` contexts to pass the `isLoading` state to their child components ➡️ commit [7ab0f6c](https://github.com/bigstack-oss/cube-cos-ui/pull/273/commits/7ab0f6c94c6c75c51b459293aecb23256c9507ea)

- Update the current `dataCenter` usage to reflect the data structure changes and ensure `<Content>` receives the expected values ➡️ commit [06db670](https://github.com/bigstack-oss/cube-cos-ui/pull/273/commits/06db670a65648c4d94708e653a87fc4fc9a91205)


https://github.com/user-attachments/assets/61afdf05-77e9-4c70-83ab-687ce0834f53


#### Which issue(s) this PR fixes

Fixes #134 

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
