### PR TITLE
281 settings email senders from field empty bug

### DIFF
--- a/packages/cube-frontend-api/sdk/api.ts
+++ b/packages/cube-frontend-api/sdk/api.ts
@@ -383,6 +383,43 @@ export interface EmailRecipientResponse {
 /**
  * 
  * @export
+ * @interface EmailSenderPatchRequest
+ */
+export interface EmailSenderPatchRequest {
+    /**
+     * 
+     * @type {string}
+     * @memberof EmailSenderPatchRequest
+     */
+    'host'?: string;
+    /**
+     * 
+     * @type {number}
+     * @memberof EmailSenderPatchRequest
+     */
+    'port'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof EmailSenderPatchRequest
+     */
+    'username'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof EmailSenderPatchRequest
+     */
+    'password'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof EmailSenderPatchRequest
+     */
+    'from'?: string;
+}
+/**
+ * 
+ * @export
  * @interface EmailSenderPostRequest
  */
 export interface EmailSenderPostRequest {
@@ -415,44 +452,7 @@ export interface EmailSenderPostRequest {
      * @type {string}
      * @memberof EmailSenderPostRequest
      */
-    'email': string;
-}
-/**
- * 
- * @export
- * @interface EmailSenderPutRequest
- */
-export interface EmailSenderPutRequest {
-    /**
-     * 
-     * @type {string}
-     * @memberof EmailSenderPutRequest
-     */
-    'host'?: string;
-    /**
-     * 
-     * @type {number}
-     * @memberof EmailSenderPutRequest
-     */
-    'port'?: number;
-    /**
-     * 
-     * @type {string}
-     * @memberof EmailSenderPutRequest
-     */
-    'username'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof EmailSenderPutRequest
-     */
-    'password'?: string;
-    /**
-     * 
-     * @type {string}
-     * @memberof EmailSenderPutRequest
-     */
-    'email'?: string;
+    'from': string;
 }
 /**
  * 
@@ -483,7 +483,7 @@ export interface EmailSenderResponse {
      * @type {string}
      * @memberof EmailSenderResponse
      */
-    'email': string;
+    'from': string;
     /**
      * 
      * @type {boolean}
@@ -12234,17 +12234,17 @@ export const SettingsApiAxiosParamCreator = function (configuration?: Configurat
          * @summary Update an email sender
          * @param {string} dataCenter The name of the data center to operate
          * @param {string} senderHost The host of the email sender to operate
-         * @param {EmailSenderPutRequest} emailSenderPutRequest 
+         * @param {EmailSenderPatchRequest} emailSenderPatchRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        updateEmailSender: async (dataCenter: string, senderHost: string, emailSenderPutRequest: EmailSenderPutRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+        updateEmailSender: async (dataCenter: string, senderHost: string, emailSenderPatchRequest: EmailSenderPatchRequest, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
             // verify required parameter 'dataCenter' is not null or undefined
             assertParamExists('updateEmailSender', 'dataCenter', dataCenter)
             // verify required parameter 'senderHost' is not null or undefined
             assertParamExists('updateEmailSender', 'senderHost', senderHost)
-            // verify required parameter 'emailSenderPutRequest' is not null or undefined
-            assertParamExists('updateEmailSender', 'emailSenderPutRequest', emailSenderPutRequest)
+            // verify required parameter 'emailSenderPatchRequest' is not null or undefined
+            assertParamExists('updateEmailSender', 'emailSenderPatchRequest', emailSenderPatchRequest)
             const localVarPath = `/api/v1/datacenters/{dataCenter}/settings/email/senders/{senderHost}`
                 .replace(`{${"dataCenter"}}`, encodeURIComponent(String(dataCenter)))
                 .replace(`{${"senderHost"}}`, encodeURIComponent(String(senderHost)));
@@ -12266,7 +12266,7 @@ export const SettingsApiAxiosParamCreator = function (configuration?: Configurat
             setSearchParams(localVarUrlObj, localVarQueryParameter);
             let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
             localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
-            localVarRequestOptions.data = serializeDataIfNeeded(emailSenderPutRequest, localVarRequestOptions, configuration)
+            localVarRequestOptions.data = serializeDataIfNeeded(emailSenderPatchRequest, localVarRequestOptions, configuration)
 
             return {
                 url: toPathString(localVarUrlObj),
@@ -12566,12 +12566,12 @@ export const SettingsApiFp = function(configuration?: Configuration) {
          * @summary Update an email sender
          * @param {string} dataCenter The name of the data center to operate
          * @param {string} senderHost The host of the email sender to operate
-         * @param {EmailSenderPutRequest} emailSenderPutRequest 
+         * @param {EmailSenderPatchRequest} emailSenderPatchRequest 
          * @param {*} [options] Override http request option.
          * @throws {RequiredError}
          */
-        async updateEmailSender(dataCenter: string, senderHost: string, emailSenderPutRequest: EmailSenderPutRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PutEmailSenderResponse>> {
-            const localVarAxiosArgs = await localVarAxiosParamCreator.updateEmailSender(dataCenter, senderHost, emailSenderPutRequest, options);
+        async updateEmailSender(dataCenter: string, senderHost: string, emailSenderPatchRequest: EmailSenderPatchRequest, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<PutEmailSenderResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.updateEmailSender(dataCenter, senderHost, emailSenderPatchRequest, options);
             const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
             const localVarOperationServerBasePath = operationServerMap['SettingsApi.updateEmailSender']?.[localVarOperationServerIndex]?.url;
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
@@ -12763,7 +12763,7 @@ export const SettingsApiFactory = function (configuration?: Configuration, baseP
          * @throws {RequiredError}
          */
         updateEmailSender(requestParameters: SettingsApiUpdateEmailSenderRequest, options?: RawAxiosRequestConfig): AxiosPromise<PutEmailSenderResponse> {
-            return localVarFp.updateEmailSender(requestParameters.dataCenter, requestParameters.senderHost, requestParameters.emailSenderPutRequest, options).then((request) => request(axios, basePath));
+            return localVarFp.updateEmailSender(requestParameters.dataCenter, requestParameters.senderHost, requestParameters.emailSenderPatchRequest, options).then((request) => request(axios, basePath));
         },
         /**
          * 
@@ -13090,10 +13090,10 @@ export interface SettingsApiUpdateEmailSenderRequest {
 
     /**
      * 
-     * @type {EmailSenderPutRequest}
+     * @type {EmailSenderPatchRequest}
      * @memberof SettingsApiUpdateEmailSender
      */
-    readonly emailSenderPutRequest: EmailSenderPutRequest
+    readonly emailSenderPatchRequest: EmailSenderPatchRequest
 }
 
 /**
@@ -13329,7 +13329,7 @@ export class SettingsApi extends BaseAPI {
      * @memberof SettingsApi
      */
     public updateEmailSender(requestParameters: SettingsApiUpdateEmailSenderRequest, options?: RawAxiosRequestConfig) {
-        return SettingsApiFp(this.configuration).updateEmailSender(requestParameters.dataCenter, requestParameters.senderHost, requestParameters.emailSenderPutRequest, options).then((request) => request(this.axios, this.basePath));
+        return SettingsApiFp(this.configuration).updateEmailSender(requestParameters.dataCenter, requestParameters.senderHost, requestParameters.emailSenderPatchRequest, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/EmailSenders.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/EmailSenders.tsx
@@ -51,21 +51,21 @@ export const EmailSenders = (props: EmailSendersProps) => {
           is not available in phase 1. */}
       <EmailSendersHeader isAddButtonVisible={false} onAddButtonClick={noop} />
       <EmailSenderTable isLoading={isLoading} rows={rows}>
-        <EmailSenderTable.Column property="email" label="From Email">
-          {(email, row) => (
+        <EmailSenderTable.Column property="from" label="From Email">
+          {(from, row) => (
             <div className="flex items-center gap-x-2">
               {row.isEditing ? (
                 <CosTableInput
-                  name="email"
+                  name={'from' satisfies keyof EmailSenderRow}
                   type="email"
-                  value={email}
-                  errorMessage={rowsErrorMap.get(row.id)?.email}
+                  value={from}
+                  errorMessage={rowsErrorMap.get(row.id)?.from}
                   disabled={row.status.isUpdating}
                   onChange={(e) => onChange(row.id, e)}
                 />
               ) : (
                 <div className="flex items-center gap-2">
-                  {email}
+                  {from}
                   {!row.isNew && !row.accessVerified && (
                     <CosIconText type="warning">unverified</CosIconText>
                   )}
@@ -81,7 +81,7 @@ export const EmailSenders = (props: EmailSendersProps) => {
           {(host, row) =>
             row.isEditing ? (
               <CosTableInput
-                name="host"
+                name={'host' satisfies keyof EmailSenderRow}
                 value={host}
                 errorMessage={rowsErrorMap.get(row.id)?.host}
                 disabled={row.status.isUpdating}
@@ -97,7 +97,7 @@ export const EmailSenders = (props: EmailSendersProps) => {
             row.isEditing ? (
               <CosTableInput
                 className="w-16"
-                name="port"
+                name={'port' satisfies keyof EmailSenderRow}
                 value={port}
                 errorMessage={rowsErrorMap.get(row.id)?.port}
                 disabled={row.status.isUpdating}
@@ -113,7 +113,7 @@ export const EmailSenders = (props: EmailSendersProps) => {
             row.isEditing ? (
               <CosTableInput
                 className="w-24"
-                name="username"
+                name={'username' satisfies keyof EmailSenderRow}
                 value={username}
                 errorMessage={rowsErrorMap.get(row.id)?.username}
                 disabled={row.status.isUpdating}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/actions/updateEmailSender.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/actions/updateEmailSender.ts
@@ -1,6 +1,6 @@
 import { SettingStatusCurrentEnum } from '@cube-frontend/api'
 import { settingsApi } from '@cube-frontend/web-app/api/cosApi'
-import { rowToEmailSenderPutRequest } from '../emailSenderMappers'
+import { rowToEmailSenderPatchRequest } from '../emailSenderMappers'
 import { ActionOptions } from './utils'
 
 export const updateEmailSender = async (
@@ -17,13 +17,13 @@ export const updateEmailSender = async (
     },
   })
 
-  const updatedEmailSender = rowToEmailSenderPutRequest(row)
+  const updatedEmailSender = rowToEmailSenderPatchRequest(row)
 
   try {
     await settingsApi.updateEmailSender({
       dataCenter,
       senderHost: row.originalState.host,
-      emailSenderPutRequest: updatedEmailSender,
+      emailSenderPatchRequest: updatedEmailSender,
     })
     patchRow(row.id, {
       password: '',

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/emailSenderMappers.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/emailSenderMappers.ts
@@ -1,6 +1,6 @@
 import {
+  EmailSenderPatchRequest,
   EmailSenderPostRequest,
-  EmailSenderPutRequest,
   EmailSenderResponse,
 } from '@cube-frontend/api'
 import { EmailSenderForUi, EmailSenderRow, getRowId } from './emailSendersUtils'
@@ -28,17 +28,17 @@ export const emailSenderToRow = (
 export const rowToEmailSenderPostRequest = (
   row: EmailSenderRow,
 ): EmailSenderPostRequest => ({
-  email: row.email,
+  from: row.from,
   host: row.host,
   port: parseInt(row.port),
   username: row.username,
   password: row.password,
 })
 
-export const rowToEmailSenderPutRequest = (
+export const rowToEmailSenderPatchRequest = (
   row: EmailSenderRow,
-): EmailSenderPutRequest => ({
-  email: row.email,
+): EmailSenderPatchRequest => ({
+  from: row.from,
   host: row.host,
   port: parseInt(row.port),
   username: row.username,

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/emailSendersUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/emailSendersUtils.ts
@@ -30,7 +30,7 @@ const createEmailSender = (): EmailSenderForUi => ({
   port: '',
   username: '',
   password: '',
-  email: '',
+  from: '',
   accessVerified: false,
 })
 
@@ -59,6 +59,6 @@ export const emailSenderSchema = z.object({
   port: z.string().regex(/^\d+$/, 'Invalid port number'),
   username: z.string().min(1, 'Username cannot be empty'),
   password: z.string().optional(),
-  email: z.string().email('Invalid email'),
+  from: z.string().email('Invalid email'),
   isNew: z.boolean(),
 })

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/tableCells/PasswordCell.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/tableCells/PasswordCell.tsx
@@ -30,7 +30,7 @@ export const PasswordCell = (props: PasswordCellProps) => {
   return (
     <div className="flex items-center gap-x-2">
       <CosTableInput
-        name="password"
+        name={'password' satisfies keyof EmailSenderRow}
         type="password"
         className="w-32"
         value={password}

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/useSyncSenderRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/useSyncSenderRows.ts
@@ -10,7 +10,7 @@ import {
 const computeMapKey = (
   sender: EmailSenderResponse | EmailSenderForUi,
 ): string => {
-  return `${sender.email},${sender.host}:${sender.port}`
+  return `${sender.from},${sender.host}:${sender.port}`
 }
 
 export const useSyncSenderRows = (


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

The `email` field on the Settings Page -> Email Senders section has been renamed to `from` on the API side, causing the frontend column to be empty.

Simply renamed all `email` properties to `from` in the Email Senders section to fix the bug.

#### Which issue(s) this PR fixes

Close #281 

<img width="763" alt="{504F76E4-CF26-4B72-BB91-36E2A2B8943E}" src="https://github.com/user-attachments/assets/ac1afde1-0d0a-45b5-b62f-04698ebfb07a" />
