### PR TITLE
feat: 409 enlarge the license import modal

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosModal/CosModal.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosModal/CosModal.tsx
@@ -56,7 +56,7 @@ export const CosModal = (props: CosModalProps) => {
     <>
       <div className={backdrop({ isOpen })} onClick={onCloseClick} />
       <div
-        className={twMerge(classNameProp, modal({ size, isOpen }))}
+        className={twMerge(modal({ size, isOpen }), classNameProp)}
         style={{
           boxShadow: '0px 0px 2px 0px rgba(0, 0, 0, 0.20)',
         }}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/ImportLicenseModal/ImportLicenseModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/ImportLicenseModal/ImportLicenseModal.tsx
@@ -25,6 +25,7 @@ export const ImportLicenseModal = (props: ImportLicenseModalProps) => {
 
   return (
     <CosModal
+      className="h-[780px] max-h-screen"
       isOpen={!!licenseVerifyInfo}
       title="Import License"
       actionText="Yes, import license"


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### Which issue(s) this PR fixes

Fixes #409

#### What this PR does / why we need it

Custom the height of import license modal using the `className` Prop to ensure that at least 3 nodes are displayed.

#### Screenshots

https://github.com/user-attachments/assets/6425d568-4d0e-4669-86b7-40f28e0fbeb7
