### PR TITLE
fix: 366 inconsistent name case format for OpenStack

### DIFF
--- a/packages/cube-frontend-web-app/src/layout/Layout.tsx
+++ b/packages/cube-frontend-web-app/src/layout/Layout.tsx
@@ -1,10 +1,6 @@
-import { CosHeader, CosSideBar } from '@cube-frontend/ui-library'
-import CephIcon from '@cube-frontend/ui-library/icons/colored/ceph.svg?react'
-import KeycloakIcon from '@cube-frontend/ui-library/icons/colored/keycloak.svg?react'
-import OpenStackIcon from '@cube-frontend/ui-library/icons/colored/openstack.svg?react'
-import RancherIcon from '@cube-frontend/ui-library/icons/colored/rancher.svg?react'
 import { PropsWithChildren, useContext } from 'react'
 import { Link } from 'react-router'
+import { CosHeader, CosSideBar } from '@cube-frontend/ui-library'
 import { DataCenterContext } from '../context/DataCenterContext'
 import { IntegrationsContext } from '../context/IntegrationsContext'
 import { UserContext } from '../context/UserContext'
@@ -14,27 +10,7 @@ import { useFunctionBarItems } from './useFunctionBarItems'
 import { useSidebarBottomLinks } from './useSidebarBottomLinks'
 import { useSideBarNagging } from './useSideBarNagging'
 import { useSidebarOptions } from './useSidebarOptions'
-
-const integrationUIData = {
-  keycloak: {
-    Icon: KeycloakIcon,
-    hoverMessage: 'Keycloak',
-  },
-  ceph: {
-    Icon: CephIcon,
-    hoverMessage: 'Ceph',
-  },
-  openstack: {
-    Icon: OpenStackIcon,
-    hoverMessage: 'OpenStack',
-  },
-  rancher: {
-    Icon: RancherIcon,
-    hoverMessage: 'Rancher',
-  },
-} as const
-
-type IntegrationKey = keyof typeof integrationUIData
+import { IntegrationKey, integrationUIData } from '../utils/integration'
 
 const Layout = (props: PropsWithChildren) => {
   const { children } = props
@@ -64,7 +40,8 @@ const Layout = (props: PropsWithChildren) => {
     }
 
     return {
-      ...uiData,
+      Icon: uiData.Icon,
+      hoverMessage: uiData.displayName,
       href: integration.url,
     }
   })

--- a/packages/cube-frontend-web-app/src/pages/integrations/IntegrationsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/integrations/IntegrationsPage.tsx
@@ -10,6 +10,10 @@ import {
 import { integrationsApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
+import {
+  IntegrationKey,
+  integrationUIData,
+} from '@cube-frontend/web-app/utils/integration'
 
 type IntegrationRow = CosTableRow & GetIntegrationsResponseDataInner
 
@@ -19,6 +23,18 @@ const integrationToRow = (item: GetIntegrationsResponseDataInner) => ({
   id: uniqueId('integration'),
   ...item,
 })
+
+const renderIntegrationName = (name: string) => {
+  const key = name as IntegrationKey
+  const uiData = integrationUIData[key]
+
+  if (!uiData) {
+    console.warn(`No UI data is defined for integration: ${name}`)
+    return capitalize(name)
+  }
+
+  return uiData.displayName
+}
 
 export const IntegrationsPage = () => {
   const { dataCenter } = useContext(DataCenterContext)
@@ -50,7 +66,7 @@ export const IntegrationsPage = () => {
             property="name"
             emphasize={true}
           >
-            {capitalize}
+            {renderIntegrationName}
           </IntegrationTable.Column>
           <IntegrationTable.Column
             label="Shown on header"

--- a/packages/cube-frontend-web-app/src/utils/integration.ts
+++ b/packages/cube-frontend-web-app/src/utils/integration.ts
@@ -1,0 +1,25 @@
+import CephIcon from '@cube-frontend/ui-library/icons/colored/ceph.svg?react'
+import KeycloakIcon from '@cube-frontend/ui-library/icons/colored/keycloak.svg?react'
+import OpenStackIcon from '@cube-frontend/ui-library/icons/colored/openstack.svg?react'
+import RancherIcon from '@cube-frontend/ui-library/icons/colored/rancher.svg?react'
+
+export const integrationUIData = {
+  keycloak: {
+    Icon: KeycloakIcon,
+    displayName: 'Keycloak',
+  },
+  ceph: {
+    Icon: CephIcon,
+    displayName: 'Ceph',
+  },
+  openstack: {
+    Icon: OpenStackIcon,
+    displayName: 'OpenStack',
+  },
+  rancher: {
+    Icon: RancherIcon,
+    displayName: 'Rancher',
+  },
+} as const
+
+export type IntegrationKey = keyof typeof integrationUIData


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### Which issue(s) this PR fixes

Fixes #366 

#### What this PR does / why we need it

Issue: Please see Fixes #366

Solution: 

Extracted `integrationUIData` into `utils/integration.ts`, so both `CosHeader` and the `Integration Page` can share the same icon and display logic.

<img width="1331" alt="Screenshot 2025-05-13 at 4 13 05 PM" src="https://github.com/user-attachments/assets/e64b0336-7b29-4fc4-942d-f04a1a1038ef" />

