### PR TITLE
302 feat(web-app): health segmented bar blank section tooltip

### DIFF
--- a/packages/cube-frontend-web-app/src/components/HealthSegmentedBar/computeHealthSegments.ts
+++ b/packages/cube-frontend-web-app/src/components/HealthSegmentedBar/computeHealthSegments.ts
@@ -267,12 +267,13 @@ const createSegment = (options: CreateSegmentOptions): HealthSegment => {
   }
 }
 
-const createHoverContent = (
-  segment: HealthSegment,
-): CosTooltipInformation | undefined => {
+const createHoverContent = (segment: HealthSegment): CosTooltipInformation => {
   const { status, startDateTime, endDateTime } = segment
+
   if (status === 'blank') {
-    return undefined
+    return {
+      message: 'No data',
+    }
   }
 
   const formatDateTime = (dateTime: Dayjs): string => {


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Show "No data" hover tooltip to blank sections in health segmented bars.

#### Which issue(s) this PR fixes

Close #302 

![chrome_xMUAqvXpiA](https://github.com/user-attachments/assets/befc7e8b-f28a-4dc7-a8b3-a9e974eaafa1)
