### PR TITLE
415 license page and health module value casing

### DIFF
--- a/packages/cube-frontend-ui-library/src/stories/components/CosTables/ViewDetails/CosViewDetailsTable.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosTables/ViewDetails/CosViewDetailsTable.stories.tsx
@@ -3,7 +3,7 @@ import {
   useExpandedRowIdSet,
 } from '@cube-frontend/ui-library'
 import { Meta, StoryObj } from '@storybook/react'
-import { capitalize } from 'lodash'
+import { upperFirst } from 'lodash'
 import { StoryLayout } from '../../../../internal/components/StoryLayout/StoryLayout'
 import {
   isCmpLicense,
@@ -55,7 +55,7 @@ const Default = () => {
       },
       {
         title: 'Feature',
-        value: capitalize(license.feature),
+        value: upperFirst(license.feature),
       },
     ]
   }
@@ -98,7 +98,7 @@ const WithoutTitle = () => {
       },
       {
         title: 'Feature',
-        value: capitalize(license.feature),
+        value: upperFirst(license.feature),
       },
     ]
   }
@@ -148,7 +148,7 @@ const DynamicContent = () => {
       },
       {
         title: 'Feature',
-        value: capitalize(license.feature),
+        value: upperFirst(license.feature),
       },
     ]
 

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectHosts/RoleDropdown.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectHosts/RoleDropdown.tsx
@@ -1,7 +1,7 @@
 import { GetDataCentersResponseDataInnerRolesEnum } from '@cube-frontend/api'
 import { CosDropdown } from '@cube-frontend/ui-library'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import { capitalize } from 'lodash'
+import { upperFirst } from 'lodash'
 import { ChangeEvent, useContext, useMemo, useState } from 'react'
 
 type RoleDropdownProps = {
@@ -70,7 +70,7 @@ export const RoleDropdown = (props: RoleDropdownProps) => {
             item={role}
             onClick={() => onRoleClick(role)}
           >
-            {capitalize(role)}
+            {upperFirst(role)}
           </CosDropdown.Item>
         ))}
       </CosDropdown.Menu>

--- a/packages/cube-frontend-web-app/src/pages/home/health/_components/healthCheck/NgService.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/_components/healthCheck/NgService.tsx
@@ -1,6 +1,6 @@
 import { GetHealthsResponseDataServicesInner } from '@cube-frontend/api'
 import WarningFilled from '@cube-frontend/ui-library/icons/monochrome/warning_filled.svg?react'
-import { capitalize } from 'lodash'
+import { serviceNameToLabel } from '../../homeHealthPageUtils'
 
 export type NgServiceProps = {
   service: GetHealthsResponseDataServicesInner
@@ -26,7 +26,7 @@ export const NgService = (props: NgServiceProps) => {
       <div className="flex items-center gap-x-2">
         <WarningFilled className="size-4 shrink-0 text-status-negative" />
         <span className="primary-body3 font-semibold text-status-negative">
-          {capitalize(service.name)}
+          {serviceNameToLabel(service.name)}
         </span>
       </div>
       <span className="primary-body4 text-functional-text-light">

--- a/packages/cube-frontend-web-app/src/pages/home/health/homeHealthPageUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/health/homeHealthPageUtils.ts
@@ -1,3 +1,5 @@
+import { upperFirst } from 'lodash'
+
 export const HOME_HEALTH_PAGE_POLLING_INTERVAL = 5 * 1000
 
 const serviceNameLabelMap: Record<string, string> = {
@@ -35,8 +37,9 @@ export const serviceNameToLabel = (name: string | undefined): string => {
   const label = serviceNameLabelMap[name]
   if (!label) {
     console.warn(`Cannot find the label for service ${name}`)
+    return upperFirst(name)
   }
-  return label || name
+  return label
 }
 
 const moduleNameLabelMap: Record<string, string> = {
@@ -56,6 +59,7 @@ const moduleNameLabelMap: Record<string, string> = {
   haproxy: 'HAProxy',
   httpd: 'Httpd',
   skyline: 'Skyline',
+  nginx: 'Nginx',
   lmi: 'LMI',
   memcache: 'Memcache',
   api: 'API',
@@ -102,6 +106,7 @@ export const moduleNameToLabel = (name: string | undefined): string => {
   const label = moduleNameLabelMap[name]
   if (!label) {
     console.warn(`Cannot find the label for module ${name}`)
+    return upperFirst(name)
   }
-  return label || name
+  return label
 }

--- a/packages/cube-frontend-web-app/src/pages/integrations/IntegrationsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/integrations/IntegrationsPage.tsx
@@ -1,5 +1,5 @@
 import { useContext, useMemo } from 'react'
-import { capitalize, uniqueId } from 'lodash'
+import { upperFirst, uniqueId } from 'lodash'
 import { GetIntegrationsResponseDataInner } from '@cube-frontend/api'
 import {
   CosButton,
@@ -30,7 +30,7 @@ const renderIntegrationName = (name: string) => {
 
   if (!uiData) {
     console.warn(`No UI data is defined for integration: ${name}`)
-    return capitalize(name)
+    return upperFirst(name)
   }
 
   return uiData.displayName

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/HardwareSerialNumberModal/LicenseAttachmentTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/HardwareSerialNumberModal/LicenseAttachmentTable.tsx
@@ -1,6 +1,6 @@
 import { GetLicenseAttachmentsResponseDataInner } from '@cube-frontend/api'
 import { GetCosBatchActionTable } from '@cube-frontend/ui-library'
-import { capitalize } from 'lodash'
+import { upperFirst } from 'lodash'
 
 export type BatchLicenseAttachmentTableRow =
   GetLicenseAttachmentsResponseDataInner & {
@@ -25,7 +25,7 @@ export const LicenseAttachmentTable = (props: LicenseAttachmentTableProps) => {
       <BatchLicenseAttachmentTable.Column label="Role" property="role" />
       <BatchLicenseAttachmentTable.Column label="Product" property="product" />
       <BatchLicenseAttachmentTable.Column label="Status" property="status">
-        {capitalize}
+        {upperFirst}
       </BatchLicenseAttachmentTable.Column>
     </BatchLicenseAttachmentTable>
   )

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/ImportLicenseModal/EffectNodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/ImportLicenseModal/EffectNodeTable.tsx
@@ -1,5 +1,6 @@
 import { VerifyLicenseResponseData } from '@cube-frontend/api'
 import { CosTableRow, GetCosBasicTable } from '@cube-frontend/ui-library'
+import { upperFirst } from 'lodash'
 import { ComponentProps } from 'react'
 import { renderExpiredDays } from '../../utils'
 
@@ -16,7 +17,7 @@ export const EffectNodeTable = (props: EffectNodeTableProps) => {
       <EffectNodeBasicTable.Column label="Host affected" property="name" />
       <EffectNodeBasicTable.Column label="Roles" property="role" />
       <EffectNodeBasicTable.Column label="Current status" property="status">
-        {(status) => status.current}
+        {(status) => upperFirst(status.current)}
       </EffectNodeBasicTable.Column>
       <EffectNodeBasicTable.Column label="Expiration" property="expiry">
         {renderExpiredDays}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/ImportLicenseModal/ImportLicenseTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/ImportLicenseModal/ImportLicenseTable.tsx
@@ -1,7 +1,7 @@
 import { VerifyLicenseResponseDataLicense } from '@cube-frontend/api'
 import { CosDetailsTable } from '@cube-frontend/ui-library'
 import { formatLicenseDate } from '@cube-frontend/web-app/utils/date'
-import { capitalize } from 'lodash'
+import { upperFirst } from 'lodash'
 
 export type ImportLicenseTableProps = {
   license: VerifyLicenseResponseDataLicense
@@ -16,10 +16,10 @@ export const ImportLicenseTable = (props: ImportLicenseTableProps) => {
         {license.product.name}
       </CosDetailsTable.Row>
       <CosDetailsTable.Row title="Status">
-        {license.status.current}
+        {upperFirst(license.status.current)}
       </CosDetailsTable.Row>
       <CosDetailsTable.Row title="Feature">
-        {capitalize(license.product.feature)}
+        {upperFirst(license.product.feature)}
       </CosDetailsTable.Row>
       <CosDetailsTable.Row title="Support Plan">
         {license.supportPlan}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseFilters/LicenseStatusFilter.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseFilters/LicenseStatusFilter.tsx
@@ -1,5 +1,6 @@
 import { ListLicenseCurrentStatus } from '@cube-frontend/api'
 import { CosDropdown } from '@cube-frontend/ui-library'
+import { upperFirst } from 'lodash'
 import { ChangeEvent, useState } from 'react'
 
 const licenseStatuses = Object.values(ListLicenseCurrentStatus)
@@ -75,7 +76,7 @@ export const LicenseStatusFilter = (props: LicenseStatusFilterProps) => {
               item={licenseStatus}
               onClick={() => handleLicenseStatusClick(licenseStatus)}
             >
-              {licenseStatus}
+              {upperFirst(licenseStatus)}
             </CosDropdown.Item>
           )
         })}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseFilters/TypeFilter.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseFilters/TypeFilter.tsx
@@ -1,5 +1,6 @@
 import { GetLicensesTypesEnum } from '@cube-frontend/api'
 import { CosDropdown } from '@cube-frontend/ui-library'
+import { upperFirst } from 'lodash'
 import { ChangeEvent, useState } from 'react'
 
 const licenseTypes = Object.values(GetLicensesTypesEnum)
@@ -72,7 +73,7 @@ export const TypeFilter = (props: TypeFilterProps) => {
               item={licenseType}
               onClick={() => handleLicenseTypeClick(licenseType)}
             >
-              {licenseType}
+              {upperFirst(licenseType)}
             </CosDropdown.Item>
           )
         })}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseTable.tsx
@@ -1,4 +1,4 @@
-import { capitalize, upperFirst } from 'lodash'
+import { upperFirst } from 'lodash'
 import { GetLicensesResponseDataLicensesInner } from '@cube-frontend/api'
 import {
   CosBasicTableProps,
@@ -49,7 +49,7 @@ export const LicenseTable = (props: LicenseTableProps) => {
       },
       {
         title: 'Feature',
-        value: capitalize(license.product.feature),
+        value: upperFirst(license.product.feature),
       },
     ]
   }

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDevices.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeDevices.tsx
@@ -9,7 +9,7 @@ import {
 } from '@cube-frontend/ui-library'
 import WarningFilled from '@cube-frontend/ui-library/icons/monochrome/warning_filled.svg?react'
 import { toReadableSizeString } from '@cube-frontend/web-app/utils/byte'
-import { capitalize } from 'lodash'
+import { upperFirst } from 'lodash'
 import { useMemo, useState } from 'react'
 import { Panel } from './Panel'
 
@@ -65,7 +65,7 @@ export const NodeDevices = (props: NodeDevicesProps) => {
       )
     }
 
-    return capitalize(availability)
+    return upperFirst(availability)
   }
 
   return (


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix UI texts casing.

#### Which issue(s) this PR fixes

Close #415 

#### Special notes for your reviewer

Issues with etcd were fixed yesterday, but nginx was missing from the known module list. We use a map to convert module names to labels because there are non-intuitive cases (e.g., "iaasDb" -> "IaaS DB", "k8saas" -> "K8SaaS"), and the service/module names that's not in the map will be displayed as-is.

<img width="688" alt="Image" src="https://github.com/user-attachments/assets/e1894932-6b56-42c1-b89d-bdd97942d48d" />

I’ve added "nginx" to the map and updated the default behavior to capitalize the first letter of unmapped names, which should cover most scenarios.

<img width="678" alt="Image" src="https://github.com/user-attachments/assets/e2d3f920-3f6c-4e22-aa72-ef11e421a6fb" />

https://github.com/user-attachments/assets/cbf7d246-1e4e-41a2-93e2-c54ab434e00b


#### Additional documentation

Lodash's [capitalize](https://lodash.com/docs/4.17.15#capitalize) function converts first character of a string to upper case and **converts the remaining to lower case**. That means `capitalize('HeLLo')` outputs `Hello`. This is so counterintuitive. 😢😢😢 We should use [upperFirst](https://lodash.com/docs/4.17.15#upperFirst) instead.
