### PR TITLE
fix: datacenter api response 401 after change local api server env

### DIFF
--- a/packages/cube-frontend-web-app/src/api/cosApi.ts
+++ b/packages/cube-frontend-web-app/src/api/cosApi.ts
@@ -18,7 +18,10 @@ import {
   TriggersApi,
   GrafanaApi,
 } from '@cube-frontend/api'
-import devAccessTokenInterceptor from './devAccessTokenInterceptor'
+import {
+  devAccessTokenRequestInterceptor,
+  devAccessTokenErrorInterceptor,
+} from './devAccessTokenInterceptor'
 import { samlAuthErrorInterceptor } from './samlAuthErrorInterceptor'
 import { config, validateStatus } from './utils'
 
@@ -77,10 +80,11 @@ export const supportFilesApi = createApiInstance(SupportFilesApi)
 export const triggersApi = createApiInstance(TriggersApi)
 export const grafanaApi = createApiInstance(GrafanaApi)
 
-cosApi.interceptors.response.use(undefined, samlAuthErrorInterceptor)
-
 if (import.meta.env.DEV) {
-  cosApi.interceptors.request.use(devAccessTokenInterceptor)
+  cosApi.interceptors.request.use(devAccessTokenRequestInterceptor)
+  cosApi.interceptors.response.use(undefined, devAccessTokenErrorInterceptor)
+} else {
+  cosApi.interceptors.response.use(undefined, samlAuthErrorInterceptor)
 }
 
 export default cosApi

--- a/packages/cube-frontend-web-app/src/api/devAccessTokenInterceptor.ts
+++ b/packages/cube-frontend-web-app/src/api/devAccessTokenInterceptor.ts
@@ -7,14 +7,15 @@
  * using a username, password and data center to obtain an access token for
  * accessing protected APIs.
  */
-import { InternalAxiosRequestConfig } from 'axios'
+import { HttpStatusCode, InternalAxiosRequestConfig, isAxiosError } from 'axios'
 import { tokenApi } from './cosTokenApi'
 import dayjs from 'dayjs'
 
 const ACCESS_TOKEN_KEY = 'accessToken'
 const EXPIRES_KEY = 'expires'
+const DATA_CENTER_KEY = 'dataCenter'
 
-const renewToken = async () => {
+export const renewToken = async () => {
   const {
     VITE_USERNAME: name,
     VITE_PASSWORD: password,
@@ -31,6 +32,7 @@ const renewToken = async () => {
 
   localStorage.setItem(ACCESS_TOKEN_KEY, accessToken)
   localStorage.setItem(EXPIRES_KEY, accessTokenExpires)
+  localStorage.setItem(DATA_CENTER_KEY, dataCenter)
 
   return accessToken
 }
@@ -38,6 +40,11 @@ const renewToken = async () => {
 const getDevAccessToken = async (): Promise<string> => {
   const accessToken = localStorage.getItem(ACCESS_TOKEN_KEY)
   const expires = localStorage.getItem(EXPIRES_KEY)
+  const dataCenter = localStorage.getItem(DATA_CENTER_KEY)
+
+  if (dataCenter !== import.meta.env.VITE_DATA_CENTER) {
+    return renewToken()
+  }
 
   if (accessToken && expires && dayjs().isBefore(dayjs(expires))) {
     return accessToken
@@ -46,7 +53,7 @@ const getDevAccessToken = async (): Promise<string> => {
   return renewToken()
 }
 
-const devAccessTokenInterceptor = async (
+export const devAccessTokenRequestInterceptor = async (
   config: InternalAxiosRequestConfig,
 ) => {
   const devAccessToken = await getDevAccessToken()
@@ -54,4 +61,14 @@ const devAccessTokenInterceptor = async (
   return config
 }
 
-export default devAccessTokenInterceptor
+export const devAccessTokenErrorInterceptor = async (
+  error: unknown,
+): Promise<unknown> => {
+  if (
+    isAxiosError(error) &&
+    error.response?.status === HttpStatusCode.Unauthorized
+  ) {
+    await renewToken()
+  }
+  return Promise.reject(error)
+}


### PR DESCRIPTION
## Fix 401 Error after changed local api server env

## Steps to Reproduce

1. Set `VITE_API_SERVER=https://10.32.10.113:4443` in `.env.local`
2. Set `VITE_DATA_CENTER=dell13` in `.env.local`
3. Run `pnpm run web-app:dev`
4. Set `VITE_API_SERVER=https://10.32.10.150:4443` in `.env.local`
5. Set `VITE_DATA_CENTER=sky150` in `.env.local`
6. Rerun `pnpm run web-app:dev`

## Strategy

1. Renew a token when receiving a 401 response.
2. Renew a token when the `dataCenter` changes (store in localStorage).

## Test Plan & Screenshots

Please see Slack channel.