### PR TITLE
341 fix(web-app): home chart page usage panel role groups

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/UsagePanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/UsagePanel.tsx
@@ -1,11 +1,9 @@
-import { GetMetricsResponseData, RoleUsage } from '@cube-frontend/api'
+import { GetMetricsResponseData } from '@cube-frontend/api'
 import { CosGeneralPanel, CosStroke } from '@cube-frontend/ui-library'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { useContext, useMemo } from 'react'
 import { UsageMetricsItem } from './UsageMetricsItem'
-
-type RoleGroup = {
-  name: string
-  value: RoleUsage
-}[]
+import { metricsToRoleGroups, RoleGroup } from './usagePanelUtils'
 
 export type UsagePanelProps = {
   metrics: GetMetricsResponseData
@@ -15,38 +13,12 @@ export type UsagePanelProps = {
 export const UsagePanel = (props: UsagePanelProps) => {
   const { metrics, isLoading } = props
 
-  const roleGroups: RoleGroup[] = [
-    [
-      {
-        name: 'Control-converged Nodes',
-        value: metrics.host.role.controlConverged,
-      },
-      {
-        name: 'Control Nodes',
-        value: metrics.host.role.control,
-      },
-    ],
-    [
-      {
-        name: 'Compute Nodes',
-        value: metrics.host.role.compute,
-      },
-      {
-        name: 'Storage Nodes',
-        value: metrics.host.role.storage,
-      },
-    ],
-    [
-      {
-        name: 'Edge-core Nodes',
-        value: metrics.host.role.edgeCore,
-      },
-      {
-        name: 'Moderator Nodes',
-        value: metrics.host.role.moderator,
-      },
-    ],
-  ]
+  const { dataCenter } = useContext(DataCenterContext)
+
+  const roleGroups = useMemo<RoleGroup[]>(
+    () => metricsToRoleGroups(metrics, dataCenter!.type),
+    [metrics, dataCenter],
+  )
 
   return (
     <CosGeneralPanel topic="Usage">

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/usagePanelUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/usagePanelUtils.ts
@@ -1,0 +1,71 @@
+import {
+  GetDataCentersResponseDataInnerTypeEnum,
+  GetMetricsResponseData,
+  RoleUsage,
+} from '@cube-frontend/api'
+
+export type RoleGroup = {
+  name: string
+  value: RoleUsage
+}[]
+
+export const metricsToRoleGroups = (
+  metrics: GetMetricsResponseData,
+  dataCenterType: GetDataCentersResponseDataInnerTypeEnum,
+): RoleGroup[] => {
+  const mapFns: Record<
+    GetDataCentersResponseDataInnerTypeEnum,
+    (metrics: GetMetricsResponseData) => RoleGroup[]
+  > = {
+    cloud: mapCloudRoleGroups,
+    edge: mapEdgeRoleGroups,
+  }
+  const fn = mapFns[dataCenterType]
+  if (!fn) {
+    console.warn(
+      `Cannot find the role groups mapper for data center with type ${dataCenterType}`,
+    )
+    return []
+  }
+  return fn(metrics)
+}
+
+const mapCloudRoleGroups = (metrics: GetMetricsResponseData): RoleGroup[] => {
+  return [
+    [
+      {
+        name: 'Control-converged Nodes',
+        value: metrics.host.role.controlConverged,
+      },
+      {
+        name: 'Control Nodes',
+        value: metrics.host.role.control,
+      },
+    ],
+    [
+      {
+        name: 'Compute Nodes',
+        value: metrics.host.role.compute,
+      },
+      {
+        name: 'Storage Nodes',
+        value: metrics.host.role.storage,
+      },
+    ],
+  ]
+}
+
+const mapEdgeRoleGroups = (metrics: GetMetricsResponseData): RoleGroup[] => {
+  return [
+    [
+      {
+        name: 'Edge-core Nodes',
+        value: metrics.host.role.edgeCore,
+      },
+      {
+        name: 'Moderator Nodes',
+        value: metrics.host.role.moderator,
+      },
+    ],
+  ]
+}


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

In Home Chart page -> Usage panel, show role groups based on the data center type.

#### Which issue(s) this PR fixes

Close #341 

- Cloud
  - ![image](https://github.com/user-attachments/assets/26b954f3-2eae-49da-b718-237019c4582a)
- Edge
  - ![image](https://github.com/user-attachments/assets/49327f86-aa70-46ec-bb21-65a726d886a1)

