### PR TITLE
367 tabs style

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosTabs/CosTab.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosTabs/CosTab.tsx
@@ -18,26 +18,53 @@ export type CosTabProps = {
 )
 
 const tab = cva(
-  'secondary-body2 flex min-h-[34px] max-w-[200px] items-center justify-center border-b-2 px-2.5 py-2',
+  'inline-block min-h-[34px] max-w-[200px] border-b border-b-functional-border-divider',
   {
     variants: {
       isActive: {
-        false: ['border-b-transparent text-functional-text-light'],
+        false: 'text-functional-text-light',
       },
       disabled: {
-        false: [
-          'cursor-pointer font-medium hover:text-functional-hover-primary',
-        ],
-        true: [
-          'cursor-default border-b-transparent text-functional-disable-text',
-        ],
+        false: ['cursor-pointer hover:text-functional-hover-primary'],
+        true: ['cursor-default text-functional-disable-text'],
       },
     },
     compoundVariants: [
       {
         isActive: true,
         disabled: false,
-        className: 'border-b-cosmos-primary font-semibold text-cosmos-primary',
+        className: 'border-b-cosmos-primary text-cosmos-primary',
+      },
+    ],
+    defaultVariants: {
+      isActive: false,
+      disabled: false,
+    },
+  },
+)
+
+// Use an inner container with a default transparent border-bottom to avoid a
+// slight layout shift when toggling between active and inactive states.
+const innerContainer = cva(
+  [
+    'secondary-body2 flex items-center justify-center px-2.5 py-2',
+    'border-b border-b-transparent',
+  ],
+  {
+    variants: {
+      isActive: {
+        true: '',
+        false: '',
+      },
+      disabled: {
+        false: 'font-medium',
+      },
+    },
+    compoundVariants: [
+      {
+        isActive: true,
+        disabled: false,
+        className: 'border-b-cosmos-primary font-semibold',
       },
     ],
     defaultVariants: {
@@ -104,8 +131,17 @@ export const CosTab = (props: CosTabProps) => {
         href: hrefAttribute,
         onClick,
       },
-      renderLabel(),
-      renderDecoration(),
+      <div
+        className={twMerge(
+          innerContainer({
+            isActive,
+            disabled,
+          }),
+        )}
+      >
+        {renderLabel()}
+        {renderDecoration()}
+      </div>,
     )
   }
 

--- a/packages/cube-frontend-ui-library/src/components/CosTabs/CosTabSkeleton.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosTabs/CosTabSkeleton.tsx
@@ -2,7 +2,7 @@ import { CosSkeleton } from '../CosSkeleton/CosSkeleton'
 
 export const CosTabSkeleton = () => {
   return (
-    <div className="px-5 py-2">
+    <div className="border-b border-b-functional-border-divider px-5 py-2">
       <CosSkeleton className="h-4 w-9" />
     </div>
   )

--- a/packages/cube-frontend-ui-library/src/components/CosTabs/CosTabs.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosTabs/CosTabs.tsx
@@ -9,11 +9,7 @@ export type CosTabsProps = {
 export const CosTabs = (props: CosTabsProps) => {
   const { children } = props
 
-  return (
-    <div className="flex items-end border-b border-b-functional-border-divider">
-      {children}
-    </div>
-  )
+  return <div className="flex items-end">{children}</div>
 }
 
 CosTabs.Tab = CosTab


### PR DESCRIPTION
#### What type of PR is this?

- Fix

#### What this PR does / why we need it

1. The grey bottom line should appear only beneath the tab item itself.

<img width="1508" alt="Screenshot 2025-05-13 at 1 43 11 PM" src="https://github.com/user-attachments/assets/849509cd-28fa-408f-972c-a3d7a81142fe" />

2. When the tab is selected, the blue bottom line should fully cover the grey line beneath it.

<img width="890" alt="Screenshot 2025-05-13 at 3 55 30 PM" src="https://github.com/user-attachments/assets/8acb7755-34d5-4dcb-b9c8-357c6c622d00" />


#### Which issue(s) this PR fixes

Fixes #367

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
