### PR TITLE
353 fix(web-app): rename COS license expiration table header back to license expiration

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
@@ -65,7 +65,7 @@ export const NodeTable = (props: NodeTableProps) => {
           </CosTag>
         )}
       </BasicNodeTable.Column>
-      <BasicNodeTable.Column label="COS License Expiration" property="license">
+      <BasicNodeTable.Column label="License Expiration" property="license">
         {toLicenseExpirationDate}
       </BasicNodeTable.Column>
       <BasicNodeTable.Column

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeSummary.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeSummary.tsx
@@ -156,7 +156,7 @@ export const NodeSummary = (props: NodeSummaryProps) => {
             'Up Time',
             dayjs.duration(node.uptimeSeconds, 'seconds').humanize(),
           )}
-          {renderRow('COS License Expiration', getLicenseExpiration())}
+          {renderRow('License Expiration', getLicenseExpiration())}
           {renderRow(
             'Management IP',
             <div className="flex items-center gap-x-5">

--- a/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
@@ -67,7 +67,7 @@ export const NodeTable = (props: NodeTableProps) => {
         )}
       </BatchActionNodeTable.Column>
       <BatchActionNodeTable.Column
-        label="COS License Expiration"
+        label="License Expiration"
         property="license"
       >
         {toLicenseExpirationDate}


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Rename "COS License Expiration" table headers back to "License Expiration".

#### Which issue(s) this PR fixes

Close #353

#### Special notes for your reviewer

I think that makes sense. As the original issue description has outlined:

> Since one host can have multiple licenses, with 0 or 1 license per product...

If we just show "COS License Expiration", users may get confused if the host has only CubeCMP license(s) installed
