### PR TITLE
fix: 275 295 summary chart color incorrect

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/utils.ts
@@ -11,17 +11,17 @@ export const toMetricsChart = (metrics: GetMetricsResponseData) => {
     },
     {
       name: 'Stopped',
-      color: 'fill-chart-4',
+      color: 'fill-status-warning',
       count: metrics.vm.status.stopped,
     },
     {
       name: 'Suspended',
-      color: 'fill-chart-3',
+      color: 'fill-chart-1',
       count: metrics.vm.status.suspend,
     },
     {
       name: 'Paused',
-      color: 'fill-chart-6',
+      color: 'fill-status-paused',
       count: metrics.vm.status.paused,
     },
     {
@@ -35,32 +35,32 @@ export const toMetricsChart = (metrics: GetMetricsResponseData) => {
   const roleCountInfos: CosCountSegmentedChartCountInfo[] = [
     {
       name: 'Control-converged',
-      color: 'fill-chart-6',
+      color: 'fill-chart-1',
       count: metrics.host.role.controlConverged.count,
     },
     {
       name: 'Control',
-      color: 'fill-chart-1',
+      color: 'fill-chart-2',
       count: metrics.host.role.control.count,
     },
     {
       name: 'Compute',
-      color: 'fill-chart-2',
+      color: 'fill-chart-3',
       count: metrics.host.role.compute.count,
     },
     {
       name: 'Storage',
-      color: 'fill-chart-3',
+      color: 'fill-chart-5',
       count: metrics.host.role.storage.count,
     },
     {
       name: 'Edge-core',
-      color: 'fill-chart-4',
+      color: 'fill-chart-8',
       count: metrics.host.role.edgeCore.count,
     },
     {
       name: 'Moderator',
-      color: 'fill-chart-5',
+      color: 'fill-chart-9',
       count: metrics.host.role.moderator.count,
     },
   ]


### PR DESCRIPTION
#### What type of PR is this?

fix

#### Which issue(s) this PR fixes

Fixes #275, Fixes #295 

#### What this PR does / why we need it

Chart colors should follow the [design guidelines](https://www.figma.com/design/T95ymFSTSDKdmr9WEjylQE/COS-Design-System-2024?node-id=6093-21872&m=dev), and avoid using red or orange as role colors.

<img width="1394" alt="Screenshot 2025-05-07 at 4 30 01 PM" src="https://github.com/user-attachments/assets/67d1affa-08d7-4c1d-a5fb-6cfcdd43123d" />
<img width="1402" alt="Screenshot 2025-05-07 at 4 30 16 PM" src="https://github.com/user-attachments/assets/ea086b34-1eed-48de-a990-33b5bd529386" />
