### PR TITLE
Fix/325 web app max content width

### DIFF
--- a/packages/cube-frontend-web-app/src/layout/Content.tsx
+++ b/packages/cube-frontend-web-app/src/layout/Content.tsx
@@ -10,15 +10,17 @@ const Content = (props: PropsWithChildren) => {
   return (
     <div
       id={containerId}
-      className="h-[calc(100svh_-_54px)] overflow-auto px-5 py-3"
+      className="flex h-[calc(100svh_-_54px)] w-full items-start justify-center overflow-auto"
     >
-      <UseFloatingExternalContextProvider
-        scrollableRootSelector={`#${containerId}`}
-      >
-        {/* Page content level error boundary. This ensures sidebar and navbar
+      <div className="w-full max-w-[1600px] px-5 pb-[60px] pt-4 [&>*]:w-full">
+        <UseFloatingExternalContextProvider
+          scrollableRootSelector={`#${containerId}`}
+        >
+          {/* Page content level error boundary. This ensures sidebar and navbar
         remain visible if an uncaught error is thrown by the page content. */}
-        <CosErrorBoundary>{children}</CosErrorBoundary>
-      </UseFloatingExternalContextProvider>
+          <CosErrorBoundary>{children}</CosErrorBoundary>
+        </UseFloatingExternalContextProvider>
+      </div>
     </div>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/NodeDetailsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/NodeDetailsPage.tsx
@@ -44,7 +44,7 @@ export const NodeDetailsPage = () => {
   }
 
   return (
-    <div className="flex flex-col gap-y-4 px-5 py-4">
+    <div className="flex flex-col gap-y-4">
       <NodeDetailsHeader node={node} />
       <NodeSummary node={node} />
       <NodeNetworks node={node} />


### PR DESCRIPTION
# ⚠️ This PR is based on https://github.com/bigstack-oss/cube-cos-ui/pull/351

#### What type of PR is this?

FIx

#### Which issue(s) this PR fixes

Fixes #325

#### What this PR does / why we need it

1. Sets the `Content` max-width to 1600px.
2. Set the `Content` bottom padding to 60px.

https://github.com/user-attachments/assets/1f27f8d4-aaf5-48b6-832d-2b25faaf0879

Design guideline: https://www.figma.com/design/kRJ5MUAkMF0AYgXCeChtZn/COS-management-UI-Redesign-v.3?node-id=9483-10211&m=dev

In Phase 1, we only need to implement a maximum content width of 1600px.
Other responsive features like breakpoints and scaling can be discussed in Phase 2.
