### PR TITLE
fix: 271 home page event table should display severity

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/EventPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/EventPanel.tsx
@@ -1,4 +1,3 @@
-import { useContext, useMemo, useState } from 'react'
 import {
   EventsApiGetAbstractedEventsRequest,
   GetAbstractedEventsResponseData,
@@ -11,14 +10,15 @@ import {
 } from '@cube-frontend/ui-library'
 import { eventsApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
-import { formatEventTime } from '@cube-frontend/web-app/utils/date'
-import { useUpdateTime } from '@cube-frontend/web-app/hooks/useUpdateTime'
-import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentialInterval/useSequentialInterval'
-import { HOME_OVERVIEW_PAGE_POLLING_INTERVAL } from '../homeOverviewPageUtils'
-import { noop } from 'lodash'
-import { Link } from 'react-router'
 import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
+import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
+import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentialInterval/useSequentialInterval'
+import { useUpdateTime } from '@cube-frontend/web-app/hooks/useUpdateTime'
+import { formatEventTime } from '@cube-frontend/web-app/utils/date'
+import { noop } from 'lodash'
+import { useContext, useMemo, useState } from 'react'
+import { Link } from 'react-router'
+import { HOME_OVERVIEW_PAGE_POLLING_INTERVAL } from '../homeOverviewPageUtils'
 
 const HOME_PAGE_EVENT_ROW_LIMIT = 5
 
@@ -103,7 +103,7 @@ export const EventPanel = () => {
           </CosContentSwitcher.Item>
         </CosContentSwitcher>
         <EventTable rows={rows} isLoading={isLoading}>
-          <EventTable.Column label="Type" property="type" />
+          <EventTable.Column label="Severity" property="severity" />
           <EventTable.Column
             label="Event ID"
             property="eventId"

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeEvents.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeEvents.tsx
@@ -111,6 +111,7 @@ export const NodeEvents = (props: NodeEventsProps) => {
         />
       </div>
       <EventTable isLoading={!node} rows={rows} skeletonRowCount={10}>
+        <EventTable.Column label="Severity" property="severity" />
         <EventTable.Column label="Event ID" property="eventId" />
         <EventTable.Column label="Timestamp" property="time">
           {(time) => dayjs.respectTzOffset(time).format('YYYY/MM/DD HH:mm:ss')}


### PR DESCRIPTION
#### What type of PR is this?

bug

#### What this PR does / why we need it

1.) Added `severity` column in the Home Page Event Table.

<img width="1296" alt="Screenshot 2025-05-02 at 2 52 21 PM" src="https://github.com/user-attachments/assets/ee803613-5bbd-49cc-9b30-c52b3bce5f72" />

2.) Added `severity` column in the Node Details Event Table.

<img width="1511" alt="Screenshot 2025-05-02 at 3 16 18 PM" src="https://github.com/user-attachments/assets/4f2755b6-158f-4215-9257-5a4b5901e3d2" />

#### Which issue(s) this PR fixes

Fixes https://github.com/bigstack-oss/cube-cos-ui/issues/271