### PR TITLE
fix: 378 chart page host chart panel title incorrect

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/RankingPanels/HostRankingPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/RankingPanels/HostRankingPanel.tsx
@@ -87,7 +87,7 @@ export const HostRankingPanel = () => {
   return (
     <CosGeneralPanel.Container className="flex-1">
       <CosGeneralPanel.TitleBar
-        title="Ranking"
+        title="Host"
         hyperLinkProps={computeTitleBarHyperlinkProps(grafanaLinkResponse)}
       />
       <CosGeneralPanel


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### Which issue(s) this PR fixes

Fixes #378

#### What this PR does / why we need it

Please see #378

Before

<img width="1912" alt="Screenshot 2025-05-13 at 6 11 13 PM" src="https://github.com/user-attachments/assets/6431974d-99ca-4948-af28-9d91db2fee1d" />

After

<img width="1529" alt="Screenshot 2025-05-13 at 6 11 39 PM" src="https://github.com/user-attachments/assets/66217b50-23e2-40e5-bea8-a8c96b1881b7" />
