### PR TITLE
fix: 279 integration connect button missing hover mouse feedback

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosButton/CosButton.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosButton/CosButton.tsx
@@ -86,7 +86,7 @@ const button = cva(
         ],
         light: [
           'bg-secondary text-dark-400',
-          'hover:bg-secondary',
+          'hover:bg-secondary-400',
           'disabled:bg-secondary-50 disabled:text-functional-disable-text',
         ],
       },


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix: The `Connect` buttons on the Integration Page is missing hover feedback.

https://github.com/user-attachments/assets/bff97dd5-d088-4648-a695-65f0ecb505e4

#### Which issue(s) this PR fixes

Fixes #279