### PR TITLE
304 remove repeated table titles

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/events/triggers/EventsTriggersPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/EventsTriggersPage.tsx
@@ -33,43 +33,35 @@ export const EventsTriggersPage = () => {
         </CosInlineNotification>
       ))}
       <CosStroke type="dot" />
-      <div className="flex flex-col gap-2">
-        <div className="primary-h5">Triggers</div>
-        <TriggersTable rows={rows} isLoading={isLoading}>
-          <TriggersTable.Column
-            label="Triggers"
-            property="name"
-            emphasize={true}
-          >
-            {(name, row) => (
-              <div className="flex items-center gap-2">
-                {name}
-                {row.status.isUpdating && (
-                  <CosLoadingSpinner variant="dot120" />
-                )}
-              </div>
-            )}
-          </TriggersTable.Column>
-          <TriggersTable.Column label="Description" property="description" />
-          <TriggersTable.Column label="Response" property="response">
-            {(response) => (
-              <span className="whitespace-nowrap">
-                {getTriggerResponse(response.types)}
-              </span>
-            )}
-          </TriggersTable.Column>
-          <TriggersTable.Column label="Status">
-            {(_, row) => (
-              <TriggersStatusToggle row={row} onChange={handleStatusChange} />
-            )}
-          </TriggersTable.Column>
-          <TriggersTable.Column>
-            {(_, row) => (
-              <TriggersActionCell row={row} onEditClick={handleEdit} />
-            )}
-          </TriggersTable.Column>
-        </TriggersTable>
-      </div>
+
+      <TriggersTable rows={rows} isLoading={isLoading}>
+        <TriggersTable.Column label="Triggers" property="name" emphasize={true}>
+          {(name, row) => (
+            <div className="flex items-center gap-2">
+              {name}
+              {row.status.isUpdating && <CosLoadingSpinner variant="dot120" />}
+            </div>
+          )}
+        </TriggersTable.Column>
+        <TriggersTable.Column label="Description" property="description" />
+        <TriggersTable.Column label="Response" property="response">
+          {(response) => (
+            <span className="whitespace-nowrap">
+              {getTriggerResponse(response.types)}
+            </span>
+          )}
+        </TriggersTable.Column>
+        <TriggersTable.Column label="Status">
+          {(_, row) => (
+            <TriggersStatusToggle row={row} onChange={handleStatusChange} />
+          )}
+        </TriggersTable.Column>
+        <TriggersTable.Column>
+          {(_, row) => (
+            <TriggersActionCell row={row} onEditClick={handleEdit} />
+          )}
+        </TriggersTable.Column>
+      </TriggersTable>
     </div>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/integrations/IntegrationsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/integrations/IntegrationsPage.tsx
@@ -34,8 +34,7 @@ export const IntegrationsPage = () => {
 
   return (
     <CosGeneralPanel topic="Integrations">
-      <div className="flex flex-col gap-y-2 pt-2">
-        <h5 className="primary-h5 text-functional-text">Integrations</h5>
+      <div className="pt-2">
         <IntegrationTable rows={rows} isLoading={isLoading}>
           <IntegrationTable.Column property="url" fitContent={true}>
             {(url) => (

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/MaintenanceSupportFilesPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/MaintenanceSupportFilesPage.tsx
@@ -91,7 +91,6 @@ export const MaintenanceSupportFilesPage = () => {
           <CosStroke type="dot" />
           <div className="flex flex-col gap-y-6">
             <div className="flex flex-col gap-y-2">
-              <h5 className="primary-h5 text-functional-text">Support Files</h5>
               <SupportFilesFilters
                 searchKeyword={searchKeyword}
                 handleSearchKeywordChange={setSearchKeyword}


### PR DESCRIPTION
#### What type of PR is this?

- Fix

#### What this PR does / why we need it

- Remove repeated table titles on `Triggers`, `Integrations` and `Support Files` pages.

<img width="1509" alt="Screenshot 2025-04-30 at 4 48 03 PM" src="https://github.com/user-attachments/assets/4b24c8fe-fb2d-458a-a7a2-b3013a801655" />

<img width="1506" alt="Screenshot 2025-04-30 at 4 47 52 PM" src="https://github.com/user-attachments/assets/1dfe7b60-fb9b-48c2-a0b9-f44bfa71008a" />

<img width="1493" alt="Screenshot 2025-04-30 at 4 47 40 PM" src="https://github.com/user-attachments/assets/8558a379-1a79-4034-a7b7-99e009585da9" />

#### Which issue(s) this PR fixes

Fixes #304

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
