### PR TITLE
408 fix(web-app): page-level error page vertical alignment

### DIFF
--- a/packages/cube-frontend-web-app/src/layout/Content.tsx
+++ b/packages/cube-frontend-web-app/src/layout/Content.tsx
@@ -10,9 +10,9 @@ const Content = (props: PropsWithChildren) => {
   return (
     <div
       id={containerId}
-      className="flex h-[calc(100svh_-_54px)] w-full items-start justify-center overflow-auto"
+      className="flex h-[calc(100svh_-_54px)] w-full items-start justify-center"
     >
-      <div className="w-full max-w-[1600px] px-5 pb-[60px] pt-4 [&>*]:w-full">
+      <div className="size-full max-w-[1600px] overflow-auto px-5 pb-[60px] pt-4 [&>*]:w-full">
         <UseFloatingExternalContextProvider
           scrollableRootSelector={`#${containerId}`}
         >


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Make sure page-level error page is vertically aligned center.

#### Which issue(s) this PR fixes

Close #408 

<img width="1279" alt="{AEBF3886-94E1-46F5-A2E9-0F58143FC15A}" src="https://github.com/user-attachments/assets/8b71898a-d0b0-4eda-b8c1-6ffb7e02e7de" />
