### PR TITLE
299 fix(web-app): health details page back button title

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthDetailsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthDetailsPage.tsx
@@ -7,7 +7,7 @@ import {
 import { noop } from 'lodash'
 import { useMemo, useState } from 'react'
 import { Link, Navigate, useParams } from 'react-router'
-import { moduleNameToLabel, serviceNameToLabel } from '../homeHealthPageUtils'
+import { moduleNameToLabel } from '../homeHealthPageUtils'
 import { HealthDetails } from './HealthDetails'
 
 export const HealthDetailsPage = () => {
@@ -40,7 +40,6 @@ export const HealthDetailsPage = () => {
         <CosBackButton
           isLoading={!module}
           variant="title"
-          details={`${moduleNameToLabel(moduleName)} Details`}
           backLinkContainer={{
             Component: Link,
             props: {
@@ -50,7 +49,7 @@ export const HealthDetailsPage = () => {
           // Assign noop because `CosBackButton` requires either `href` or `onClick` prop to be presented.
           onClick={noop}
         >
-          {serviceNameToLabel(module?.service)}
+          {`${moduleNameToLabel(moduleName)} Details`}
         </CosBackButton>
         <CosToggle
           label="Auto-Refresh"


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Adjust the title for the Health Details page.

#### Which issue(s) this PR fixes

Close #299 

#### Special notes for your reviewer

- Previous: `${service}` as title, and `${module} Details` as subtext.
- Now: `${module} Details` as title, no subtext.

<img width="497" alt="{FB5B6EF9-19A9-48E0-8AE4-4CD604D0BB0F}" src="https://github.com/user-attachments/assets/b4b73c73-a25f-4e11-afe8-a93063b5b1b7" />

