### PR TITLE
369 update checkbox style in dropdown

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
@@ -6,13 +6,20 @@ import CheckboxSelected from '../../components/CosIcon/monochrome/checkbox_check
 import CheckboxIndeterminate from '../../components/CosIcon/monochrome/checkbox_undeterminate_filled.svg?react'
 import { CosCheckboxSkeleton } from './CosCheckboxSkeleton'
 
+export type CosCheckboxVariant = 'primary' | 'secondary'
+
 export type CosCheckboxStatus = 'unselected' | 'selected' | 'indeterminate'
 
 export type CosCheckboxProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   'checked' | 'defaultChecked'
 > & {
+  /**
+   * @default primary
+   */
+  variant?: CosCheckboxVariant
   label?: string
+  labelClassName?: string
   /**
    * Use `null` for indeterminate state.
    */
@@ -36,17 +43,45 @@ const checkbox = {
   iconWrap: cva(
     [
       'shrink-0 p-0.5',
-      'text-functional-border-darker transition-colors duration-100 peer-hover:text-functional-hover-primary',
+      'text-functional-border-darker transition-colors duration-100',
     ],
     {
       variants: {
+        variant: {
+          primary: '',
+          secondary: '',
+        },
         isSelected: {
-          true: 'text-primary',
+          true: '',
         },
         disabled: {
-          true: 'text-functional-disable-text peer-hover:text-functional-disable-text',
+          true: '',
         },
       },
+      compoundVariants: [
+        {
+          variant: 'primary',
+          isSelected: true,
+          className: 'text-primary peer-hover:text-functional-hover-primary',
+        },
+        {
+          variant: 'primary',
+          disabled: true,
+          className:
+            'text-functional-disable-text peer-hover:text-functional-disable-text',
+        },
+        {
+          variant: 'secondary',
+          isSelected: true,
+          className: 'text-blue-500 peer-hover:text-blue-700',
+        },
+        {
+          variant: 'secondary',
+          disabled: true,
+          className:
+            'text-functional-disable-text peer-hover:text-functional-disable-text',
+        },
+      ],
     },
   ),
   label: cva('max-w-[152px] text-functional-text', {
@@ -60,7 +95,9 @@ const checkbox = {
 
 export const CosCheckbox = (props: CosCheckboxProps) => {
   const {
+    variant = 'primary',
     label,
+    labelClassName,
     id,
     defaultChecked = false,
     checked: controlledChecked,
@@ -100,6 +137,7 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
       <div
         className={twMerge(
           checkbox.iconWrap({
+            variant,
             isSelected: effectiveChecked || isIndeterminate,
             disabled,
           }),
@@ -126,7 +164,9 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
       />
       {renderIcon()}
       {label && (
-        <span className={twMerge(checkbox.label({ disabled }))}>{label}</span>
+        <span className={twMerge(checkbox.label({ disabled }), labelClassName)}>
+          {label}
+        </span>
       )}
     </label>
   )

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownItem.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownItem.tsx
@@ -36,12 +36,13 @@ export const CosDropdownItem = <Item,>(props: CosDropdownItemProps<Item>) => {
         itemStyle({ variant, type, isSelected, isCheckbox, disabled }),
       )}
     >
-      {/** TODO: The checkbox needs to be aligned with the design */}
       <CosCheckbox
         label={label}
+        labelClassName="truncate"
         disabled={disabled}
         checked={isSelected}
         onChange={handleClick}
+        variant={type === 'checkbox' ? 'primary' : 'secondary'}
       />
     </div>
   ) : (

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownMenu.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownMenu.tsx
@@ -58,6 +58,7 @@ export const CosDropdownMenu = (props: CosDropdownMenuProps) => {
         >
           <CosCheckbox
             label="All"
+            variant={type === 'checkbox' ? 'primary' : 'secondary'}
             checked={isAllChecked}
             onClick={() => onAllCheckChange?.(!isAllChecked)}
           />

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownTrigger.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownTrigger.tsx
@@ -75,7 +75,7 @@ export const CosDropdownTrigger = (props: CosDropdownTriggerProps) => {
       <span className="flex shrink-0 items-center gap-2">
         {renderSelectedItemCount()}
         {renderClearButton()}
-        <ChevronDown className={twMerge(triggerIcon({ isOpen }))} />
+        <ChevronDown className={twMerge(triggerIcon({ isOpen, disabled }))} />
       </span>
     </button>
   )

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/styles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/styles.ts
@@ -123,6 +123,10 @@ export const triggerIcon = cva(
       isOpen: {
         true: '-scale-y-100 transform',
       },
+      disabled: {
+        true: 'text-functional-disable-text',
+        false: 'text-functional-text',
+      },
     },
   },
 )

--- a/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/CheckboxDropdown.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/CheckboxDropdown.tsx
@@ -11,7 +11,7 @@ type OptionType = {
 const fruits = [
   {
     code: 'apple',
-    name: 'Apple',
+    name: 'Apple apple apple apple apple',
     disabled: false,
   },
   {
@@ -66,7 +66,7 @@ const fruits = [
   },
   {
     code: 'watermelon',
-    name: 'Watermelon',
+    name: 'Watermelon watermelon watermelon',
     disabled: false,
   },
 ]


### PR DESCRIPTION
#### What type of PR is this?

- Fix

#### What this PR does / why we need it

1. The trigger icon color should be functional-text when it is not in a disabled state.

<img width="1520" alt="Screenshot 2025-05-13 at 4 16 05 PM" src="https://github.com/user-attachments/assets/2ef66a9c-2fff-4ab9-9c27-bac5a1d6267f" />

2. The checkbox color in the dropdown (with a search bar) should be blue-500.

3. Since the dropdown menu has a maximum width, text should be truncated when it's too long. It's confirmed with designer.

https://github.com/user-attachments/assets/a2db9bfd-e9f6-46d7-9752-9b5430382c27

<img width="970" alt="Screenshot 2025-05-13 at 4 09 40 PM" src="https://github.com/user-attachments/assets/484ad3c3-0500-4c19-8559-cde31f5cae17" />



#### Which issue(s) this PR fixes

Fixes #369 

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
