### PR TITLE
346 conditionally put `password`  in the patch request

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/emailSenderMappers.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/emailSenderMappers.ts
@@ -37,10 +37,22 @@ export const rowToEmailSenderPostRequest = (
 
 export const rowToEmailSenderPatchRequest = (
   row: EmailSenderRow,
-): EmailSenderPatchRequest => ({
-  from: row.from,
-  host: row.host,
-  port: parseInt(row.port),
-  username: row.username,
-  password: row.password,
-})
+): EmailSenderPatchRequest => {
+  const request: EmailSenderPatchRequest = {
+    from: row.from,
+    host: row.host,
+    port: parseInt(row.port),
+    username: row.username,
+  }
+
+  /**
+   * Conditionally put the `password` field in the patch request:
+   * - If no password is provided, omit the `password` key to avoid unnecessary updates.
+   * - If a new password is provided, include it in the patch request payload.
+   */
+  if (row.password) {
+    request.password = row.password
+  }
+
+  return request
+}


### PR DESCRIPTION
#### What type of PR is this?

- Feat

#### What this PR does / why we need it

- If a new password is provided, include it in the patch request payload.


https://github.com/user-attachments/assets/12278368-718e-4818-bf75-153edd473cd9


- If no password is provided, omit the `password` key.


https://github.com/user-attachments/assets/49f0210f-3198-43af-b9a2-5cabab461ed9




#### Which issue(s) this PR fixes

Fixes #346 

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```

https://github.com/user-attachments/assets/5120c513-f48a-49bd-aaf1-03dd5a071cb9

