### PR TITLE
426 use cos mutation request data less requests

### DIFF
--- a/packages/cube-frontend-web-app/src/api/samlAuthErrorInterceptor.ts
+++ b/packages/cube-frontend-web-app/src/api/samlAuthErrorInterceptor.ts
@@ -1,5 +1,5 @@
 import { HttpStatusCode, isAxiosError } from 'axios'
-import { CosApiInnerResponse } from '../hooks/useCosRequest/cosRequestUtils'
+import { isCosApiResponse } from '../hooks/useCosRequest/cosRequestUtils'
 
 // Redirect to perform SAML auth if HTTP status code 401 is received.
 export const samlAuthErrorInterceptor = (error: unknown): Promise<unknown> => {
@@ -10,14 +10,11 @@ export const samlAuthErrorInterceptor = (error: unknown): Promise<unknown> => {
     return Promise.reject(error)
   }
 
-  const data = error.response.data as
-    | Partial<CosApiInnerResponse<never>>
-    | undefined
-
-  const redirectUrl = data?.msg
-
-  if (redirectUrl) {
-    window.location.replace(redirectUrl)
+  if (isCosApiResponse(error.response)) {
+    const redirectUrl = error.response.data.msg
+    if (redirectUrl) {
+      window.location.replace(redirectUrl)
+    }
   }
 
   return Promise.reject(error)

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosGetRequestUtils.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosGetRequestUtils.ts
@@ -1,0 +1,12 @@
+import { AxiosResponse, HttpStatusCode } from 'axios'
+
+export type CosGetApiRequest<T> = () => Promise<CosGetApiResponse<T>>
+
+export type CosGetApiResponse<T> = AxiosResponse<CosGetApiInnerResponse<T>>
+
+export type CosGetApiInnerResponse<T> = {
+  code: HttpStatusCode
+  msg: string
+  status: string
+  data: T
+}

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosMutationRequestUtils.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosMutationRequestUtils.ts
@@ -1,0 +1,14 @@
+import { AxiosResponse, HttpStatusCode } from 'axios'
+
+export type CosMutationApiRequest<T> = () => Promise<CosMutationApiResponse<T>>
+
+export type CosMutationApiResponse<T> = AxiosResponse<
+  CosMutationApiInnerResponse<T>
+>
+
+type CosMutationApiInnerResponse<T> = {
+  code: HttpStatusCode
+  msg: string
+  status: string
+  data?: T
+}

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosRequestUtils.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosRequestUtils.ts
@@ -1,27 +1,18 @@
-import { validateStatus } from '@cube-frontend/web-app/api/utils'
-import { AxiosResponse, HttpStatusCode } from 'axios'
+import { HttpStatusCode } from 'axios'
 import { isObject } from 'lodash'
-
-export type CosApiRequest<T> = () => Promise<CosApiResponse<T>>
-
-export type CosApiInnerResponse<T> = {
-  code: HttpStatusCode
-  msg: string
-  status: string
-  data: T
-}
-
-export type CosApiResponse<T> = AxiosResponse<CosApiInnerResponse<T>>
+import { CosGetApiResponse } from './cosGetRequestUtils'
+import { CosMutationApiResponse } from './cosMutationRequestUtils'
 
 export type CosRequestError = {
   native: Error
   api: CosApiError | undefined
 }
 
-export type CosApiError = Pick<
-  CosApiInnerResponse<unknown>,
-  'code' | 'msg' | 'status'
->
+export type CosApiError = {
+  code: HttpStatusCode
+  msg: string
+  status: string
+}
 
 export type Nullish<T> = T | null | undefined
 
@@ -29,10 +20,10 @@ export type GetParamFn<T> = () => T | null | undefined
 
 export const isCosApiResponse = (
   value: unknown,
-): value is CosApiResponse<unknown> => {
+): value is CosGetApiResponse<unknown> | CosMutationApiResponse<unknown> => {
+  const isAxiosResponse = isObject(value) && 'data' in value
   return (
-    isObject(value) &&
-    'data' in value &&
+    isAxiosResponse &&
     isObject(value.data) &&
     'code' in value.data &&
     'msg' in value.data &&
@@ -56,79 +47,5 @@ export const getNativeError = (error: unknown): Error => {
     return new Error(JSON.stringify(error))
   } catch {
     return new Error(String(error))
-  }
-}
-
-export const readStream = async <
-  ChunkResponse extends CosApiInnerResponse<unknown>,
->(
-  stream: ReadableStream,
-  abortSignal: AbortSignal,
-  onChunk: (chunkResponse: ChunkResponse) => void,
-) => {
-  const reader = stream.getReader()
-  abortSignal.onabort = () => {
-    reader.cancel()
-  }
-  const decoder = new TextDecoder()
-  let buffer = ''
-
-  while (true) {
-    const { done, value } = await reader.read()
-    if (done) break
-
-    const chunk = decoder.decode(value, { stream: true })
-    buffer += chunk
-
-    const validChunks: string[] = []
-    // split the buffer using '}{', also tolerate newlines between '}' and '{'
-    const segments = buffer.split(/}[\r\n]*{/)
-    if (segments.length > 1) {
-      // add the removed '}' or '{' back
-      segments[0] += '}'
-
-      for (let i = 1; i < segments.length - 1; i++) {
-        segments[i] = '{' + segments[i] + '}'
-      }
-
-      const lastSegment = '{' + (segments.pop() ?? '')
-      if (/}[\r\n]*$/.test(lastSegment)) {
-        // if the last segment is also a valid JSON, clean up the buffer
-        segments.push(lastSegment)
-        buffer = ''
-      } else {
-        // if not, push the last segment to the buffer
-        buffer = lastSegment
-      }
-
-      segments.forEach((segment) => {
-        if (isValidJsonString(segment)) {
-          validChunks.push(segment)
-        }
-      })
-    } else if (isValidJsonString(buffer)) {
-      // buffer is a valid JSON
-      validChunks.push(buffer)
-      buffer = ''
-    }
-
-    validChunks.forEach((validChunk) => {
-      const chunkResponse = JSON.parse(validChunk) as ChunkResponse
-
-      if (!validateStatus(chunkResponse.code)) {
-        // TODO: Handle CosAPI Error Status
-        throw new Error(chunkResponse.msg)
-      }
-      onChunk(chunkResponse)
-    })
-  }
-}
-
-const isValidJsonString = (value: string): boolean => {
-  try {
-    JSON.parse(value)
-    return true
-  } catch {
-    return false
   }
 }

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosStreamRequestUtils.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosStreamRequestUtils.ts
@@ -1,0 +1,76 @@
+import { validateStatus } from '@cube-frontend/web-app/api/utils'
+import { CosGetApiInnerResponse } from './cosGetRequestUtils'
+
+export const readStream = async <
+  ChunkResponse extends CosGetApiInnerResponse<unknown>,
+>(
+  stream: ReadableStream,
+  abortSignal: AbortSignal,
+  onChunk: (chunkResponse: ChunkResponse) => void,
+) => {
+  const reader = stream.getReader()
+  abortSignal.onabort = () => {
+    reader.cancel()
+  }
+  const decoder = new TextDecoder()
+  let buffer = ''
+
+  while (true) {
+    const { done, value } = await reader.read()
+    if (done) break
+
+    const chunk = decoder.decode(value, { stream: true })
+    buffer += chunk
+
+    const validChunks: string[] = []
+    // split the buffer using '}{', also tolerate newlines between '}' and '{'
+    const segments = buffer.split(/}[\r\n]*{/)
+    if (segments.length > 1) {
+      // add the removed '}' or '{' back
+      segments[0] += '}'
+
+      for (let i = 1; i < segments.length - 1; i++) {
+        segments[i] = '{' + segments[i] + '}'
+      }
+
+      const lastSegment = '{' + (segments.pop() ?? '')
+      if (/}[\r\n]*$/.test(lastSegment)) {
+        // if the last segment is also a valid JSON, clean up the buffer
+        segments.push(lastSegment)
+        buffer = ''
+      } else {
+        // if not, push the last segment to the buffer
+        buffer = lastSegment
+      }
+
+      segments.forEach((segment) => {
+        if (isValidJsonString(segment)) {
+          validChunks.push(segment)
+        }
+      })
+    } else if (isValidJsonString(buffer)) {
+      // buffer is a valid JSON
+      validChunks.push(buffer)
+      buffer = ''
+    }
+
+    validChunks.forEach((validChunk) => {
+      const chunkResponse = JSON.parse(validChunk) as ChunkResponse
+
+      if (!validateStatus(chunkResponse.code)) {
+        // TODO: Handle CosAPI Error Status
+        throw new Error(chunkResponse.msg)
+      }
+      onChunk(chunkResponse)
+    })
+  }
+}
+
+const isValidJsonString = (value: string): boolean => {
+  try {
+    JSON.parse(value)
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/readStream.test.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/readStream.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest'
-import { CosApiInnerResponse, readStream } from './cosRequestUtils'
+import { CosGetApiInnerResponse } from './cosGetRequestUtils'
+import { readStream } from './cosStreamRequestUtils'
 
 // Helper function to create a readable stream from chunks
 const createStream = (chunks: string[]): ReadableStream => {
@@ -29,7 +30,7 @@ describe('readStream', () => {
       '{"code":200,"msg":"abc","status":"ok","data":{"id":1}}\r',
     ])
 
-    await readStream<CosApiInnerResponse<unknown>>(
+    await readStream<CosGetApiInnerResponse<unknown>>(
       stream,
       abortController.signal,
       onChunk,
@@ -51,7 +52,7 @@ describe('readStream', () => {
       '{"code":200,"msg":"abc","status":"ok","data":{"id":1}}\n{"co',
     ])
 
-    await readStream<CosApiInnerResponse<unknown>>(
+    await readStream<CosGetApiInnerResponse<unknown>>(
       stream,
       abortController.signal,
       onChunk,
@@ -75,7 +76,7 @@ describe('readStream', () => {
       '"code":200,"msg":"lorem ipsum 4","status":"ok","data":{"value":"{{{{{{{}}}"}}\n',
     ])
 
-    await readStream<CosApiInnerResponse<unknown>>(
+    await readStream<CosGetApiInnerResponse<unknown>>(
       stream,
       abortController.signal,
       onChunk,
@@ -124,7 +125,7 @@ describe('readStream', () => {
     ])
 
     await expect(async () => {
-      await readStream<CosApiInnerResponse<unknown>>(
+      await readStream<CosGetApiInnerResponse<unknown>>(
         stream,
         abortController.signal,
         onChunk,
@@ -137,7 +138,7 @@ describe('readStream', () => {
   test('handles an empty stream without errors', async () => {
     const onChunk = vi.fn()
     const stream = createStream([])
-    await readStream<CosApiInnerResponse<unknown>>(
+    await readStream<CosGetApiInnerResponse<unknown>>(
       stream,
       abortController.signal,
       onChunk,

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosGetRequest.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosGetRequest.ts
@@ -1,12 +1,8 @@
 import { useSyncedRef } from '@cube-frontend/utils'
 import { isEqual } from 'lodash'
 import { useCallback, useEffect, useRef } from 'react'
-import {
-  CosApiResponse,
-  GetParamFn,
-  isNullish,
-  Nullish,
-} from './cosRequestUtils'
+import { CosGetApiResponse } from './cosGetRequestUtils'
+import { GetParamFn, isNullish, Nullish } from './cosRequestUtils'
 import {
   INTERNAL_useCosRequestHandler,
   UseCosRequestHandler,
@@ -32,8 +28,8 @@ export type UseCosGetRequestOptions = {
   fetchOnParamChanges?: boolean
 }
 
-type NullaryRequest<T> = () => Promise<CosApiResponse<T>>
-type UnaryRequest<T, Param> = (param: Param) => Promise<CosApiResponse<T>>
+type NullaryRequest<T> = () => Promise<CosGetApiResponse<T>>
+type UnaryRequest<T, Param> = (param: Param) => Promise<CosGetApiResponse<T>>
 
 type UseCosGetRequestHook = {
   <Data>(

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosMutationRequest.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosMutationRequest.ts
@@ -1,4 +1,4 @@
-import { CosApiResponse } from './cosRequestUtils'
+import { CosMutationApiResponse } from './cosMutationRequestUtils'
 import {
   INTERNAL_useCosRequestHandler,
   UseCosRequestHandler,
@@ -13,7 +13,7 @@ export type UseCosMutationRequest<Data, Params extends Array<unknown>> = Omit<
 
 type MutationRequest<Data, Params extends Array<unknown>> = (
   ...params: Params
-) => Promise<CosApiResponse<Data>>
+) => Promise<CosMutationApiResponse<Data>>
 
 export const useCosMutationRequest = <Data, Params extends Array<unknown>>(
   request: MutationRequest<Data, Params>,

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosRequestHandler.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosRequestHandler.ts
@@ -1,8 +1,9 @@
 import { isAxiosError } from 'axios'
 import { useCallback, useState } from 'react'
+import { CosGetApiRequest } from './cosGetRequestUtils'
+import { CosMutationApiRequest } from './cosMutationRequestUtils'
 import {
   CosApiError,
-  CosApiRequest,
   CosRequestError,
   getNativeError,
   isCosApiResponse,
@@ -16,7 +17,9 @@ export type UseCosRequestHandler<Data> = {
   hasResponseBeenReceived: boolean
   data: Data | undefined
   errorState: CosRequestError | undefined
-  oversee: (request: CosApiRequest<Data>) => Promise<Data>
+  oversee: (
+    request: CosGetApiRequest<Data> | CosMutationApiRequest<Data>,
+  ) => Promise<Data>
   clearError: () => void
 }
 
@@ -34,7 +37,9 @@ export const INTERNAL_useCosRequestHandler = <Data>(
   const [data, setData] = useState<Data | undefined>()
   const [errorState, setErrorState] = useState<CosRequestError | undefined>()
 
-  const oversee = async (request: CosApiRequest<Data>): Promise<Data> => {
+  const oversee = async (
+    request: CosGetApiRequest<Data> | CosMutationApiRequest<Data>,
+  ): Promise<Data> => {
     setIsLoading(true)
     setErrorState(undefined)
 
@@ -42,7 +47,7 @@ export const INTERNAL_useCosRequestHandler = <Data>(
       const response = await request()
       setData(response.data.data)
       setHasResponseBeenReceived(true)
-      return response.data.data
+      return response.data.data as Data
     } catch (error) {
       if (isAxiosError(error) && isCosApiResponse(error.response)) {
         const cosApiResponse = error.response

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosStreamRequest.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosStreamRequest.ts
@@ -1,18 +1,17 @@
+import { AxiosRequestConfig, isAxiosError, isCancel } from 'axios'
 import { isEqual } from 'lodash'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { CosGetApiInnerResponse, CosGetApiResponse } from './cosGetRequestUtils'
 import {
   CosApiError,
-  CosApiInnerResponse,
-  CosApiResponse,
   CosRequestError,
   getNativeError,
   GetParamFn,
   isCosApiResponse,
   isNullish,
   Nullish,
-  readStream,
 } from './cosRequestUtils'
-import { AxiosRequestConfig, isAxiosError, isCancel } from 'axios'
+import { readStream } from './cosStreamRequestUtils'
 
 export type UseCosStreamRequest<Data> = {
   isLoading: boolean
@@ -27,7 +26,7 @@ type StreamParam = {
 type StreamRequest<T, Param extends StreamParam> = (
   param: Param,
   options: AxiosRequestConfig,
-) => Promise<CosApiResponse<T>>
+) => Promise<CosGetApiResponse<T>>
 
 type UseCosStreamRequestHook = {
   <Data, Param extends StreamParam>(
@@ -74,7 +73,7 @@ export const useCosStreamRequest: UseCosStreamRequestHook = <
         },
       )
 
-      readStream<CosApiInnerResponse<Data>>(
+      readStream<CosGetApiInnerResponse<Data>>(
         response.data as unknown as ReadableStream,
         abortControllerRef.current.signal,
         (chunkRes) => {

--- a/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/useUpdateTrigger.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/triggers/[create]/useUpdateTrigger.ts
@@ -1,15 +1,9 @@
 import { useContext } from 'react'
 import { useNavigate } from 'react-router'
-import {
-  GetTriggersResponseDataInner,
-  TriggersApiUpdateTriggerRequest,
-} from '@cube-frontend/api'
+import { GetTriggersResponseDataInner } from '@cube-frontend/api'
 import { triggersApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import {
-  CosApiResponse,
-  CosRequestError,
-} from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
+import { CosRequestError } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { formValueToRequest } from './utils'
 import { CreateTriggerFormValue } from './useCreateTriggerForm'
@@ -40,11 +34,7 @@ export const useUpdateTrigger = (
     mutateResource: updateTrigger,
     errorState,
     clearError,
-  } = useCosMutationRequest(
-    triggersApi.updateTrigger as (
-      params: TriggersApiUpdateTriggerRequest,
-    ) => Promise<CosApiResponse<undefined>>,
-  )
+  } = useCosMutationRequest(triggersApi.updateTrigger)
 
   const handleTriggerUpdate = async () => {
     clearError()

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/create/CreateTuningsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/create/CreateTuningsPage.tsx
@@ -1,11 +1,9 @@
-import { TuningsApiUpdateTuningRequest } from '@cube-frontend/api'
 import { CosBackButton } from '@cube-frontend/ui-library'
 import { tuningsApi } from '@cube-frontend/web-app/api/cosApi'
 import { CreateTunings } from '@cube-frontend/web-app/components/UpsertTunings/CreateTunings'
 import { NonNullableUpsertTuningsPayload } from '@cube-frontend/web-app/components/UpsertTunings/upsertTuningsUtils'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { useContext } from 'react'
 import { Link, useNavigate } from 'react-router'
@@ -19,11 +17,7 @@ export const CreateTuningsPage = () => {
     mutateResource: updateTuning,
     errorState,
     clearError,
-  } = useCosMutationRequest(
-    tuningsApi.updateTuning as (
-      params: TuningsApiUpdateTuningRequest,
-    ) => Promise<CosApiResponse<undefined>>,
-  )
+  } = useCosMutationRequest(tuningsApi.updateTuning)
 
   const onPublishClick = async (payload: NonNullableUpsertTuningsPayload) => {
     const { selectedSpecName, value, selectedHosts } = payload

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/edit/EditTuningsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/edit/EditTuningsPage.tsx
@@ -1,11 +1,9 @@
-import { TuningsApiUpdateTuningRequest } from '@cube-frontend/api'
 import { CosBackButton } from '@cube-frontend/ui-library'
 import { tuningsApi } from '@cube-frontend/web-app/api/cosApi'
 import { EditTunings } from '@cube-frontend/web-app/components/UpsertTunings/EditTunings'
 import { NonNullableUpsertTuningsPayload } from '@cube-frontend/web-app/components/UpsertTunings/upsertTuningsUtils'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { useEditTuningsStore } from '@cube-frontend/web-app/stores/editTuningsStore'
 import { useContext } from 'react'
@@ -22,11 +20,7 @@ export const EditTuningsPage = () => {
     mutateResource: updateTuning,
     errorState,
     clearError,
-  } = useCosMutationRequest(
-    tuningsApi.updateTuning as (
-      params: TuningsApiUpdateTuningRequest,
-    ) => Promise<CosApiResponse<undefined>>,
-  )
+  } = useCosMutationRequest(tuningsApi.updateTuning)
 
   const onPublishClick = async (payload: NonNullableUpsertTuningsPayload) => {
     const { selectedSpecName, value, selectedHosts } = payload

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/utils.ts
@@ -18,16 +18,16 @@ import {
 } from '@cube-frontend/api'
 import { CosGeneralPanelTitleBarProps } from '@cube-frontend/ui-library'
 import { metricsApi } from '@cube-frontend/web-app/api/cosApi'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
+import { CosGetApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosGetRequestUtils'
 import { AxiosRequestConfig } from 'axios'
 import { noop } from 'lodash'
 
 const getMetricsByTypes = async <T extends GetMetricByTypes200Response>(
   req: MetricsApiGetMetricByTypesRequest,
   options?: AxiosRequestConfig,
-): Promise<CosApiResponse<T['data']>> => {
+): Promise<CosGetApiResponse<T['data']>> => {
   const metrics = await metricsApi.getMetricByTypes(req, options)
-  return metrics as unknown as CosApiResponse<T['data']>
+  return metrics as unknown as CosGetApiResponse<T['data']>
 }
 
 export type TypeParams = Pick<

--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthHistoryPanel.tsx
@@ -1,9 +1,7 @@
-import { HealthApiRepairModuleHealthRequest } from '@cube-frontend/api'
 import { CosStroke } from '@cube-frontend/ui-library'
 import { healthApi } from '@cube-frontend/web-app/api/cosApi'
 import { useTimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/useTimeRange'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { ModuleMetadata } from '@cube-frontend/web-app/hooks/useServices/useServices'
 import { cva } from 'class-variance-authority'
@@ -72,9 +70,7 @@ export const HealthHistoryPanel = (props: HealthHistoryPanelProps) => {
   const [isCallingRepairApi, setIsCallingRepairApi] = useState(false)
 
   const { mutateResource: repairModuleHealth } = useCosMutationRequest(
-    healthApi.repairModuleHealth as (
-      params: HealthApiRepairModuleHealthRequest,
-    ) => Promise<CosApiResponse<undefined>>,
+    healthApi.repairModuleHealth,
   )
 
   const onRepairClick = async () => {

--- a/packages/cube-frontend-web-app/src/pages/home/health/_components/healthCheck/HealthCheck.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/_components/healthCheck/HealthCheck.tsx
@@ -1,11 +1,7 @@
-import {
-  HealthApiGetHealthsRequest,
-  HealthApiRepairAllModulesHealthRequest,
-} from '@cube-frontend/api'
+import { HealthApiGetHealthsRequest } from '@cube-frontend/api'
 import { CosButton, CosLoadingSpinner } from '@cube-frontend/ui-library'
 import { healthApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentialInterval/useSequentialInterval'
@@ -41,9 +37,7 @@ export const HealthCheck = () => {
   const [isCallingRepairApi, setIsCallingRepairApi] = useState(false)
 
   const { mutateResource: repairHealth } = useCosMutationRequest(
-    healthApi.repairAllModulesHealth as (
-      params: HealthApiRepairAllModulesHealthRequest,
-    ) => Promise<CosApiResponse<undefined>>,
+    healthApi.repairAllModulesHealth,
   )
 
   const renderNgServices = () => {

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/HealthPanel/HealthPanel.tsx
@@ -1,11 +1,7 @@
-import {
-  HealthApiGetHealthsRequest,
-  HealthApiRepairAllModulesHealthRequest,
-} from '@cube-frontend/api'
+import { HealthApiGetHealthsRequest } from '@cube-frontend/api'
 import { CosDashboardPanel } from '@cube-frontend/ui-library'
 import { healthApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { useSequentialInterval } from '@cube-frontend/web-app/hooks/useSequentialInterval/useSequentialInterval'
@@ -59,9 +55,7 @@ const HealthPanel = () => {
   const [isCallingRepairApi, setIsCallingRepairApi] = useState(false)
 
   const { mutateResource: repairHealth } = useCosMutationRequest(
-    healthApi.repairAllModulesHealth as (
-      params: HealthApiRepairAllModulesHealthRequest,
-    ) => Promise<CosApiResponse<undefined>>,
+    healthApi.repairAllModulesHealth,
   )
 
   const handleRepair = async () => {

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/useImportLicense.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/useImportLicense.ts
@@ -5,13 +5,9 @@ import {
   useRef,
   useState,
 } from 'react'
-import {
-  LicensesApiImportClusterLicenseRequest,
-  VerifyLicenseResponseData,
-} from '@cube-frontend/api'
+import { VerifyLicenseResponseData } from '@cube-frontend/api'
 import { licenseApi } from '@cube-frontend/web-app/api/cosApi'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 
 const MESSAGE_TIMEOUT = 5 * 1000
@@ -35,11 +31,7 @@ export const useImportLicense = (options: UseImportLicenseOptions) => {
     mutateResource: importLicense,
     isLoading: isUploadingLicense,
     errorState: importLicenseErrorState,
-  } = useCosMutationRequest(
-    licenseApi.importClusterLicense as (
-      params: LicensesApiImportClusterLicenseRequest,
-    ) => Promise<CosApiResponse<undefined>>,
-  )
+  } = useCosMutationRequest(licenseApi.importClusterLicense)
 
   const fileInputRef = useRef<HTMLInputElement>(null)
 

--- a/packages/cube-frontend-web-app/src/pages/node/_components/CreateSupportFilesModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/CreateSupportFilesModal.tsx
@@ -1,7 +1,4 @@
-import {
-  Node,
-  SupportFilesApiCreateSupportFilesRequest,
-} from '@cube-frontend/api'
+import { Node } from '@cube-frontend/api'
 import {
   CosInput,
   CosModal,
@@ -10,7 +7,6 @@ import {
 } from '@cube-frontend/ui-library'
 import { supportFilesApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { useContext } from 'react'
 
@@ -42,11 +38,7 @@ export const CreateSupportFilesModal = (
   const { dataCenter } = useContext(DataCenterContext)
 
   const { isLoading: isCreating, mutateResource: createSupportFilesApi } =
-    useCosMutationRequest(
-      supportFilesApi.createSupportFiles as (
-        params: SupportFilesApiCreateSupportFilesRequest,
-      ) => Promise<CosApiResponse<undefined>>,
-    )
+    useCosMutationRequest(supportFilesApi.createSupportFiles)
 
   const onCreateClick = async (): Promise<void> => {
     try {

--- a/packages/cube-frontend-web-app/src/pages/settings/ManageContact.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/ManageContact.tsx
@@ -1,12 +1,10 @@
 import {
   GetSettingResponseDataTitlePrefix,
-  SettingsApiUpdateTitlePrefixRequest,
   SettingStatusCurrentEnum,
 } from '@cube-frontend/api'
 import { CosButton, CosInput, CosStroke } from '@cube-frontend/ui-library'
 import { settingsApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { useShowErrorToast } from '@cube-frontend/web-app/hooks/useShowErrorToast/useShowErrorToast'
 import { ChangeEvent, FormEvent, useContext, useEffect, useState } from 'react'
@@ -46,11 +44,7 @@ export const ManageContact = (props: ManageContactProps) => {
   const {
     isLoading: isCallingUpdateApi,
     mutateResource: updateTitlePrefixApi,
-  } = useCosMutationRequest(
-    settingsApi.updateTitlePrefix as (
-      params: SettingsApiUpdateTitlePrefixRequest,
-    ) => Promise<CosApiResponse<undefined>>,
-  )
+  } = useCosMutationRequest(settingsApi.updateTitlePrefix)
 
   const onTitlePrefixChange = (e: ChangeEvent<HTMLInputElement>): void => {
     setTitlePrefix((prev) => ({

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/VerifyEmailSenderModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/senders/VerifyEmailSenderModal.tsx
@@ -1,8 +1,6 @@
-import { SettingsApiTryEmailSenderRequest } from '@cube-frontend/api'
 import { CosInput, CosModal } from '@cube-frontend/ui-library'
 import { settingsApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
-import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import {
   ChangeEvent,
@@ -36,11 +34,7 @@ export const VerifyEmailSenderModal = (props: VerifyEmailSenderModalProps) => {
     mutateResource: tryEmailSender,
     errorState,
     clearError,
-  } = useCosMutationRequest(
-    settingsApi.tryEmailSender as (
-      params: SettingsApiTryEmailSenderRequest,
-    ) => Promise<CosApiResponse<undefined>>,
-  )
+  } = useCosMutationRequest(settingsApi.tryEmailSender)
 
   useEffect(() => {
     if (isOpen) {


### PR DESCRIPTION
#### What type of PR is this?

Refactor

#### What this PR does / why we need it

Add support for data-less requests in the `useCosMutationRequest` hook.

#### Which issue(s) this PR fixes

Close #426 

- Type castings have been removed.
   - ![image](https://github.com/user-attachments/assets/b2d08b0c-433c-4a5a-a3a1-2c3467a922cd)
- The `data` field for data-less mutation requests will be of the `unknown` type.
   - We could've made it `never`, but that would require less-readable code and the trade-off probably isn’t worth it.
   - ![image](https://github.com/user-attachments/assets/f417cf01-2df3-4610-a0d8-500e3908b694)
