### PR TITLE
Fix/289 grafana link position

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosPanel/CosGeneralPanel/CosGeneralPanelTitleBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPanel/CosGeneralPanel/CosGeneralPanelTitleBar.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
-import { CosSkeleton } from '../../CosSkeleton/CosSkeleton'
 import {
   CosHyperlink,
   CosHyperlinkProps,
 } from '../../CosHyperlink/CosHyperlink'
+import { CosSkeleton } from '../../CosSkeleton/CosSkeleton'
 
 export type CosGeneralPanelTitleBarProps = {
   title?: string
@@ -37,20 +37,20 @@ export const CosGeneralPanelTitleBar = (
 
   return (
     <div className="flex items-end justify-between">
-      <span className="secondary-body1 text-functional-text-light">
-        {title}
-      </span>
-      <div className="flex items-end gap-x-3">
+      <div className="flex items-center gap-x-3">
+        <span className="secondary-body1 text-functional-text-light">
+          {title}
+        </span>
         {hyperLinkProps && (
           <CosHyperlink variant="text-inline" size="sm" {...hyperLinkProps} />
         )}
-        {(timeElement || dropdown) && (
-          <div className="flex items-end gap-x-2">
-            {timeElement}
-            {dropdown}
-          </div>
-        )}
       </div>
+      {(timeElement || dropdown) && (
+        <div className="flex items-end gap-x-2">
+          {timeElement}
+          {dropdown}
+        </div>
+      )}
     </div>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/ExtraInformationPanel/ExtraInformationPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/ExtraInformationPanel/ExtraInformationPanel.tsx
@@ -96,9 +96,7 @@ export const ExtraInformationPanel = () => {
           boxShadow: '0px 0px 2px 0px rgba(0, 0, 0, 0.20)',
         }}
       >
-        <div className="secondary-h4 text-functional-title">
-          Extra Information
-        </div>
+        <div className="secondary-h4 text-functional-title">Extra Monitor</div>
         {networkLinkElement}
         {deviceLinkElement}
       </div>

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/utils.ts
@@ -1,25 +1,25 @@
-import { AxiosRequestConfig } from 'axios'
 import {
-  GetMetricByTypes200Response,
-  MetricsApiGetMetricByTypesRequest,
+  GetCpuUsageRankOfHostsResponse,
+  GetCpuUsageRankOfVmsResponse,
   GetDiskBandwidthHistoryOfHostsResponse,
   GetDiskIopsHistoryOfHostsResponse,
-  GetNetworkTrafficInRankOfHostsResponse,
-  GetCpuUsageRankOfHostsResponse,
-  GetDiskUsageRankOfHostsResponse,
-  GetMemoryUsageRankOfHostsResponse,
-  GetNetworkTrafficOutRankOfHostsResponse,
-  GetNetworkTrafficInRankOfVmsResponse,
-  GetNetworkTrafficOutRankOfVmsResponse,
-  GetCpuUsageRankOfVmsResponse,
-  GetMemoryUsageRankOfVmsResponse,
   GetDiskReadIopsRankOfVmsResponse,
+  GetDiskUsageRankOfHostsResponse,
   GetDiskWriteIopsRankOfVmsResponse,
   GetGrafanaDashboardLinkResponseData,
+  GetMemoryUsageRankOfHostsResponse,
+  GetMemoryUsageRankOfVmsResponse,
+  GetMetricByTypes200Response,
+  GetNetworkTrafficInRankOfHostsResponse,
+  GetNetworkTrafficInRankOfVmsResponse,
+  GetNetworkTrafficOutRankOfHostsResponse,
+  GetNetworkTrafficOutRankOfVmsResponse,
+  MetricsApiGetMetricByTypesRequest,
 } from '@cube-frontend/api'
+import { CosGeneralPanelTitleBarProps } from '@cube-frontend/ui-library'
 import { metricsApi } from '@cube-frontend/web-app/api/cosApi'
 import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
-import { CosGeneralPanelTitleBarProps } from '@cube-frontend/ui-library'
+import { AxiosRequestConfig } from 'axios'
 import { noop } from 'lodash'
 
 const getMetricsByTypes = async <T extends GetMetricByTypes200Response>(
@@ -81,7 +81,7 @@ export const computeTitleBarHyperlinkProps = (
   if (!response) {
     // Grafana link is still loading.
     return {
-      children: 'More',
+      children: 'Monitor',
       onClick: noop,
       disabled: true,
     }
@@ -94,7 +94,7 @@ export const computeTitleBarHyperlinkProps = (
   }
 
   return {
-    children: 'More',
+    children: 'Monitor',
     href: response.link,
     target: '_blank',
   }

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDetailsHeader.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDetailsHeader.tsx
@@ -39,7 +39,7 @@ export const NodeDetailsHeader = (props: NodeDetailsHeaderProps) => {
 
     return [
       {
-        children: 'Grafana',
+        children: 'Monitor',
         href: grafanaLinkResponse.link,
         target: '_blank',
         onClick: noop,


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### Which issue(s) this PR fixes

- #289 
- #290

#### What this PR does

1.) UI Library: Panel - General

<img width="1483" alt="Screenshot 2025-05-07 at 4 01 44 PM" src="https://github.com/user-attachments/assets/8c69cfeb-79d8-4c72-8b32-1bc5bebef6d4" /> 

2.) Web APP: Home/Chart Page

<img width="1916" alt="Screenshot 2025-05-07 at 4 00 14 PM" src="https://github.com/user-attachments/assets/d813e3cd-e76c-4af0-9240-dbe9f63afed0" />

3.) Web APP: Node Details Page

<img width="1910" alt="Screenshot 2025-05-07 at 4 03 34 PM" src="https://github.com/user-attachments/assets/f40e5fcb-b925-4d2b-bad5-cb85e5821414" />

Closes #289 