### PR TITLE
294 fix(web-app): node details page events table id column suffix

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeEvents.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeEvents.tsx
@@ -24,7 +24,11 @@ type NodeEventsProps = {
   node: Node | undefined
 }
 
-const EventTable = GetCosBasicTable<GetEventsResponseDataEventsInner>()
+const EventTable = GetCosBasicTable<EventRow>()
+
+type EventRow = GetEventsResponseDataEventsInner & {
+  eventId: string
+}
 
 export const NodeEvents = (props: NodeEventsProps) => {
   const { node } = props
@@ -82,13 +86,17 @@ export const NodeEvents = (props: NodeEventsProps) => {
     },
   )
 
-  const rows = useMemo<GetEventsResponseDataEventsInner[]>(() => {
+  const rows = useMemo<EventRow[]>(() => {
     const events = response?.events ?? []
-    return events.map((event, index) => ({
-      ...event,
-      // Map events because `event.id` is not unique.
-      id: `${event.id}-${index}`,
-    }))
+    return events.map(
+      (event, index) =>
+        ({
+          ...event,
+          eventId: event.id,
+          // Map events because `event.id` is not unique.
+          id: `${event.id}-${index}`,
+        }) satisfies EventRow,
+    )
   }, [response?.events])
 
   return (
@@ -103,7 +111,7 @@ export const NodeEvents = (props: NodeEventsProps) => {
         />
       </div>
       <EventTable isLoading={!node} rows={rows} skeletonRowCount={10}>
-        <EventTable.Column label="Event ID" property="id" />
+        <EventTable.Column label="Event ID" property="eventId" />
         <EventTable.Column label="Timestamp" property="time">
           {(time) => dayjs.respectTzOffset(time).format('YYYY/MM/DD HH:mm:ss')}
         </EventTable.Column>


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Remove the unexpected `-${index}` suffix from the Events table in the Node Details page.

#### Which issue(s) this PR fixes

Close #294 

#### Special notes for your reviewer

The `id` field in Cos Tables needs to be unique. But due to the fact that the Events API returns non-unique ids, I appended `-${index}` to each `id` to avoid duplicate key issues in React list rendering.

However, this modified `id` was also shown in the table, which confused users. To fix this, I added a new `eventId` field to hold the original event ID, and kept the modified `id` just for React rendering.

![image](https://github.com/user-attachments/assets/1b90713e-fe9c-4529-9a17-b4b490e5eddb)
