### PR TITLE
fix: 353 node table and node details license expiration wording

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
@@ -7,6 +7,8 @@ import {
   CosTooltip,
   GetCosBasicTable,
 } from '@cube-frontend/ui-library'
+import { CopyButton } from '@cube-frontend/web-app/components/CopyButton'
+import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
 import {
   humanizeDuration,
   toLicenseExpirationDate,
@@ -16,8 +18,6 @@ import { toPercentage } from '@cube-frontend/web-app/utils/number'
 import { noop } from 'lodash'
 import { ComponentProps } from 'react'
 import { Link } from 'react-router'
-import { CopyButton } from '@cube-frontend/web-app/components/CopyButton'
-import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
 
 const BasicNodeTable = GetCosBasicTable<GetNodesResponseData['nodes'][number]>()
 
@@ -65,7 +65,7 @@ export const NodeTable = (props: NodeTableProps) => {
           </CosTag>
         )}
       </BasicNodeTable.Column>
-      <BasicNodeTable.Column label="License Expiration" property="license">
+      <BasicNodeTable.Column label="COS License Expiration" property="license">
         {toLicenseExpirationDate}
       </BasicNodeTable.Column>
       <BasicNodeTable.Column

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeSummary.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeSummary.tsx
@@ -156,7 +156,7 @@ export const NodeSummary = (props: NodeSummaryProps) => {
             'Up Time',
             dayjs.duration(node.uptimeSeconds, 'seconds').humanize(),
           )}
-          {renderRow('License Expiration', getLicenseExpiration())}
+          {renderRow('COS License Expiration', getLicenseExpiration())}
           {renderRow(
             'Management IP',
             <div className="flex items-center gap-x-5">

--- a/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
@@ -7,6 +7,8 @@ import {
   CosTooltip,
   GetCosBatchActionTable,
 } from '@cube-frontend/ui-library'
+import { CopyButton } from '@cube-frontend/web-app/components/CopyButton'
+import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
 import {
   humanizeDuration,
   toLicenseExpirationDate,
@@ -16,8 +18,6 @@ import { toPercentage } from '@cube-frontend/web-app/utils/number'
 import { noop } from 'lodash'
 import { ComponentProps } from 'react'
 import { Link } from 'react-router'
-import { CopyButton } from '@cube-frontend/web-app/components/CopyButton'
-import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
 
 const BatchActionNodeTable =
   GetCosBatchActionTable<GetNodesResponseData['nodes'][number]>()
@@ -67,7 +67,7 @@ export const NodeTable = (props: NodeTableProps) => {
         )}
       </BatchActionNodeTable.Column>
       <BatchActionNodeTable.Column
-        label="License Expiration"
+        label="COS License Expiration"
         property="license"
       >
         {toLicenseExpirationDate}


### PR DESCRIPTION
#### What type of PR is this?

FIx

#### Which issue(s) this PR fixes

Fixes #353 

#### What this PR does / why we need it

Since one host can have multiple licenses, with 0 or 1 license per product, we need a UI solution to display multiple license details.

In Phase 1, we will display the most important license—COS License—and rename the label from License Expiration to COS License Expiration.

A more comprehensive UI solution can be discussed and implemented in Phase 2.

#### Test Result

https://github.com/user-attachments/assets/191a63d9-6452-4ce5-bfcb-d69c5ce6d933


