### PR TITLE
345 health details page is fixing status display

### DIFF
--- a/packages/cube-frontend-api/sdk/api.ts
+++ b/packages/cube-frontend-api/sdk/api.ts
@@ -3480,6 +3480,12 @@ export interface GetModuleHealthHistoryResponseData {
      * @memberof GetModuleHealthHistoryResponseData
      */
     'history': Array<GetModuleHealthHistoryResponseDataHistoryInner>;
+    /**
+     * 
+     * @type {GetModuleHealthHistoryResponseDataStatus}
+     * @memberof GetModuleHealthHistoryResponseData
+     */
+    'status': GetModuleHealthHistoryResponseDataStatus;
 }
 /**
  * 
@@ -3551,6 +3557,33 @@ export interface GetModuleHealthHistoryResponseDataHistoryInnerError {
      */
     'log'?: string;
 }
+/**
+ * 
+ * @export
+ * @interface GetModuleHealthHistoryResponseDataStatus
+ */
+export interface GetModuleHealthHistoryResponseDataStatus {
+    /**
+     * 
+     * @type {string}
+     * @memberof GetModuleHealthHistoryResponseDataStatus
+     */
+    'current': GetModuleHealthHistoryResponseDataStatusCurrentEnum;
+    /**
+     * 
+     * @type {boolean}
+     * @memberof GetModuleHealthHistoryResponseDataStatus
+     */
+    'isFixing': boolean;
+}
+
+export const GetModuleHealthHistoryResponseDataStatusCurrentEnum = {
+    Ok: 'ok',
+    Ng: 'ng'
+} as const;
+
+export type GetModuleHealthHistoryResponseDataStatusCurrentEnum = typeof GetModuleHealthHistoryResponseDataStatusCurrentEnum[keyof typeof GetModuleHealthHistoryResponseDataStatusCurrentEnum];
+
 /**
  * 
  * @export

--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanel.tsx
@@ -62,6 +62,7 @@ export const HealthHistoryPanel = (props: HealthHistoryPanelProps) => {
       <HealthHistoryPanelHeader
         module={module}
         isRepairable={!!historyResponse?.isRepairable}
+        isFixing={!!historyResponse?.status.isFixing}
         selectedTimeRange={timeRange}
         onTimeRangeChange={onTimeRangeChange}
         onToggleDetailPanel={onToggleDetailPanel}

--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanelHeader.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanelHeader.tsx
@@ -14,6 +14,7 @@ import { moduleNameToLabel } from '../homeHealthPageUtils'
 export type HealthHistoryPanelHeaderProps = {
   module: ModuleMetadata | undefined
   isRepairable: boolean
+  isFixing: boolean
   selectedTimeRange: HealthTimeRange
   onTimeRangeChange: (timeRange: HealthTimeRange) => void
   onToggleDetailPanel: () => void
@@ -25,6 +26,7 @@ export const HealthHistoryPanelHeader = (
   const {
     module,
     isRepairable,
+    isFixing,
     selectedTimeRange,
     onTimeRangeChange,
     onToggleDetailPanel,
@@ -65,7 +67,7 @@ export const HealthHistoryPanelHeader = (
           )}
         </span>
         <CosButton
-          loading={isCallingRepairApi}
+          loading={isCallingRepairApi || isFixing}
           disabled={!module || !isRepairable}
           onClick={onRepairClick}
         >


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Transition the Repair button to loading state when `status.isFixing` is `true`.

#### Which issue(s) this PR fixes

Close #345 

- Is fixing:

   https://github.com/user-attachments/assets/8cecf585-bb5a-49ad-a712-95faa590013d

- Not fixing:
   ![image](https://github.com/user-attachments/assets/8b89026c-1aed-4256-9165-07783c55073d)

