### PR TITLE
130: fix(ui-library): cos progress bar border radius

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBar.tsx
@@ -4,6 +4,7 @@ import { twMerge } from 'tailwind-merge'
 import { BackgroundColorClass } from '@cube-frontend/ui-theme'
 import { PropsWithClassName } from '@cube-frontend/utils'
 import { CosProgressBarSkeleton } from './CosProgressBarSkeleton'
+import { useFillWidth } from './useFillWidth'
 
 export type CosProgressBarProps = {
   color: BackgroundColorClass
@@ -25,13 +26,15 @@ const progressCva = cva('absolute h-full', {
 export const CosProgressBar = (props: CosProgressBarProps) => {
   const { className: classNameProps, color, progress } = props
 
-  // Use inline style because dynamic value is not supported in TailwindCSS.
-  const progressWidthStyle: CSSProperties = {
-    width: `${Math.min(progress, 100)}%`,
-  }
-
   if (progress < 0) {
     console.warn('progress value should not be less than 0')
+  }
+
+  const { barRef, fillWidthPercentage } = useFillWidth(progress)
+
+  // Use inline style because dynamic value is not supported in TailwindCSS.
+  const progressWidthStyle: CSSProperties = {
+    width: `${fillWidthPercentage}%`,
   }
 
   const className = twMerge(
@@ -41,7 +44,10 @@ export const CosProgressBar = (props: CosProgressBarProps) => {
 
   return (
     <div className={className}>
-      <div className="relative h-[9px] w-full rounded-full bg-functional-border-divider">
+      <div
+        ref={barRef}
+        className="relative h-[9px] w-full rounded-full bg-functional-border-divider"
+      >
         <div
           className={twMerge(
             progressCva({

--- a/packages/cube-frontend-ui-library/src/components/CosProgressBar/useFillWidth.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBar/useFillWidth.ts
@@ -1,0 +1,82 @@
+import { RefObject, useEffect, useMemo, useRef, useState } from 'react'
+
+type UseFillWidth = {
+  barRef: RefObject<HTMLDivElement | null>
+  fillWidthPercentage: number
+}
+
+const MIN_TRACK_WIDTH = 16
+const MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE = 4
+
+/**
+ * If the bar width is too small, the filled area will be too short for the
+ * border-radius to appear. Likewise, if the filled area is too long, the
+ * remaining blank space will be too narrow for the trailing border-radius
+ * to show.
+ * Thus, instead of using the user-provided `progress`, we should calculate a
+ * value that ensures either the filled area or the trailing blank space is
+ * wide enough.
+ */
+export const useFillWidth = (progressProp: number): UseFillWidth => {
+  const [barWidth, setBarWidth] = useState(0)
+
+  const barRef = useRef<HTMLDivElement | null>(null)
+
+  useEffect(() => {
+    const observer = new ResizeObserver(([entry]) => {
+      setBarWidth(entry.contentRect.width)
+    })
+
+    const bar = barRef.current
+    if (bar) {
+      observer.observe(bar)
+    }
+
+    return () => {
+      observer.disconnect()
+    }
+  }, [])
+
+  const fillWidthPercentage = useMemo<number>(() => {
+    if (
+      progressProp <= 0 ||
+      progressProp >= 100 ||
+      barWidth <= MIN_TRACK_WIDTH
+    ) {
+      return progressProp
+    }
+
+    let progress = progressProp
+    let filledWidth = 0
+    let blankWidth = 0
+
+    const updateWidths = (): void => {
+      filledWidth = barWidth * (progress / 100)
+      blankWidth = barWidth - filledWidth
+    }
+
+    updateWidths()
+
+    if (filledWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE) {
+      while (
+        filledWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE &&
+        progress < 100
+      ) {
+        progress++
+        updateWidths()
+      }
+    } else if (blankWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE) {
+      while (blankWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE && progress > 0) {
+        progress--
+        updateWidths()
+      }
+    }
+
+    return progress
+  }, [barWidth, progressProp])
+
+  return {
+    barRef,
+    fillWidthPercentage,
+  }
+}


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix the border-radius issue for `CosProgressBar`.

#### Which issue(s) this PR fixes

Close #130 

#### Special notes for your reviewer

This problem occurs not only when the filled percentage is 1% and 99%. The root cause is that if the bar width is too small, the filled area will be too short for the border-radius to appear (e.g. when `progress` = 1%). Likewise, if the filled area is too long, the remaining blank space will be too narrow for the trailing border-radius to show (e.g., when `progress` = 99%). It depends on the width of the progress bar.

<img width="980" alt="{29959E73-5518-40AB-89D2-2D36BCEFE2A0}" src="https://github.com/user-attachments/assets/595bffef-cf02-455c-9cc1-f41a77a32e74" />

Similar issue also occurs with SVG. While SVG does solve the border-radius problem, the filled area can still be too short to be visible, making it an imperfect solution:

![image](https://github.com/user-attachments/assets/3aed57fd-8983-46f8-9d6d-2fbd4329d950)

In theory, we should also adjust `CosSegmentedBar` to prevent the same problem from happening; luckily, `CosSegmentedBar` is only used in much wider areas due to the extra info it contains, so I decided to leave it as is for now.


