### PR TITLE
399 Update dropdown style

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
@@ -1,12 +1,16 @@
-import { cva } from 'class-variance-authority'
 import { ChangeEvent, InputHTMLAttributes, RefObject, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import CheckboxUnselected from '../../components/CosIcon/monochrome/checkbox.svg?react'
 import CheckboxSelected from '../../components/CosIcon/monochrome/checkbox_checked_filled.svg?react'
 import CheckboxIndeterminate from '../../components/CosIcon/monochrome/checkbox_undeterminate_filled.svg?react'
 import { CosCheckboxSkeleton } from './CosCheckboxSkeleton'
+import { checkbox } from './styles'
 
-export type CosCheckboxVariant = 'primary' | 'secondary'
+export type CosCheckboxColor =
+  | 'primary'
+  | 'primary-dark'
+  | 'secondary'
+  | 'secondary-dark'
 
 export type CosCheckboxStatus = 'unselected' | 'selected' | 'indeterminate'
 
@@ -17,7 +21,7 @@ export type CosCheckboxProps = Omit<
   /**
    * @default primary
    */
-  variant?: CosCheckboxVariant
+  color?: CosCheckboxColor
   label?: string
   labelClassName?: string
   /**
@@ -32,70 +36,9 @@ export type CosCheckboxProps = Omit<
   ref?: RefObject<HTMLInputElement | null>
 }
 
-const checkbox = {
-  container: cva('primary-body2 inline-flex w-fit cursor-pointer gap-x-2', {
-    variants: {
-      disabled: {
-        true: 'cursor-default',
-      },
-    },
-  }),
-  iconWrap: cva(
-    [
-      'shrink-0 p-0.5',
-      'text-functional-border-darker transition-colors duration-100',
-    ],
-    {
-      variants: {
-        variant: {
-          primary: '',
-          secondary: '',
-        },
-        isSelected: {
-          true: '',
-        },
-        disabled: {
-          true: '',
-        },
-      },
-      compoundVariants: [
-        {
-          variant: 'primary',
-          isSelected: true,
-          className: 'text-primary peer-hover:text-functional-hover-primary',
-        },
-        {
-          variant: 'primary',
-          disabled: true,
-          className:
-            'text-functional-disable-text peer-hover:text-functional-disable-text',
-        },
-        {
-          variant: 'secondary',
-          isSelected: true,
-          className: 'text-blue-500 peer-hover:text-blue-700',
-        },
-        {
-          variant: 'secondary',
-          disabled: true,
-          className:
-            'text-functional-disable-text peer-hover:text-functional-disable-text',
-        },
-      ],
-    },
-  ),
-  label: cva('max-w-[152px] text-functional-text', {
-    variants: {
-      disabled: {
-        true: 'text-functional-disable-text',
-      },
-    },
-  }),
-}
-
 export const CosCheckbox = (props: CosCheckboxProps) => {
   const {
-    variant = 'primary',
+    color = 'primary',
     label,
     labelClassName,
     id,
@@ -137,7 +80,7 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
       <div
         className={twMerge(
           checkbox.iconWrap({
-            variant,
+            color,
             isSelected: effectiveChecked || isIndeterminate,
             disabled,
           }),
@@ -164,7 +107,12 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
       />
       {renderIcon()}
       {label && (
-        <span className={twMerge(checkbox.label({ disabled }), labelClassName)}>
+        <span
+          className={twMerge(
+            checkbox.label({ color, disabled }),
+            labelClassName,
+          )}
+        >
           {label}
         </span>
       )}

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/styles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/styles.ts
@@ -1,0 +1,154 @@
+import { cva } from 'class-variance-authority'
+
+export const checkbox = {
+  container: cva('primary-body2 inline-flex w-fit cursor-pointer gap-x-2', {
+    variants: {
+      disabled: {
+        true: 'cursor-default',
+      },
+    },
+  }),
+  iconWrap: cva('shrink-0 p-0.5 transition-colors duration-100', {
+    variants: {
+      color: {
+        primary: '',
+        secondary: '',
+        'primary-dark': '',
+        'secondary-dark': '',
+      },
+      isSelected: {
+        true: '',
+      },
+      disabled: {
+        true: '',
+      },
+    },
+    compoundVariants: [
+      /** Primary */
+      {
+        color: 'primary',
+        isSelected: false,
+        className:
+          'text-functional-border-darker peer-hover:text-functional-hover-primary',
+      },
+      {
+        color: 'primary',
+        isSelected: true,
+        className: 'text-primary peer-hover:text-functional-hover-primary',
+      },
+      {
+        color: 'primary',
+        disabled: true,
+        className:
+          'text-functional-disable-text peer-hover:text-functional-disable-text',
+      },
+      /** Primary (dark) */
+      {
+        color: 'primary-dark',
+        isSelected: false,
+        className:
+          'text-functional-text peer-hover:text-functional-hover-primary',
+      },
+      {
+        color: 'primary-dark',
+        isSelected: true,
+        className: 'text-primary-700 peer-hover:text-primary-500',
+      },
+      {
+        color: 'primary-dark',
+        disabled: true,
+        className:
+          'text-functional-disable-text peer-hover:text-functional-disable-text',
+      },
+      /** Secondary */
+      {
+        color: 'secondary',
+        isSelected: false,
+        className: 'text-functional-border-darker peer-hover:text-blue-700',
+      },
+      {
+        color: 'secondary',
+        isSelected: true,
+        className: 'text-blue-600 peer-hover:text-blue-700',
+      },
+      {
+        color: 'secondary',
+        disabled: true,
+        className:
+          'text-functional-disable-text peer-hover:text-functional-disable-text',
+      },
+      /** Secondary (dark) */
+      {
+        color: 'secondary-dark',
+        isSelected: false,
+        className: 'text-functional-text peer-hover:text-blue-600',
+      },
+      {
+        color: 'secondary-dark',
+        isSelected: true,
+        className: 'text-blue-700 peer-hover:text-blue-600',
+      },
+      {
+        color: 'secondary-dark',
+        disabled: true,
+        className:
+          'text-functional-disable-text peer-hover:text-functional-disable-text',
+      },
+    ],
+  }),
+  label: cva('max-w-[152px] text-functional-text', {
+    variants: {
+      color: {
+        primary: '',
+        secondary: '',
+        'primary-dark': '',
+        'secondary-dark': '',
+      },
+      disabled: {
+        true: 'text-functional-disable-text',
+      },
+    },
+    compoundVariants: [
+      {
+        color: 'primary',
+        disabled: false,
+        className: 'text-functional-text',
+      },
+      {
+        color: 'primary',
+        disabled: true,
+        className: 'text-functional-disable-text',
+      },
+      {
+        color: 'primary-dark',
+        disabled: false,
+        className: 'font-semibold text-functional-text',
+      },
+      {
+        color: 'primary-dark',
+        disabled: true,
+        className: 'font-semibold text-functional-disable-text',
+      },
+      {
+        color: 'secondary',
+        disabled: false,
+        className: 'text-functional-text',
+      },
+      {
+        color: 'secondary',
+        disabled: true,
+        className: 'text-functional-disable-text',
+      },
+      {
+        color: 'secondary-dark',
+        disabled: false,
+        className: 'font-semibold text-functional-text',
+      },
+      {
+        color: 'secondary-dark',
+        disabled: true,
+        className: 'font-semibold text-functional-disable-text',
+      },
+    ],
+  }),
+}

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownItem.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownItem.tsx
@@ -1,6 +1,6 @@
 import { useContext } from 'react'
 import { twMerge } from 'tailwind-merge'
-import { CosCheckbox } from '../CosCheckbox/CosCheckbox'
+import { CosCheckbox, CosCheckboxColor } from '../CosCheckbox/CosCheckbox'
 import { CosDropdownContext } from './context'
 import { item as itemStyle } from './styles'
 
@@ -30,22 +30,31 @@ export const CosDropdownItem = <Item,>(props: CosDropdownItemProps<Item>) => {
     }
   }
 
-  return isCheckbox ? (
-    <div
-      className={twMerge(
-        itemStyle({ variant, type, isSelected, isCheckbox, disabled }),
-      )}
-    >
-      <CosCheckbox
-        label={label}
-        labelClassName="truncate"
-        disabled={disabled}
-        checked={isSelected}
-        onChange={handleClick}
-        variant={type === 'checkbox' ? 'primary' : 'secondary'}
-      />
-    </div>
-  ) : (
+  const getCheckboxColor = (): CosCheckboxColor | undefined => {
+    if (type === 'checkbox') return 'primary'
+    if (type === 'search-checkbox') return 'secondary'
+    return undefined
+  }
+
+  if (isCheckbox)
+    return (
+      <div
+        className={twMerge(
+          itemStyle({ variant, type, isSelected, isCheckbox, disabled }),
+        )}
+      >
+        <CosCheckbox
+          label={label}
+          labelClassName="truncate"
+          disabled={disabled}
+          checked={isSelected}
+          onChange={handleClick}
+          color={getCheckboxColor()}
+        />
+      </div>
+    )
+
+  return (
     <div
       className={twMerge(
         itemStyle({ variant, type, isSelected, isCheckbox, disabled }),

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownMenu.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownMenu.tsx
@@ -1,7 +1,7 @@
 import { ReactNode, useContext, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { twMerge } from 'tailwind-merge'
-import { CosCheckbox } from '../CosCheckbox/CosCheckbox'
+import { CosCheckbox, CosCheckboxColor } from '../CosCheckbox/CosCheckbox'
 import { CosDropdownSearchBar } from './CosDropdownSearchBar'
 import { CosDropdownContext } from './context'
 import { content, item } from './styles'
@@ -37,6 +37,12 @@ export const CosDropdownMenu = (props: CosDropdownMenuProps) => {
     return selectedItems.length === itemCount
   }, [selectedItems.length, itemCount])
 
+  const getCheckboxColor = (): CosCheckboxColor | undefined => {
+    if (type === 'checkbox') return 'primary-dark'
+    if (type === 'search-checkbox') return 'secondary-dark'
+    return undefined
+  }
+
   return createPortal(
     <div
       ref={elementRef}
@@ -58,9 +64,10 @@ export const CosDropdownMenu = (props: CosDropdownMenuProps) => {
         >
           <CosCheckbox
             label="All"
-            variant={type === 'checkbox' ? 'primary' : 'secondary'}
+            disabled={false}
             checked={isAllChecked}
             onClick={() => onAllCheckChange?.(!isAllChecked)}
+            color={getCheckboxColor()}
           />
         </div>
       )}

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownTrigger.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownTrigger.tsx
@@ -64,6 +64,7 @@ export const CosDropdownTrigger = (props: CosDropdownTriggerProps) => {
       className={twMerge(
         trigger({
           variant,
+          isMenuOpen: isOpen,
           hasSearchbar,
           hasSelectedValue: isSelected,
           disabled,

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/styles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/styles.ts
@@ -8,6 +8,10 @@ export const trigger = cva(
         default: 'h-[38px] min-w-[116px] max-w-[360px] px-4 py-[10px]',
         'in-table': 'h-[34px] min-w-[80px] max-w-[240px] px-3 py-2',
       },
+      isMenuOpen: {
+        true: '',
+        false: '',
+      },
       hasSearchbar: {
         true: '',
         false: '',
@@ -24,17 +28,19 @@ export const trigger = cva(
     compoundVariants: [
       // Default Dropdown
       {
+        isMenuOpen: false,
         hasSearchbar: false,
         hasSelectedValue: false,
         disabled: false,
         class: [
           'hover:border-functional-hover-primary',
           'border-functional-border-divider',
-          'text-functional-border-darker',
+          'text-functional-text-light',
           'bg-white',
         ],
       },
       {
+        isMenuOpen: false,
         hasSearchbar: false,
         hasSelectedValue: true,
         disabled: false,
@@ -46,6 +52,7 @@ export const trigger = cva(
         ],
       },
       {
+        isMenuOpen: false,
         hasSearchbar: false,
         hasSelectedValue: false,
         disabled: true,
@@ -57,6 +64,7 @@ export const trigger = cva(
         ],
       },
       {
+        isMenuOpen: false,
         hasSearchbar: false,
         hasSelectedValue: true,
         disabled: true,
@@ -64,6 +72,28 @@ export const trigger = cva(
           'hover:border-functional-border-divider',
           'border-functional-border-divider',
           'text-functional-disable-text',
+          'bg-white',
+        ],
+      },
+      {
+        isMenuOpen: true,
+        hasSearchbar: false,
+        hasSelectedValue: false,
+        disabled: false,
+        class: [
+          'border-functional-hover-primary',
+          'text-functional-text-light',
+          'bg-white',
+        ],
+      },
+      {
+        isMenuOpen: true,
+        hasSearchbar: false,
+        hasSelectedValue: true,
+        disabled: false,
+        class: [
+          'border-functional-hover-primary',
+          'text-functional-text',
           'bg-white',
         ],
       },

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CosCheckbox.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CosCheckbox.stories.tsx
@@ -43,42 +43,176 @@ export const Gallery: StoryObj = {
         <StoryLayout.Section title="Variants">
           <div className="flex flex-col gap-y-8">
             <CheckboxGrid title="">
-              <div className="primary-body2">Default</div>
-              <div className="primary-body2">Disabled</div>
+              <div className="primary-body2">Unselect</div>
+              <div className="primary-body2">Select</div>
+              <div className="primary-body2">Indeterminate</div>
             </CheckboxGrid>
-            <CheckboxGrid title="Unselect">
+            <CheckboxGrid title="Primary">
               <CosCheckbox
+                color="primary"
                 label={checkboxText}
                 checked={unchecked}
                 onChange={handleUnchecked}
               />
               <CosCheckbox
-                label={checkboxText}
-                checked={false}
-                onChange={handleUnchecked}
-                disabled
-              />
-            </CheckboxGrid>
-            <CheckboxGrid title="Select">
-              <CosCheckbox
+                color="primary"
                 label={checkboxText}
                 checked={checked}
                 onChange={handleChecked}
               />
               <CosCheckbox
+                color="primary"
+                label={checkboxText}
+                checked={indeterminateChecked}
+                onChange={handleIndeterminateChecked}
+              />
+            </CheckboxGrid>
+            <CheckboxGrid title="Primary (Disabled)">
+              <CosCheckbox
+                color="primary"
+                label={checkboxText}
+                checked={false}
+                onChange={handleUnchecked}
+                disabled
+              />
+              <CosCheckbox
+                color="primary"
                 label={checkboxText}
                 checked={true}
                 onChange={handleChecked}
                 disabled
               />
-            </CheckboxGrid>
-            <CheckboxGrid title="Indeterminate">
               <CosCheckbox
+                color="primary"
+                label={checkboxText}
+                checked={null}
+                onChange={handleIndeterminateChecked}
+                disabled
+              />
+            </CheckboxGrid>
+            <CheckboxGrid title="Primary Dark">
+              <CosCheckbox
+                color="primary-dark"
+                label={checkboxText}
+                checked={unchecked}
+                onChange={handleUnchecked}
+              />
+              <CosCheckbox
+                color="primary-dark"
+                label={checkboxText}
+                checked={checked}
+                onChange={handleChecked}
+              />
+              <CosCheckbox
+                color="primary-dark"
                 label={checkboxText}
                 checked={indeterminateChecked}
                 onChange={handleIndeterminateChecked}
               />
+            </CheckboxGrid>
+            <CheckboxGrid title="Primary Dark (Disabled)">
               <CosCheckbox
+                color="primary-dark"
+                label={checkboxText}
+                checked={false}
+                onChange={handleUnchecked}
+                disabled
+              />
+              <CosCheckbox
+                color="primary-dark"
+                label={checkboxText}
+                checked={true}
+                onChange={handleChecked}
+                disabled
+              />
+              <CosCheckbox
+                color="primary-dark"
+                label={checkboxText}
+                checked={null}
+                onChange={handleIndeterminateChecked}
+                disabled
+              />
+            </CheckboxGrid>
+            <CheckboxGrid title="Secondary">
+              <CosCheckbox
+                color="secondary"
+                label={checkboxText}
+                checked={unchecked}
+                onChange={handleUnchecked}
+              />
+              <CosCheckbox
+                color="secondary"
+                label={checkboxText}
+                checked={checked}
+                onChange={handleChecked}
+              />
+              <CosCheckbox
+                color="secondary"
+                label={checkboxText}
+                checked={indeterminateChecked}
+                onChange={handleIndeterminateChecked}
+              />
+            </CheckboxGrid>
+            <CheckboxGrid title="Secondary (Disabled)">
+              <CosCheckbox
+                color="secondary"
+                label={checkboxText}
+                checked={false}
+                onChange={handleUnchecked}
+                disabled
+              />
+              <CosCheckbox
+                color="secondary"
+                label={checkboxText}
+                checked={true}
+                onChange={handleChecked}
+                disabled
+              />
+              <CosCheckbox
+                color="secondary"
+                label={checkboxText}
+                checked={null}
+                onChange={handleIndeterminateChecked}
+                disabled
+              />
+            </CheckboxGrid>
+            <CheckboxGrid title="Secondary Dark">
+              <CosCheckbox
+                color="secondary-dark"
+                label={checkboxText}
+                checked={unchecked}
+                onChange={handleUnchecked}
+              />
+              <CosCheckbox
+                color="secondary-dark"
+                label={checkboxText}
+                checked={checked}
+                onChange={handleChecked}
+              />
+              <CosCheckbox
+                color="secondary-dark"
+                label={checkboxText}
+                checked={indeterminateChecked}
+                onChange={handleIndeterminateChecked}
+              />
+            </CheckboxGrid>
+            <CheckboxGrid title="Secondary Dark (Disabled)">
+              <CosCheckbox
+                color="secondary-dark"
+                label={checkboxText}
+                checked={false}
+                onChange={handleUnchecked}
+                disabled
+              />
+              <CosCheckbox
+                color="secondary-dark"
+                label={checkboxText}
+                checked={true}
+                onChange={handleChecked}
+                disabled
+              />
+              <CosCheckbox
+                color="secondary-dark"
                 label={checkboxText}
                 checked={null}
                 onChange={handleIndeterminateChecked}

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/ModifiedStatusDropdown.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/ModifiedStatusDropdown.tsx
@@ -1,0 +1,70 @@
+import { ChangeEvent, useMemo, useState } from 'react'
+import { CosDropdown } from '@cube-frontend/ui-library'
+import { modifiedOptions } from './tuningsUtils'
+
+type ModifiedStatusDropdownProps = {
+  selectedModified: boolean[]
+  onItemClick: (modified: boolean) => void
+  onAllCheckChange: (checked: boolean) => void
+}
+
+export const ModifiedStatusDropdown = (props: ModifiedStatusDropdownProps) => {
+  const { selectedModified, onItemClick, onAllCheckChange } = props
+
+  const [searchValue, setSearchValue] = useState('')
+
+  const matchedStatuses = useMemo(() => {
+    if (!searchValue) {
+      return modifiedOptions
+    }
+
+    const loweredValue = searchValue.toLowerCase()
+    return modifiedOptions.filter((modified) => {
+      if (modified) {
+        const modifiedString = 'modified'
+        return modifiedString.includes(loweredValue)
+      }
+
+      const unmodifiedString = 'unmodified'
+      return unmodifiedString.includes(loweredValue)
+      return
+    })
+  }, [searchValue])
+
+  const onSearchChange = (e: ChangeEvent<HTMLInputElement>): void => {
+    setSearchValue(e.target.value)
+  }
+
+  const onClearClick = (): void => {
+    onAllCheckChange(false)
+  }
+
+  return (
+    <CosDropdown
+      type="search-checkbox"
+      selectedItems={selectedModified}
+      searchValue={searchValue}
+      onAllCheckChange={onAllCheckChange}
+      onSearchChange={onSearchChange}
+      onClearClick={onClearClick}
+    >
+      <CosDropdown.Trigger
+        className="h-[34px] w-[168px]"
+        placeholder="Modify Statuses"
+      >
+        {selectedModified.length ? 'Modify Statuses' : undefined}
+      </CosDropdown.Trigger>
+      <CosDropdown.Menu>
+        {matchedStatuses.map((modified) => (
+          <CosDropdown.Item
+            key={modified.toString()}
+            item={modified}
+            onClick={() => onItemClick(modified)}
+          >
+            {modified ? 'Modified' : 'Unmodified'}
+          </CosDropdown.Item>
+        ))}
+      </CosDropdown.Menu>
+    </CosDropdown>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/TuningsFilter.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/TuningsFilter.tsx
@@ -1,8 +1,8 @@
 import { Node } from '@cube-frontend/api'
-import { CosDropdown, CosSearchBarFilter } from '@cube-frontend/ui-library'
+import { CosSearchBarFilter } from '@cube-frontend/ui-library'
 import { ChangeEvent } from 'react'
 import { HostDropdown } from './HostDropdown'
-import { modifiedOptions } from './tuningsUtils'
+import { ModifiedStatusDropdown } from './ModifiedStatusDropdown'
 import { ListTuningsQuery } from './useListTuningsQuery'
 
 type TuningsFilterProps = {
@@ -35,29 +35,11 @@ export const TuningsFilter = (props: TuningsFilterProps) => {
         onChange={onKeywordChange}
         onInputClear={onKeywordClear}
       />
-      <CosDropdown
-        type="checkbox"
-        selectedItems={query.modified}
+      <ModifiedStatusDropdown
+        selectedModified={query.modified}
+        onItemClick={onModifiedItemClick}
         onAllCheckChange={onModifiedAllCheckChange}
-      >
-        <CosDropdown.Trigger
-          className="h-[34px] w-[168px]"
-          placeholder="Modify Statuses"
-        >
-          {query.modified.length ? 'Modify Statuses' : undefined}
-        </CosDropdown.Trigger>
-        <CosDropdown.Menu>
-          {modifiedOptions.map((modified) => (
-            <CosDropdown.Item
-              key={modified.toString()}
-              item={modified}
-              onClick={() => onModifiedItemClick(modified)}
-            >
-              {modified ? 'Modified' : 'Unmodified'}
-            </CosDropdown.Item>
-          ))}
-        </CosDropdown.Menu>
-      </CosDropdown>
+      />
       <HostDropdown
         selectedHosts={query.hosts}
         onItemClick={onNodeItemClick}


### PR DESCRIPTION
#### What type of PR is this?

- Feat

#### What this PR does / why we need it

### 1. Update `Checkbox` Styles for Use in `Dropdown` (commit [1b8f2d6](https://github.com/bigstack-oss/cube-cos-ui/pull/414/commits/1b8f2d60de78ca7d55455941baa586d570600675))

- Design Reference:

<img width="1412" alt="Screenshot 2025-05-14 at 5 45 49 PM" src="https://github.com/user-attachments/assets/c7de96c9-e212-424d-b41a-f78b32171001" />

- Updated Implementation:

<img width="1090" alt="Screenshot 2025-05-14 at 3 48 04 PM" src="https://github.com/user-attachments/assets/fd65a553-cd31-45a2-a8b1-177357e1a291" />

### 2. Update Dropdown Styles (commit [95bab89](https://github.com/bigstack-oss/cube-cos-ui/pull/414/commits/95bab89970d7f7c8f0d4aab313c41647c29cf13c))

- (1) Checkbox styles within the dropdown are updated accordingly.


https://github.com/user-attachments/assets/ab02d721-5f9c-4d22-9be7-80e988365480



- (2) Placeholder font color for both `regular` and `checkbox` variants is updated to `functional-text-light`.


<img width="935" alt="Screenshot 2025-05-14 at 6 01 20 PM" src="https://github.com/user-attachments/assets/7f77b615-028a-4531-a1b0-b8036136d021" />



- (3) According to designer, the border color when the menu is open should remain consistent with the hover color, for `regular` and `checkbox` variants.


https://github.com/user-attachments/assets/e3a43423-4ba4-4391-939c-e633b9474c32



### 3. Update dropdown filter of modified status on tunings page (commit [636968d](https://github.com/bigstack-oss/cube-cos-ui/pull/414/commits/636968d937407fa5ccbfbd09e824c7c62873bfdb))

- Following the discussion on May 14, the dropdown for the `Modified Status` field is now updated to use the `search-checkbox` variant,

https://github.com/user-attachments/assets/c07ee17e-fd53-485d-afa9-7f77b388286d


#### Which issue(s) this PR fixes

Fixes #399

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
