### PR TITLE
322 feat(web-app): show months and dates in node details page charts

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/CpuPerformanceChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/CpuPerformanceChart.tsx
@@ -1,5 +1,7 @@
 import { MetricsApiGetMetricByHostOrVmRequest, Node } from '@cube-frontend/api'
 import { metricsApi } from '@cube-frontend/web-app/api/cosApi'
+import { TimeRangeDropdown } from '@cube-frontend/web-app/components/TimeRangeDropdown/TimeRangeDropdown'
+import { useTimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/useTimeRange'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
 import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentialInterval/useSequentialInterval'
@@ -11,8 +13,6 @@ import {
   computeChartData,
   getCpuChartOptions,
 } from './nodeChartsUtils'
-import { TimeRangeDropdown } from '@cube-frontend/web-app/components/TimeRangeDropdown/TimeRangeDropdown'
-import { useTimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/useTimeRange'
 
 type CpuPerformanceChartProps = {
   node: Node | undefined
@@ -61,8 +61,8 @@ export const CpuPerformanceChart = (props: CpuPerformanceChartProps) => {
   )
 
   const chartOptions = useMemo(
-    () => getCpuChartOptions(metricsData?.unit ?? ''),
-    [metricsData?.unit],
+    () => getCpuChartOptions(metricsData),
+    [metricsData],
   )
 
   return (

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/MemoryPerformanceChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/MemoryPerformanceChart.tsx
@@ -1,9 +1,10 @@
 import { MetricsApiGetMetricByHostOrVmRequest, Node } from '@cube-frontend/api'
 import { metricsApi } from '@cube-frontend/web-app/api/cosApi'
+import { TimeRangeDropdown } from '@cube-frontend/web-app/components/TimeRangeDropdown/TimeRangeDropdown'
+import { useTimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/useTimeRange'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
 import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentialInterval/useSequentialInterval'
-import { SizeUnit } from '@cube-frontend/web-app/utils/byte'
 import { useContext, useMemo } from 'react'
 import { Line } from 'react-chartjs-2'
 import { Panel } from './Panel'
@@ -12,8 +13,6 @@ import {
   computeChartData,
   getMemoryChartOptions,
 } from './nodeChartsUtils'
-import { useTimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/useTimeRange'
-import { TimeRangeDropdown } from '@cube-frontend/web-app/components/TimeRangeDropdown/TimeRangeDropdown'
 
 type MemoryPerformanceChartProps = {
   node: Node | undefined
@@ -62,11 +61,7 @@ export const MemoryPerformanceChart = (props: MemoryPerformanceChartProps) => {
   )
 
   const chartOptions = useMemo(
-    () =>
-      getMemoryChartOptions(
-        !metricsData,
-        (metricsData?.unit.replace('size', '') ?? 'MiB') as SizeUnit,
-      ),
+    () => getMemoryChartOptions(metricsData),
     [metricsData],
   )
 

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/nodeChartsUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/nodeChartsUtils.ts
@@ -1,4 +1,7 @@
-import { HostMetricHistoryResponseData } from '@cube-frontend/api'
+import {
+  HostMetricHistoryResponseData,
+  TimeValuePair,
+} from '@cube-frontend/api'
 import { cubeTheme } from '@cube-frontend/ui-theme/src/cubeTheme'
 import { TimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/timeRangeUtils'
 import { convertSize, SizeUnit } from '@cube-frontend/web-app/utils/byte'
@@ -10,7 +13,8 @@ import {
   getChartYAxisTitleFont,
 } from '@cube-frontend/web-app/utils/chart'
 import { formatChartXAxisTime } from '@cube-frontend/web-app/utils/date'
-import { ChartData, ChartOptions } from 'chart.js'
+import { ChartData, ChartOptions, Scale, Tick } from 'chart.js'
+import dayjs from 'dayjs'
 
 export const chartTimeRanges = [
   '1h',
@@ -29,17 +33,20 @@ export const computeChartData = (
     | undefined,
   type: 'cpu' | 'memory',
 ): ChartData<'line', number[]> => {
-  if (!metricsData) {
+  const { history } = metricsData ?? {}
+
+  if (!history) {
     return {
       labels: [],
       datasets: [],
     }
   }
+
   return {
-    labels: metricsData.history.map((pair) => formatChartXAxisTime(pair.time)),
+    labels: history.map((pair) => formatChartXAxisTime(pair.time)),
     datasets: [
       {
-        data: metricsData.history.map((pair) => pair.value),
+        data: history.map((pair) => pair.value),
         borderColor: type === 'cpu' ? cpuLineColor : memoryLineColor,
         fill: false,
         tension: 0.1,
@@ -48,7 +55,10 @@ export const computeChartData = (
   }
 }
 
-export const getCpuChartOptions = (unit: string): ChartOptions<'line'> => {
+export const getCpuChartOptions = (
+  metricsData: HostMetricHistoryResponseData | undefined,
+): ChartOptions<'line'> => {
+  const { history = [], unit = '' } = metricsData ?? {}
   return {
     maintainAspectRatio: false,
     interaction: {
@@ -65,6 +75,9 @@ export const getCpuChartOptions = (unit: string): ChartOptions<'line'> => {
           display: false,
         },
         ticks: getChartTicksOptions(),
+        beforeFit: (axis) => {
+          transformTickLabelsBeforeFit(axis, history)
+        },
       },
       y: {
         min: 0,
@@ -101,6 +114,12 @@ export const getCpuChartOptions = (unit: string): ChartOptions<'line'> => {
         bodyFont: getChartTooltipBodyFont(),
         boxPadding: 4,
         callbacks: {
+          title: (tooltipItems) => {
+            if (!tooltipItems.length) return ''
+            const { dataIndex } = tooltipItems[0]
+            const pair = history[dataIndex]
+            return formatTooltipTitle(pair)
+          },
           labelPointStyle: () => ({
             pointStyle: 'line',
             rotation: 0,
@@ -123,9 +142,13 @@ export const getCpuChartOptions = (unit: string): ChartOptions<'line'> => {
   }
 }
 export const getMemoryChartOptions = (
-  isLoading: boolean,
-  originalUnit: SizeUnit,
+  metricsData: HostMetricHistoryResponseData | undefined,
 ): ChartOptions<'line'> => {
+  const isLoading = !metricsData
+  const history = metricsData?.history ?? []
+  const originalUnit = (metricsData?.unit.replace('size', '') ??
+    'MiB') as SizeUnit
+
   return {
     maintainAspectRatio: false,
     interaction: {
@@ -141,6 +164,10 @@ export const getMemoryChartOptions = (
         grid: {
           display: false,
         },
+        ticks: getChartTicksOptions(),
+        beforeFit: (axis) => {
+          transformTickLabelsBeforeFit(axis, history)
+        },
       },
       y: {
         title: {
@@ -152,6 +179,7 @@ export const getMemoryChartOptions = (
           display: false,
         },
         ticks: {
+          ...getChartTicksOptions(),
           callback: (tickValue, index) => {
             if (isLoading) return index * 10
 
@@ -182,6 +210,12 @@ export const getMemoryChartOptions = (
         bodyFont: getChartTooltipBodyFont(),
         boxPadding: 4,
         callbacks: {
+          title: (tooltipItems) => {
+            if (!tooltipItems.length) return ''
+            const { dataIndex } = tooltipItems[0]
+            const pair = history[dataIndex]
+            return formatTooltipTitle(pair)
+          },
           labelPointStyle: () => ({
             pointStyle: 'line',
             rotation: 0,
@@ -204,4 +238,45 @@ export const getMemoryChartOptions = (
       },
     },
   }
+}
+
+const formatTooltipTitle = (pair: TimeValuePair): string => {
+  return dayjs.respectTzOffset(pair.time).format('YYYY-MM-DD HH:mm')
+}
+
+type TickWithContext = Tick & {
+  // NOTE: Chart.js does not expose a type for ticks with `$context`,
+  // but this property is available at runtime.
+  $context: {
+    /**
+     * The index of the source item this tick is generated from.
+     */
+    index: number
+  }
+}
+
+const transformTickLabelsBeforeFit = (
+  axis: Scale,
+  history: TimeValuePair[],
+): void => {
+  const { ticks } = axis
+
+  let prevDate: string | undefined = undefined
+
+  ticks.forEach((tick) => {
+    const castedTick = tick as TickWithContext
+    const timeValuePair = history[castedTick.$context.index]
+    if (!timeValuePair) return
+
+    const dateWithTz = dayjs.respectTzOffset(timeValuePair.time.toString())
+    const dateString = dateWithTz.format('YYYY-MM-DD')
+
+    if (prevDate !== dateString) {
+      tick.label = dateWithTz.format('MMM DD HH:mm')
+    } else {
+      tick.label = dateWithTz.format('HH:mm')
+    }
+
+    prevDate = dateString
+  })
 }


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

For the charts in the Node Details page:

1. Show dates in the hover tooltip
2. Prepend `MMM DD` to the time label in the X-axis whenever there's a day change.

#### Which issue(s) this PR fixes

Close #322

#### Special notes for your reviewer

Chart.js automatically hides some ticks/labels (i.e., "auto-fit") based on the available width of the chart. This means that precomputing the labels in `chartData.labels` won't always work because we can't predict which labels will end up being hidden.

To handle this, we need to wait until Chart.js has determined which labels are visible or hidden and then transform the labels accordingly. I use the [beforeFit](https://www.chartjs.org/docs/latest/api/classes/Scale.html#beforefit) lifecycle hook on the scale, which seems to work well in this case.

https://github.com/user-attachments/assets/5b482836-a8d6-4afe-979d-b9469543fb7f

