### PR TITLE
feat: 335 chart warning displays

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosBackButton/BarChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosBackButton/BarChart.tsx
@@ -14,7 +14,7 @@ export const BarChart = (props: BarChartProps) => {
         {label}
       </span>
       <div className="flex w-[90px] items-center">
-        <CosProgressBar color="bg-chart-1" progress={progress} />
+        <CosProgressBar progress={progress} />
       </div>
     </div>
   )

--- a/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
@@ -17,9 +17,6 @@ export type CosPercentagePieChartProps = {
    */
   color?: StrokeColorClass
   percentageFormatter?: (value: number) => string
-  /**
-   * @default Over Limit
-   */
   overThresholdText?: string
   /**
    * @default false

--- a/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
@@ -49,7 +49,7 @@ export const CosPercentagePieChart = (props: CosPercentagePieChartProps) => {
     color: colorProp,
     thresholdPercentage = 100,
     percentageFormatter = defaultPercentageFormatter,
-    overThresholdText = 'Over Limit',
+    overThresholdText,
     isLoading = false,
   } = props
 

--- a/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
@@ -3,33 +3,60 @@ import { PercentagePie } from './PercentagePie'
 import { CosSkeleton } from '../CosSkeleton/CosSkeleton'
 import { twJoin } from 'tailwind-merge'
 
-export type CosPercentageChartProps = {
+export type CosPercentagePieChartProps = {
   title: string
   unit: string
   total: number
   used: number
   /**
-   * @default 'stroke-cosmos-secondary'
+   * @default 100
+   */
+  thresholdPercentage?: number
+  /**
+   * If not provided, the color will be determined based on the percentage.
    */
   color?: StrokeColorClass
+  percentageFormatter?: (value: number) => string
+  /**
+   * @default Over Limit
+   */
+  overThresholdText?: string
   /**
    * @default false
    */
   isLoading?: boolean
 }
 
-export const CosPercentagePieChart = (props: CosPercentageChartProps) => {
+const defaultPercentageFormatter = (value: number) => {
+  return `${value}%`
+}
+
+const getPercentageColor = (percentage: number): StrokeColorClass => {
+  if (percentage <= 50) {
+    return 'stroke-chart-1'
+  } else if (percentage > 50 && percentage <= 80) {
+    return 'stroke-status-warning'
+  }
+  return 'stroke-status-negative'
+}
+
+export const CosPercentagePieChart = (props: CosPercentagePieChartProps) => {
   const {
     title,
     unit,
     total,
     used,
-    color = 'stroke-cosmos-secondary',
+    color: colorProp,
+    thresholdPercentage = 100,
+    percentageFormatter = defaultPercentageFormatter,
+    overThresholdText = 'Over Limit',
     isLoading = false,
   } = props
 
   // Default to 0 to avoid NaN when total is 0.
   const percentage = Math.floor((used / total) * 100) || 0
+  const color = colorProp ?? getPercentageColor(percentage)
+  const isOverThreshold = percentage > thresholdPercentage
 
   return (
     <div className="flex flex-col items-center gap-y-4">
@@ -55,12 +82,23 @@ export const CosPercentagePieChart = (props: CosPercentageChartProps) => {
       ) : (
         <>
           <div className="relative">
-            <PercentagePie color={color} percentage={percentage} />
-            <div className="absolute left-1/2 top-1/2 flex -translate-x-1/2 -translate-y-1/2 flex-col items-center gap-y-1">
+            <PercentagePie
+              color={color}
+              percentage={percentage}
+              thresholdPercentage={thresholdPercentage}
+            />
+            <div className="absolute left-1/2 top-[50px] flex -translate-x-1/2 flex-col items-center gap-y-1">
               <span className="primary-h3 text-functional-title">
-                {percentage}%
+                {percentageFormatter(percentage)}
               </span>
-              <span className="primary-body5 text-functional-text-light">{`${total} ${unit}`}</span>
+              <div className="flex flex-col items-center">
+                <span className="primary-body5 text-functional-text-light">{`${total} ${unit}`}</span>
+                {isOverThreshold && (
+                  <span className="primary-body5 text-status-negative">
+                    {overThresholdText}
+                  </span>
+                )}
+              </div>
             </div>
           </div>
           <span className="primary-body5 text-functional-text-light">{`${used}/${total} ${unit} Used`}</span>

--- a/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/PercentagePie.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/PercentagePie.tsx
@@ -2,8 +2,9 @@ import { clamp } from 'lodash'
 import { StrokeColorClass } from '@cube-frontend/ui-theme'
 
 type PercentagePieProps = {
-  percentage: number
   color: StrokeColorClass
+  percentage: number
+  thresholdPercentage: number
 }
 
 const WIDTH = 144
@@ -13,8 +14,9 @@ const halfWidth = WIDTH / 2
 const radius = (WIDTH - STROKE_WIDTH) / 2
 const circumference = 2 * Math.PI * radius
 
-const getSvgPercentage = (percentage: number) => {
-  let svgPercentage = clamp(percentage, 0, 100)
+const getSvgPercentage = (percentage: number, thresholdPercentage: number) => {
+  const svgPercentageRatio = thresholdPercentage / 100
+  let svgPercentage = clamp(percentage / svgPercentageRatio, 0, 100)
 
   /**
    * Workaround:
@@ -31,11 +33,24 @@ const getSvgPercentage = (percentage: number) => {
   return svgPercentage
 }
 
-export const PercentagePie = (props: PercentagePieProps) => {
-  const { percentage, color } = props
+const getOverThresholdSvgPercentage = (
+  percentage: number,
+  thresholdPercentage: number,
+) => getSvgPercentage(percentage - thresholdPercentage, thresholdPercentage)
 
-  const svgPercentage = getSvgPercentage(percentage)
-  const offset = circumference - (svgPercentage / 100) * circumference
+export const PercentagePie = (props: PercentagePieProps) => {
+  const { color, percentage, thresholdPercentage } = props
+
+  const mainSvgPercentage = getSvgPercentage(percentage, thresholdPercentage)
+  const mainSvgOffset =
+    circumference - (mainSvgPercentage / 100) * circumference
+
+  const overThresholdSvgPercentage = getOverThresholdSvgPercentage(
+    percentage,
+    thresholdPercentage,
+  )
+  const overThresholdSvgOffset =
+    circumference - (overThresholdSvgPercentage / 100) * circumference
 
   return (
     <svg width={WIDTH} height={WIDTH} className="-rotate-90">
@@ -54,9 +69,22 @@ export const PercentagePie = (props: PercentagePieProps) => {
         fill="transparent"
         strokeWidth={STROKE_WIDTH}
         strokeDasharray={circumference}
-        strokeDashoffset={offset}
+        strokeDashoffset={mainSvgOffset}
         strokeLinecap="round"
       />
+      {overThresholdSvgPercentage > 0 && (
+        <circle
+          className={'fill-transparent stroke-status-over-limit'}
+          cx={halfWidth}
+          cy={halfWidth}
+          r={radius}
+          fill="transparent"
+          strokeWidth={STROKE_WIDTH}
+          strokeDasharray={circumference}
+          strokeDashoffset={overThresholdSvgOffset}
+          strokeLinecap="round"
+        />
+      )}
     </svg>
   )
 }

--- a/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBar.tsx
@@ -1,13 +1,12 @@
 import { CSSProperties } from 'react'
 import { cva } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
-import { BackgroundColorClass } from '@cube-frontend/ui-theme'
 import { PropsWithClassName } from '@cube-frontend/utils'
 import { CosProgressBarSkeleton } from './CosProgressBarSkeleton'
+import { BackgroundColorClass } from '@cube-frontend/ui-theme'
 import { useFillWidth } from './useFillWidth'
 
 export type CosProgressBarProps = {
-  color: BackgroundColorClass
   /**
    * An integer between 0 and 100 indicating the progress (percentage).
    */
@@ -23,24 +22,44 @@ const progressCva = cva('absolute h-full', {
   },
 })
 
+const getProgressColor = (progress: number): BackgroundColorClass => {
+  if (progress <= 50) {
+    return 'bg-chart-1'
+  } else if (progress > 50 && progress <= 80) {
+    return 'bg-status-warning'
+  }
+  return 'bg-status-negative'
+}
+
 export const CosProgressBar = (props: CosProgressBarProps) => {
-  const { className: classNameProps, color, progress } = props
+  const { className: classNameProps, progress } = props
 
   if (progress < 0) {
     console.warn('progress value should not be less than 0')
   }
 
-  const { barRef, fillWidthPercentage } = useFillWidth(progress)
+  const {
+    barRef,
+    fillWidthPercentage,
+    overThresholdFillWidthPercentage,
+    overThresholdProgress,
+  } = useFillWidth(progress)
 
   // Use inline style because dynamic value is not supported in TailwindCSS.
   const progressWidthStyle: CSSProperties = {
     width: `${fillWidthPercentage}%`,
   }
 
+  const overThresholdProgressWidthStyle: CSSProperties = {
+    width: `${overThresholdFillWidthPercentage}%`,
+  }
+
   const className = twMerge(
     'inline-flex w-full shrink-0 items-center gap-x-[6px]',
     classNameProps,
   )
+
+  const color = getProgressColor(progress)
 
   return (
     <div className={className}>
@@ -57,6 +76,17 @@ export const CosProgressBar = (props: CosProgressBarProps) => {
           )}
           style={progressWidthStyle}
         />
+        {overThresholdFillWidthPercentage > 0 && (
+          <div
+            className={twMerge(
+              progressCva({
+                isFull: overThresholdProgress >= 100,
+              }),
+              'bg-status-over-limit',
+            )}
+            style={overThresholdProgressWidthStyle}
+          />
+        )}
       </div>
       <span className="primary-body5 text-functional-text">{`${Math.round(progress)}%`}</span>
     </div>

--- a/packages/cube-frontend-ui-library/src/components/CosProgressBar/useFillWidth.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBar/useFillWidth.ts
@@ -2,11 +2,51 @@ import { RefObject, useEffect, useMemo, useRef, useState } from 'react'
 
 type UseFillWidth = {
   barRef: RefObject<HTMLDivElement | null>
+  overThresholdProgress: number
   fillWidthPercentage: number
+  overThresholdFillWidthPercentage: number
 }
 
 const MIN_TRACK_WIDTH = 16
 const MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE = 4
+
+const calculateFillWidthPercentage = (
+  progressProp: number,
+  barWidth: number,
+): number => {
+  if (progressProp >= 100) {
+    return 100
+  }
+
+  if (progressProp <= 0 || barWidth <= MIN_TRACK_WIDTH) {
+    return progressProp
+  }
+
+  let progress = progressProp
+  let filledWidth = 0
+  let blankWidth = 0
+
+  const updateWidths = (): void => {
+    filledWidth = barWidth * (progress / 100)
+    blankWidth = barWidth - filledWidth
+  }
+
+  updateWidths()
+
+  if (filledWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE) {
+    while (filledWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE && progress < 100) {
+      progress++
+      updateWidths()
+    }
+  } else if (blankWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE) {
+    while (blankWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE && progress > 0) {
+      progress--
+      updateWidths()
+    }
+  }
+
+  return progress
+}
 
 /**
  * If the bar width is too small, the filled area will be too short for the
@@ -37,46 +77,21 @@ export const useFillWidth = (progressProp: number): UseFillWidth => {
     }
   }, [])
 
-  const fillWidthPercentage = useMemo<number>(() => {
-    if (
-      progressProp <= 0 ||
-      progressProp >= 100 ||
-      barWidth <= MIN_TRACK_WIDTH
-    ) {
-      return progressProp
-    }
+  const fillWidthPercentage = useMemo<number>(
+    () => calculateFillWidthPercentage(progressProp, barWidth),
+    [progressProp, barWidth],
+  )
 
-    let progress = progressProp
-    let filledWidth = 0
-    let blankWidth = 0
+  const overThresholdProgress = Math.max(0, progressProp - 100)
 
-    const updateWidths = (): void => {
-      filledWidth = barWidth * (progress / 100)
-      blankWidth = barWidth - filledWidth
-    }
-
-    updateWidths()
-
-    if (filledWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE) {
-      while (
-        filledWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE &&
-        progress < 100
-      ) {
-        progress++
-        updateWidths()
-      }
-    } else if (blankWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE) {
-      while (blankWidth < MIN_WIDTH_FOR_RADIUS_TO_BE_VISIBLE && progress > 0) {
-        progress--
-        updateWidths()
-      }
-    }
-
-    return progress
-  }, [barWidth, progressProp])
+  const overThresholdFillWidthPercentage = useMemo<number>(() => {
+    return calculateFillWidthPercentage(overThresholdProgress, barWidth)
+  }, [barWidth, overThresholdProgress])
 
   return {
     barRef,
     fillWidthPercentage,
+    overThresholdFillWidthPercentage,
+    overThresholdProgress,
   }
 }

--- a/packages/cube-frontend-ui-library/src/components/CosProgressBarChart/CosProgressBarChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBarChart/CosProgressBarChart.tsx
@@ -1,4 +1,3 @@
-import { BackgroundColorClass } from '@cube-frontend/ui-theme'
 import {
   CosProgressBar,
   CosProgressBarProps,
@@ -24,15 +23,6 @@ export const CosProgressBarChart = (props: CosProgressBarChart) => {
     ...restProps
   } = props
 
-  const getColor = (): BackgroundColorClass => {
-    if (progress < 50) {
-      return 'bg-chart-1'
-    } else if (progress >= 50 && progress < 80) {
-      return 'bg-status-warning'
-    }
-    return 'bg-status-negative'
-  }
-
   return (
     <div className="flex flex-1 flex-col items-stretch gap-y-[14px]">
       <div className="flex items-center gap-x-3">
@@ -42,7 +32,7 @@ export const CosProgressBarChart = (props: CosProgressBarChart) => {
       {isLoading ? (
         <CosProgressBar.Skeleton className={skeletonClassName} />
       ) : (
-        <CosProgressBar {...restProps} color={getColor()} progress={progress} />
+        <CosProgressBar {...restProps} progress={progress} />
       )}
     </div>
   )

--- a/packages/cube-frontend-ui-library/src/stories/components/CosPercentagePieChart/CosPercentagePieChart.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosPercentagePieChart/CosPercentagePieChart.stories.tsx
@@ -28,78 +28,91 @@ const PercentagePieChartGallery = () => {
           <CosPercentagePieChart
             title="Memory"
             unit="GB"
+            overThresholdText="Over Limit"
             used={0}
             total={755.1}
           />
           <CosPercentagePieChart
             title="Memory"
             unit="GB"
+            overThresholdText="Over Limit"
             used={8.2}
             total={755.1}
           />
           <CosPercentagePieChart
             title="Memory"
             unit="GB"
+            overThresholdText="Over Limit"
             used={380}
             total={755.1}
           />
           <CosPercentagePieChart
             title="Memory"
             unit="GB"
+            overThresholdText="Over Limit"
             used={388}
             total={755.1}
           />
           <CosPercentagePieChart
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             used={80}
             total={100}
           />
           <CosPercentagePieChart
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             used={81}
             total={100}
           />
           <CosPercentagePieChart
             title="Memory"
             unit="GB"
+            overThresholdText="Over Limit"
             used={99}
             total={100}
           />
           <CosPercentagePieChart
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             used={101}
             total={100}
           />
           <CosPercentagePieChart
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             used={150}
             total={100}
           />
           <CosPercentagePieChart
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             used={199}
             total={100}
           />
           <CosPercentagePieChart
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             used={200}
             total={100}
           />
           <CosPercentagePieChart
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             used={250}
             total={100}
           />
           <CosPercentagePieChart
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             used={300}
             total={100}
           />
@@ -118,7 +131,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={0}
               total={10}
@@ -128,7 +140,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={4}
               total={100}
@@ -138,7 +149,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={200}
               total={100}
@@ -148,7 +158,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={396}
               total={100}
@@ -158,7 +167,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={400}
               total={100}
@@ -168,7 +176,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={404}
               total={100}
@@ -178,7 +185,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={600}
               total={100}
@@ -188,7 +194,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={796}
               total={100}
@@ -198,7 +203,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={800}
               total={100}
@@ -208,7 +212,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={1000}
               total={100}
@@ -218,7 +221,6 @@ const PercentagePieChartGallery = () => {
               unit="vCPU"
               color="stroke-chart-2"
               percentageFormatter={formatCpuPercentage}
-              overThresholdText="Over Load"
               thresholdPercentage={400}
               used={1200}
               total={100}
@@ -232,6 +234,7 @@ const PercentagePieChartGallery = () => {
             isLoading={true}
             title="Memory"
             unit="GB"
+            overThresholdText="Over Limit"
             total={0}
             used={0}
           />
@@ -239,6 +242,7 @@ const PercentagePieChartGallery = () => {
             isLoading={true}
             title="Storage"
             unit="GB"
+            overThresholdText="Over Limit"
             total={0}
             used={0}
           />

--- a/packages/cube-frontend-ui-library/src/stories/components/CosPercentagePieChart/CosPercentagePieChart.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosPercentagePieChart/CosPercentagePieChart.stories.tsx
@@ -75,6 +75,13 @@ const PercentagePieChartGallery = () => {
             total={100}
           />
           <CosPercentagePieChart
+            title="Memory"
+            unit="GB"
+            overThresholdText="Over Limit"
+            used={100}
+            total={100}
+          />
+          <CosPercentagePieChart
             title="Storage"
             unit="GB"
             overThresholdText="Over Limit"

--- a/packages/cube-frontend-ui-library/src/stories/components/CosPercentagePieChart/CosPercentagePieChart.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosPercentagePieChart/CosPercentagePieChart.stories.tsx
@@ -14,130 +14,226 @@ export const Gallery: StoryObj = {
   render: () => <PercentagePieChartGallery />,
 }
 
-const rowClass = twJoin('flex flex-row gap-x-7')
+const rowClass = twJoin('flex flex-row flex-wrap gap-10')
+
+const formatCpuPercentage = (value: number) => {
+  return `${value / 100}x`
+}
 
 const PercentagePieChartGallery = () => {
   return (
     <StoryLayout title="Percentage Pie Chart">
-      <StoryLayout.Section title="Default Color">
+      <StoryLayout.Section title="Default">
         <div className={rowClass}>
           <CosPercentagePieChart
-            title="vCPU"
-            unit="vCPU"
-            total={144}
+            title="Memory"
+            unit="GB"
             used={0}
-          />
-          <CosPercentagePieChart
-            title="vCPU"
-            unit="vCPU"
-            total={100}
-            used={1}
-          />
-          <CosPercentagePieChart
-            title="Memory"
-            unit="GB"
             total={755.1}
-            used={124.4}
           />
           <CosPercentagePieChart
             title="Memory"
             unit="GB"
+            used={8.2}
+            total={755.1}
+          />
+          <CosPercentagePieChart
+            title="Memory"
+            unit="GB"
+            used={380}
+            total={755.1}
+          />
+          <CosPercentagePieChart
+            title="Memory"
+            unit="GB"
+            used={388}
+            total={755.1}
+          />
+          <CosPercentagePieChart
+            title="Storage"
+            unit="GB"
+            used={80}
             total={100}
+          />
+          <CosPercentagePieChart
+            title="Storage"
+            unit="GB"
+            used={81}
+            total={100}
+          />
+          <CosPercentagePieChart
+            title="Memory"
+            unit="GB"
             used={99}
-          />
-          <CosPercentagePieChart
-            title="Storage"
-            unit="GB"
-            total={24401.9}
-            used={24401.9}
-          />
-          <CosPercentagePieChart
-            title="Storage"
-            unit="GB"
             total={100}
-            used={400}
+          />
+          <CosPercentagePieChart
+            title="Storage"
+            unit="GB"
+            used={101}
+            total={100}
+          />
+          <CosPercentagePieChart
+            title="Storage"
+            unit="GB"
+            used={150}
+            total={100}
+          />
+          <CosPercentagePieChart
+            title="Storage"
+            unit="GB"
+            used={199}
+            total={100}
+          />
+          <CosPercentagePieChart
+            title="Storage"
+            unit="GB"
+            used={200}
+            total={100}
+          />
+          <CosPercentagePieChart
+            title="Storage"
+            unit="GB"
+            used={250}
+            total={100}
+          />
+          <CosPercentagePieChart
+            title="Storage"
+            unit="GB"
+            used={300}
+            total={100}
           />
         </div>
       </StoryLayout.Section>
-      <StoryLayout.Section title="Custom Color">
-        <div className={rowClass}>
-          <CosPercentagePieChart
-            title="vCPU"
-            unit="vCPU"
-            total={144}
-            used={0}
-            color="stroke-chart-1"
-          />
-          <CosPercentagePieChart
-            title="vCPU"
-            unit="vCPU"
-            total={100}
-            used={1}
-            color="stroke-chart-2"
-          />
-          <CosPercentagePieChart
-            title="Memory"
-            unit="GB"
-            total={755.1}
-            used={124.4}
-            color="stroke-chart-3"
-          />
-          <CosPercentagePieChart
-            title="Memory"
-            unit="GB"
-            total={100}
-            used={99}
-            color="stroke-chart-4"
-          />
-          <CosPercentagePieChart
-            title="Storage"
-            unit="GB"
-            total={24401.9}
-            used={24401.9}
-            color="stroke-chart-5"
-          />
-          <CosPercentagePieChart
-            title="Storage"
-            unit="GB"
-            total={100}
-            used={400}
-            color="stroke-chart-6"
-          />
+
+      <StoryLayout.Section title="CPU Usage">
+        <div className="flex flex-col gap-y-4">
+          <span className="primary-body2 text-functional-text">
+            Customize the color, overLimitText and thresholdPercentage(set to
+            400).
+          </span>
+          <div className={rowClass}>
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={0}
+              total={10}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={4}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={200}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={396}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={400}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={404}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={600}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={796}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={800}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={1000}
+              total={100}
+            />
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              overThresholdText="Over Load"
+              thresholdPercentage={400}
+              used={1200}
+              total={100}
+            />
+          </div>
         </div>
       </StoryLayout.Section>
       <StoryLayout.Section title="Skeleton">
         <div className={rowClass}>
           <CosPercentagePieChart
             isLoading={true}
-            title="vCPU"
-            unit="vCPU"
-            total={0}
-            used={0}
-            color="stroke-chart-1"
-          />
-          <CosPercentagePieChart
-            isLoading={true}
-            title="vCPU"
-            unit="vCPU"
-            total={0}
-            used={0}
-            color="stroke-chart-2"
-          />
-          <CosPercentagePieChart
-            isLoading={true}
             title="Memory"
             unit="GB"
             total={0}
             used={0}
-            color="stroke-chart-3"
-          />
-          <CosPercentagePieChart
-            isLoading={true}
-            title="Memory"
-            unit="GB"
-            total={0}
-            used={0}
-            color="stroke-chart-4"
           />
           <CosPercentagePieChart
             isLoading={true}
@@ -145,15 +241,13 @@ const PercentagePieChartGallery = () => {
             unit="GB"
             total={0}
             used={0}
-            color="stroke-chart-5"
           />
           <CosPercentagePieChart
             isLoading={true}
-            title="Storage"
+            title="CPU"
             unit="GB"
             total={0}
             used={0}
-            color="stroke-chart-6"
           />
         </div>
       </StoryLayout.Section>

--- a/packages/cube-frontend-ui-library/src/stories/components/CosProgressBar/CosProgressBar.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosProgressBar/CosProgressBar.stories.tsx
@@ -16,26 +16,56 @@ const ProgressBarGallery = () => {
   return (
     <StoryLayout title="Progress Bar">
       <StoryLayout.Section title="Progress">
-        <div className="flex flex-col gap-y-4">
-          <CosProgressBar
-            className="w-[90px]"
-            progress={50}
-            color="bg-chart-1"
-          />
-          <CosProgressBar progress={50} color="bg-chart-1" />
+        <div className="flex flex-col gap-y-8">
           <div className="flex flex-col gap-y-4">
-            <CosProgressBar progress={0} color="bg-chart-1" />
-            <CosProgressBar progress={1} color="bg-chart-1" />
-            <CosProgressBar progress={50} color="bg-chart-2" />
-            <CosProgressBar progress={99} color="bg-chart-3" />
-            <CosProgressBar progress={100} color="bg-chart-4" />
+            <CosProgressBar progress={0} />
+            <CosProgressBar progress={1} />
+            <CosProgressBar progress={50} />
+            <CosProgressBar progress={51} />
+            <CosProgressBar progress={70} />
+            <CosProgressBar progress={80} />
+            <CosProgressBar progress={81} />
+            <CosProgressBar progress={99} />
+            <CosProgressBar progress={100} />
+            <CosProgressBar progress={101} />
+            <CosProgressBar progress={150} />
+            <CosProgressBar progress={199} />
+            <CosProgressBar progress={200} />
+            <CosProgressBar progress={250} />
+            <CosProgressBar progress={300} />
+          </div>
+          <div className="flex flex-col gap-y-4">
+            <div className="flex flex-col gap-y-4">
+              <span className="primary-body2 text-functional-text">
+                Default: Full Width
+              </span>
+              <CosProgressBar progress={50} />
+            </div>
+            <div className="flex flex-col gap-y-4">
+              <span className="primary-body2 text-functional-text">
+                Custom Width
+              </span>
+              <CosProgressBar className="w-[90px]" progress={50} />
+            </div>
+            <div className="flex flex-col gap-y-4">
+              <span className="primary-body2 text-functional-text">
+                Flex Display
+              </span>
+              <div className="flex items-center gap-x-4">
+                <CosProgressBar className="flex-1" progress={50} />
+                <CosProgressBar className="flex-1" progress={50} />
+                <CosProgressBar className="flex-1" progress={50} />
+                <CosProgressBar className="flex-1" progress={50} />
+                <CosProgressBar className="flex-1" progress={50} />
+              </div>
+            </div>
           </div>
         </div>
       </StoryLayout.Section>
       <StoryLayout.Section title="Skeleton">
         <div className="flex flex-col gap-y-4">
-          <CosProgressBar.Skeleton className="w-[90px]" />
           <CosProgressBar.Skeleton />
+          <CosProgressBar.Skeleton className="w-[90px]" />
           <div className="flex items-center gap-x-4">
             <CosProgressBar.Skeleton />
             <CosProgressBar.Skeleton />

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/CosBasicTable.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/CosBasicTable.stories.tsx
@@ -55,30 +55,14 @@ const Default = () => (
       {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
     </NodeTable.Column>
     <NodeTable.Column label="CPU" property="cpu">
-      {(cpu) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-1"
-          progress={cpu}
-        />
-      )}
+      {(cpu) => <CosProgressBar className="min-w-[90px]" progress={cpu} />}
     </NodeTable.Column>
     <NodeTable.Column label="RAM" property="ram">
-      {(ram) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-2"
-          progress={ram}
-        />
-      )}
+      {(ram) => <CosProgressBar className="min-w-[90px]" progress={ram} />}
     </NodeTable.Column>
     <NodeTable.Column label="Partition" property="partition">
       {(partition) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-3"
-          progress={partition}
-        />
+        <CosProgressBar className="min-w-[90px]" progress={partition} />
       )}
     </NodeTable.Column>
     <NodeTable.Column label="Running" property="running">
@@ -110,30 +94,14 @@ const Sortable = () => (
       {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
     </NodeTable.Column>
     <NodeTable.Column label="CPU" property="cpu">
-      {(cpu) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-1"
-          progress={cpu}
-        />
-      )}
+      {(cpu) => <CosProgressBar className="min-w-[90px]" progress={cpu} />}
     </NodeTable.Column>
     <NodeTable.Column label="RAM" property="ram" isSortable={true}>
-      {(ram) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-2"
-          progress={ram}
-        />
-      )}
+      {(ram) => <CosProgressBar className="min-w-[90px]" progress={ram} />}
     </NodeTable.Column>
     <NodeTable.Column label="Partition" property="partition">
       {(partition) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-3"
-          progress={partition}
-        />
+        <CosProgressBar className="min-w-[90px]" progress={partition} />
       )}
     </NodeTable.Column>
     <NodeTable.Column label="Running" property="running">
@@ -171,30 +139,14 @@ const SortableWithDefaultState = () => (
       {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
     </NodeTable.Column>
     <NodeTable.Column label="CPU" property="cpu">
-      {(cpu) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-1"
-          progress={cpu}
-        />
-      )}
+      {(cpu) => <CosProgressBar className="min-w-[90px]" progress={cpu} />}
     </NodeTable.Column>
     <NodeTable.Column label="RAM" property="ram" isSortable={true}>
-      {(ram) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-2"
-          progress={ram}
-        />
-      )}
+      {(ram) => <CosProgressBar className="min-w-[90px]" progress={ram} />}
     </NodeTable.Column>
     <NodeTable.Column label="Partition" property="partition">
       {(partition) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-3"
-          progress={partition}
-        />
+        <CosProgressBar className="min-w-[90px]" progress={partition} />
       )}
     </NodeTable.Column>
     <NodeTable.Column label="Running" property="running">
@@ -235,30 +187,14 @@ const FitContent = () => {
           {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
         </NodeTable.Column>
         <NodeTable.Column label="CPU" property="cpu">
-          {(cpu) => (
-            <CosProgressBar
-              className="min-w-[90px]"
-              color="bg-chart-1"
-              progress={cpu}
-            />
-          )}
+          {(cpu) => <CosProgressBar className="min-w-[90px]" progress={cpu} />}
         </NodeTable.Column>
         <NodeTable.Column label="RAM" property="ram">
-          {(ram) => (
-            <CosProgressBar
-              className="min-w-[90px]"
-              color="bg-chart-2"
-              progress={ram}
-            />
-          )}
+          {(ram) => <CosProgressBar className="min-w-[90px]" progress={ram} />}
         </NodeTable.Column>
         <NodeTable.Column label="Partition" property="partition">
           {(partition) => (
-            <CosProgressBar
-              className="min-w-[90px]"
-              color="bg-chart-3"
-              progress={partition}
-            />
+            <CosProgressBar className="min-w-[90px]" progress={partition} />
           )}
         </NodeTable.Column>
         <NodeTable.Column label="Running" property="running" fitContent={true}>

--- a/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/CustomSortingRule.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTables/Basic/CustomSortingRule.tsx
@@ -37,30 +37,14 @@ export const CustomSortingRule = () => (
       {(licenseExpire) => licenseExpire.toLocaleDateString('en-US')}
     </NodeTable.Column>
     <NodeTable.Column label="CPU" property="cpu">
-      {(cpu) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-1"
-          progress={cpu}
-        />
-      )}
+      {(cpu) => <CosProgressBar className="min-w-[90px]" progress={cpu} />}
     </NodeTable.Column>
     <NodeTable.Column label="RAM" property="ram">
-      {(ram) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-2"
-          progress={ram}
-        />
-      )}
+      {(ram) => <CosProgressBar className="min-w-[90px]" progress={ram} />}
     </NodeTable.Column>
     <NodeTable.Column label="Partition" property="partition">
       {(partition) => (
-        <CosProgressBar
-          className="min-w-[90px]"
-          color="bg-chart-3"
-          progress={partition}
-        />
+        <CosProgressBar className="min-w-[90px]" progress={partition} />
       )}
     </NodeTable.Column>
     <NodeTable.Column label="Running" property="running">

--- a/packages/cube-frontend-ui-theme/src/cubeTheme.ts
+++ b/packages/cube-frontend-ui-theme/src/cubeTheme.ts
@@ -165,6 +165,7 @@ export const cubeTheme = {
       warning: '#F9C300',
       paused: '#FF9920',
       neutral: '#4C68F9',
+      'over-limit': '#9B426E',
     },
     chart: {
       1: '#57E2E2',

--- a/packages/cube-frontend-web-app/src/components/CpuPercentagePieChart/CpuPercentagePieChart.tsx
+++ b/packages/cube-frontend-web-app/src/components/CpuPercentagePieChart/CpuPercentagePieChart.tsx
@@ -1,0 +1,30 @@
+import {
+  CosPercentagePieChart,
+  CosPercentagePieChartProps,
+} from '@cube-frontend/ui-library'
+
+const formatCpuPercentage = (value: number) => {
+  return `${value / 100}x`
+}
+
+export type CpuPercentagePieChartProps = Omit<
+  CosPercentagePieChartProps,
+  | 'title'
+  | 'color'
+  | 'percentageFormatter'
+  | 'overLimitText'
+  | 'thresholdPercentage'
+>
+
+export const CpuPercentagePieChart = (props: CpuPercentagePieChartProps) => {
+  return (
+    <CosPercentagePieChart
+      title="vCPU"
+      color="stroke-chart-2"
+      percentageFormatter={formatCpuPercentage}
+      overThresholdText="Over Load"
+      thresholdPercentage={400}
+      {...props}
+    />
+  )
+}

--- a/packages/cube-frontend-web-app/src/components/CpuPercentagePieChart/CpuPercentagePieChart.tsx
+++ b/packages/cube-frontend-web-app/src/components/CpuPercentagePieChart/CpuPercentagePieChart.tsx
@@ -22,7 +22,6 @@ export const CpuPercentagePieChart = (props: CpuPercentagePieChartProps) => {
       title="vCPU"
       color="stroke-chart-2"
       percentageFormatter={formatCpuPercentage}
-      overThresholdText="Over Load"
       thresholdPercentage={400}
       {...props}
     />

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/ChartPanel/ChartPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/ChartPanel/ChartPanel.tsx
@@ -10,6 +10,7 @@ import { useMediaQuery } from '@cube-frontend/web-app/hooks/useMediaQuery'
 import { useContext, useMemo } from 'react'
 import { toMetricsChart } from '../../../utils'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { CpuPercentagePieChart } from '@cube-frontend/web-app/components/CpuPercentagePieChart/CpuPercentagePieChart'
 
 export type ChartPanelProps = {
   metrics: GetMetricsResponseData
@@ -36,11 +37,7 @@ export const ChartPanel = (props: ChartPanelProps) => {
   const vmAllocationPanel = (
     <CosGeneralPanel topic="VM allocation">
       <div className="flex h-[260px] w-full flex-row justify-around gap-x-[35px] p-5">
-        <CosPercentagePieChart
-          title="vCPU"
-          isLoading={isLoading}
-          {...cpuPieChart}
-        />
+        <CpuPercentagePieChart isLoading={isLoading} {...cpuPieChart} />
         <CosPercentagePieChart
           title="Memory"
           isLoading={isLoading}

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/ChartPanel/ChartPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/ChartPanel/ChartPanel.tsx
@@ -40,11 +40,13 @@ export const ChartPanel = (props: ChartPanelProps) => {
         <CpuPercentagePieChart isLoading={isLoading} {...cpuPieChart} />
         <CosPercentagePieChart
           title="Memory"
+          overThresholdText="Over Limit"
           isLoading={isLoading}
           {...memoryPieChart}
         />
         <CosPercentagePieChart
           title="Storage"
+          overThresholdText="Over Limit"
           isLoading={isLoading}
           {...storagePieChart}
         />

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/ChartPanel/ChartPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/ChartPanel/ChartPanel.tsx
@@ -4,6 +4,7 @@ import {
   CosDashboardPanel,
   CosPercentagePieChart,
 } from '@cube-frontend/ui-library'
+
 import { toPluralizeDisplay } from '@cube-frontend/utils'
 import { metricsApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
@@ -11,6 +12,7 @@ import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/use
 import { useMediaQuery } from '@cube-frontend/web-app/hooks/useMediaQuery'
 import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentialInterval/useSequentialInterval'
 import { useUpdateTime } from '@cube-frontend/web-app/hooks/useUpdateTime'
+import { CpuPercentagePieChart } from '@cube-frontend/web-app/components/CpuPercentagePieChart/CpuPercentagePieChart'
 import { noop } from 'lodash'
 import { useContext, useMemo } from 'react'
 import { Link } from 'react-router'
@@ -59,11 +61,7 @@ const ChartPanel = () => {
   const vmAllocationPanelItem = (
     <CosDashboardPanel.Item topic="VM allocation">
       <div className="flex flex-row justify-around gap-x-7">
-        <CosPercentagePieChart
-          title="vCPU"
-          isLoading={isLoading}
-          {...cpuPieChart}
-        />
+        <CpuPercentagePieChart isLoading={isLoading} {...cpuPieChart} />
         <CosPercentagePieChart
           title="Memory"
           isLoading={isLoading}

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/ChartPanel/ChartPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/ChartPanel/ChartPanel.tsx
@@ -64,11 +64,13 @@ const ChartPanel = () => {
         <CpuPercentagePieChart isLoading={isLoading} {...cpuPieChart} />
         <CosPercentagePieChart
           title="Memory"
+          overThresholdText="Over Limit"
           isLoading={isLoading}
           {...memoryPieChart}
         />
         <CosPercentagePieChart
           title="Storage"
+          overThresholdText="Over Limit"
           isLoading={isLoading}
           {...storagePieChart}
         />

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
@@ -76,7 +76,6 @@ export const NodeTable = (props: NodeTableProps) => {
         {(cpu) => (
           <CosProgressBar
             className="min-w-[90px]"
-            color="bg-chart-1"
             progress={toPercentage(cpu.usedCores, cpu.totalCores)}
           />
         )}
@@ -89,7 +88,6 @@ export const NodeTable = (props: NodeTableProps) => {
         {(memory) => (
           <CosProgressBar
             className="min-w-[90px]"
-            color="bg-chart-2"
             progress={toPercentage(memory.usedMiB, memory.totalMiB)}
           />
         )}
@@ -102,7 +100,6 @@ export const NodeTable = (props: NodeTableProps) => {
         {(storage) => (
           <CosProgressBar
             className="min-w-[90px]"
-            color="bg-chart-3"
             progress={toPercentage(storage.usedMiB, storage.totalMiB)}
           />
         )}

--- a/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
@@ -80,7 +80,6 @@ export const NodeTable = (props: NodeTableProps) => {
         {(cpu) => (
           <CosProgressBar
             className="min-w-[90px]"
-            color="bg-chart-1"
             progress={toPercentage(cpu.usedCores, cpu.totalCores)}
           />
         )}
@@ -93,7 +92,6 @@ export const NodeTable = (props: NodeTableProps) => {
         {(memory) => (
           <CosProgressBar
             className="min-w-[90px]"
-            color="bg-chart-2"
             progress={toPercentage(memory.usedMiB, memory.totalMiB)}
           />
         )}
@@ -106,7 +104,6 @@ export const NodeTable = (props: NodeTableProps) => {
         {(storage) => (
           <CosProgressBar
             className="min-w-[90px]"
-            color="bg-chart-3"
             progress={toPercentage(storage.usedMiB, storage.totalMiB)}
           />
         )}


### PR DESCRIPTION
## What type of PR is this?

Fix

## Which issue(s) this PR fixes

Fixes #335 

#### What this PR does / why we need it

Adds warning displays for ProgressBarChart and PercentagePieChart, and customizes the CPU chart to enhance the user experience.

## Screenshots

### UI Library

#### 1.) Progress Bar

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/44c2de78-2795-4720-9a7e-1b1b6e9a38e4" />

1. Removed the `color` prop, as the progress color should be determined by the progress percentage.
2. Display progress color based on the progress percentage.
3. Display overflow progress when the `progress` exceeds 100%.

#### 2.) Progress Bar Chart

<img width="1508" alt="image" src="https://github.com/user-attachments/assets/ef55a287-abb9-4108-89ee-3065e895c4cd" />

1. Removed the `color` prop, as the progress color should be determined by the progress percentage.
2. Display progress color based on the progress percentage.
3. Display overflow progress when the `progress` exceeds 100%.

#### 3.) Percentage Pie Chart

<img width="1510" alt="image" src="https://github.com/user-attachments/assets/dbb5b64a-e707-4b0e-8ddd-b9f4ea9c8d1c" />

<img width="1629" alt="image" src="https://github.com/user-attachments/assets/4664b26b-df53-45fb-9442-f045fac1e84b" />

1. If the `color` prop is not provided, the color is determined by the progress percentage.
2. Display `Over Limit` when  `percentage` > `thresholdPercentage`.
3. Allows customization of `color`, `percentageFormatter`, `overLimitText`, and `thresholdPercentage`.
4. We don't need to handle the `CPU Usage Over Load` case in phase 1.

### Web App

#### 1.) Home Page / VM Allocation Section

<img width="1509" alt="image" src="https://github.com/user-attachments/assets/b5dd1b94-454a-4088-9902-c587f68f3a29" />

#### 2.) Home Page / Node Table

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/161820e8-1d8f-43e2-aea1-4a1a6d5d0b51" />

#### 3.) Chart Page / Usage and VM Allocation Section

<img width="1511" alt="image" src="https://github.com/user-attachments/assets/a3d72572-f0b4-4276-8d66-7a21a8bff42e" />

#### 4.) Node List Page

<img width="1512" alt="image" src="https://github.com/user-attachments/assets/3474286c-aae3-4e68-a7ed-a400d63fc964" />

#### 5.)Node Details Page

<img width="1099" alt="image" src="https://github.com/user-attachments/assets/64738b3d-f639-4fe0-a43d-c71fab581a54" />