### PR TITLE
347: feat(web-app): show service fixing spinner and text in home overview health panel

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthError.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthError.tsx
@@ -1,38 +1,66 @@
-import { range } from 'lodash'
-import { GetHealthsResponseDataServicesInner } from '@cube-frontend/api'
+import {
+  GetHealthsResponseDataOverallStatusCurrentEnum,
+  GetHealthsResponseDataServicesInner,
+} from '@cube-frontend/api'
 import {
   CosButton,
   CosButtonSkeleton,
   CosDashboardPanel,
+  CosLoadingSpinner,
   CosSkeleton,
 } from '@cube-frontend/ui-library'
+import CircleFillIcon from '@cube-frontend/ui-library/icons/monochrome/circle_fill.svg?react'
 import WarningFilledIcon from '@cube-frontend/ui-library/icons/monochrome/warning_filled.svg?react'
+import { cva } from 'class-variance-authority'
+import { ClassValue } from 'class-variance-authority/types'
+import { range } from 'lodash'
 import { serviceNameToLabel } from '../../../health/homeHealthPageUtils'
 
 type ServiceErrorProps = {
   service: GetHealthsResponseDataServicesInner
 }
 
+const nameLabel = cva('primary-body3 font-semibold', {
+  variants: {
+    status: {
+      ok: 'text-functional-text',
+      ng: 'text-status-negative',
+    } satisfies Record<
+      GetHealthsResponseDataOverallStatusCurrentEnum,
+      ClassValue
+    >,
+  },
+})
+
 const ServiceError = (props: ServiceErrorProps) => {
   const { service } = props
 
   return (
     <div className="flex items-center gap-x-5">
-      <div className="flex items-center gap-x-2 text-status-negative">
-        <WarningFilledIcon className="icon-md" />
-        <span className="primary-body3 font-semibold">
+      <div className="flex items-center gap-x-2">
+        {service.status.isFixing ? (
+          <CosLoadingSpinner variant="dot45" />
+        ) : service.status.current === 'ok' ? (
+          <CircleFillIcon className="icon-md text-status-positive" />
+        ) : (
+          <WarningFilledIcon className="icon-md text-status-negative" />
+        )}
+        <span className={nameLabel({ status: service.status.current })}>
           {serviceNameToLabel(service.name)}
         </span>
       </div>
       <div className="primary-body4 text-functional-text-light">
-        {service.modules
-          .map((module) => {
-            const name = module.name
-            const status = module.status.current
-            const statusDisplay = status === 'ng' ? 'x' : 'v'
-            return `${name}(${statusDisplay})`
-          })
-          .join('; ')}
+        {service.status.isFixing
+          ? // TODO: i18n
+            'Fixing...'
+          : service.modules
+              .map((module) => {
+                const name = module.name
+                const status = module.status.current
+                const statusDisplay = status === 'ng' ? 'x' : 'v'
+                return `${name}(${statusDisplay})`
+              })
+              .join('; ')}
       </div>
     </div>
   )
@@ -52,11 +80,18 @@ export type HealthErrorProps = {
   isLoading: boolean
   errorServices: GetHealthsResponseDataServicesInner[]
   isRepairButtonLoading: boolean
-  onRepair: () => void
+  isRepairDone: boolean
+  onRepairClick: () => void
 }
 
 export const HealthError = (props: HealthErrorProps) => {
-  const { isLoading, errorServices, isRepairButtonLoading, onRepair } = props
+  const {
+    isLoading,
+    errorServices,
+    isRepairButtonLoading,
+    isRepairDone,
+    onRepairClick,
+  } = props
 
   const renderErrorServices = () => {
     if (isLoading) {
@@ -73,8 +108,20 @@ export const HealthError = (props: HealthErrorProps) => {
       return <CosButtonSkeleton size="md" />
     }
 
+    if (isRepairDone) {
+      return (
+        <span className="secondary-body3 font-semibold text-status-positive">
+          Done!
+        </span>
+      )
+    }
+
     return (
-      <CosButton size="md" loading={isRepairButtonLoading} onClick={onRepair}>
+      <CosButton
+        size="md"
+        loading={isRepairButtonLoading}
+        onClick={onRepairClick}
+      >
         Repair
       </CosButton>
     )

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthPanel.tsx
@@ -18,6 +18,7 @@ import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentia
 import { HOME_OVERVIEW_PAGE_POLLING_INTERVAL } from '../../homeOverviewPageUtils'
 import { noop } from 'lodash'
 import { Link } from 'react-router'
+import { useDelayedRepairState } from './HealthStatus/useDelayedRepairState'
 
 const HealthPanel = () => {
   const { dataCenter } = useContext(DataCenterContext)
@@ -39,9 +40,13 @@ const HealthPanel = () => {
   })
 
   const updateTime = useUpdateTime(healths, isLoading)
+
+  const { showRepairDoneText, observedServiceNames, setObservedServiceNames } =
+    useDelayedRepairState(healths?.overall.status.isFixing ?? false)
+
   const { errorCount, errorServices } = useMemo(
-    () => toHealthUIData(healths),
-    [healths],
+    () => toHealthUIData(healths, observedServiceNames),
+    [healths, observedServiceNames],
   )
 
   const { isLoading: isCallingRepairApi, mutateResource: repairHealth } =
@@ -53,6 +58,8 @@ const HealthPanel = () => {
 
   const handleRepair = async () => {
     try {
+      const errorServiceNames = errorServices.map((service) => service.name)
+      setObservedServiceNames(new Set(errorServiceNames))
       await repairHealth({
         dataCenter: dataCenter!.name,
       })
@@ -73,12 +80,13 @@ const HealthPanel = () => {
       HyperLinkContainer={<Link to={links.health} />}
       isTimeLoading={isLoading}
     >
-      {(isLoading || errorServices.length > 0) && (
+      {(isLoading || errorServices.length > 0 || showRepairDoneText) && (
         <HealthError
           isLoading={isLoading}
           errorServices={errorServices}
-          onRepair={handleRepair}
+          onRepairClick={handleRepair}
           isRepairButtonLoading={isRepairButtonLoading}
+          isRepairDone={showRepairDoneText}
         />
       )}
       <HealthStatus services={healths?.services} />

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthStatus/HealthStatus.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthStatus/HealthStatus.tsx
@@ -12,7 +12,7 @@ export const HealthStatus = (props: HealthStatusProps) => {
   const { services } = props
 
   return (
-    <CosDashboardPanel.Item topic="Status">
+    <CosDashboardPanel.Item topic="Status" className="overflow-x-auto">
       <div className="grid grid-flow-col grid-rows-4 gap-x-3 gap-y-2">
         {!services
           ? range(20).map((i) => <ServiceHealthStatusSkeleton key={i} />)

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthStatus/ServiceHealthStatus.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthStatus/ServiceHealthStatus.tsx
@@ -1,4 +1,5 @@
 import { GetHealthsResponseDataServicesInner } from '@cube-frontend/api'
+import { CosLoadingSpinner } from '@cube-frontend/ui-library'
 import CircleFillIcon from '@cube-frontend/ui-library/icons/monochrome/circle_fill.svg?react'
 import WarningFilledIcon from '@cube-frontend/ui-library/icons/monochrome/warning_filled.svg?react'
 import { serviceNameToLabel } from '@cube-frontend/web-app/pages/home/health/homeHealthPageUtils'
@@ -12,7 +13,9 @@ export const ServiceHealthStatus = (props: ServiceHealthStatusProps) => {
 
   return (
     <div className="flex w-[150px] items-center gap-x-2 text-functional-text">
-      {service.status.current === 'ok' ? (
+      {service.status.isFixing ? (
+        <CosLoadingSpinner variant="dot45" />
+      ) : service.status.current === 'ok' ? (
         <CircleFillIcon className="icon-md text-status-positive" />
       ) : (
         <WarningFilledIcon className="icon-md text-status-negative" />

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthStatus/useDelayedRepairState.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthStatus/useDelayedRepairState.ts
@@ -1,0 +1,53 @@
+import { useEffect, useRef, useState } from 'react'
+
+type UseDelayedRepairState = {
+  showRepairDoneText: boolean
+  /**
+   * Services that are in `ng` status when the Repair button is clicked.
+   */
+  observedServiceNames: Set<string>
+  setObservedServiceNames: (names: Set<string>) => void
+}
+
+export const useDelayedRepairState = (
+  isFixing: boolean,
+): UseDelayedRepairState => {
+  const [showRepairDoneText, setShowRepairDoneText] = useState(false)
+
+  const [observedServiceNames, setObservedServiceNamesState] = useState<
+    Set<string>
+  >(() => new Set())
+
+  const prevIsFixing = useRef(isFixing)
+
+  useEffect(() => {
+    let timeoutId: NodeJS.Timeout | undefined
+
+    if (prevIsFixing.current && !isFixing) {
+      // Fixing status has transitioned from true to false.
+      // Show the "Done!" text for a couple of seconds, then hide it and clear
+      // the observed service names.
+      setShowRepairDoneText(true)
+      setTimeout(() => {
+        setShowRepairDoneText(false)
+        setObservedServiceNamesState(new Set())
+      }, 3000)
+    }
+
+    prevIsFixing.current = isFixing
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [isFixing])
+
+  const setObservedServiceNames = (names: Set<string>): void => {
+    setObservedServiceNamesState(names)
+  }
+
+  return {
+    observedServiceNames,
+    showRepairDoneText,
+    setObservedServiceNames,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/utils.ts
@@ -10,6 +10,7 @@ type HealthUIData = {
 
 export const toHealthUIData = (
   healths: GetHealthsResponseData | undefined,
+  observedServiceNames: Set<string>,
 ): HealthUIData => {
   const { services = [] } = healths ?? {}
 
@@ -17,8 +18,13 @@ export const toHealthUIData = (
   const errorServices: GetHealthsResponseDataServicesInner[] = []
 
   services.forEach((service) => {
-    if (service.status.current === 'ng') {
+    const ng = service.status.current === 'ng'
+
+    if (ng) {
       errorCount++
+    }
+
+    if (ng || observedServiceNames.has(service.name)) {
       errorServices.push(service)
     }
   })


### PR DESCRIPTION
# ⚠️ Unable to test at the moment because services never transit to fixing status ⚠️

#### What type of PR is this?

Feat

#### What this PR does / why we need it

In Home Overview page -> health panel:

- Show loading spinner for every service that's currently being fixed.
- Ensure services that are in `ng` status stay in the Error section even if they're fixed during the process to match the UI design.
- Briefly replace the Repair button with the "Done!" text once the repair is done (for 3 seconds.)

#### Which issue(s) this PR fixes

Close #347 
