### PR TITLE
fix: 433 update the license nagging after a new license file imported

### DIFF
--- a/packages/cube-frontend-web-app/src/context/DataCenterContext.ts
+++ b/packages/cube-frontend-web-app/src/context/DataCenterContext.ts
@@ -3,10 +3,14 @@ import { GetDataCentersResponseDataInner } from '@cube-frontend/api'
 
 type DataCenterContextValue = {
   dataCenter: GetDataCentersResponseDataInner | undefined
+  fetchDataCenters:
+    | (() => Promise<GetDataCentersResponseDataInner[]>)
+    | undefined
   isLoading: boolean
 }
 
 export const DataCenterContext = createContext<DataCenterContextValue>({
   dataCenter: undefined,
+  fetchDataCenters: undefined,
   isLoading: false,
 })

--- a/packages/cube-frontend-web-app/src/context/DataCenterProvider.tsx
+++ b/packages/cube-frontend-web-app/src/context/DataCenterProvider.tsx
@@ -6,10 +6,15 @@ import { useCosGetRequest } from '../hooks/useCosRequest/useCosGetRequest'
 export const DataCenterProvider = (props: PropsWithChildren) => {
   const { children } = props
 
-  const { data: dataCenters, isLoading } = useCosGetRequest(
-    dataCentersApi.getDataCenters,
-  )
+  const {
+    data: dataCenters,
+    isLoading,
+    getResource: fetchDataCenters,
+  } = useCosGetRequest(dataCentersApi.getDataCenters)
 
+  /**
+   * In Phase 1, there is only 1 data center.
+   */
   const dataCenter = dataCenters?.[0]
 
   if (!isLoading && !dataCenter) {
@@ -17,7 +22,9 @@ export const DataCenterProvider = (props: PropsWithChildren) => {
   }
 
   return (
-    <DataCenterContext.Provider value={{ dataCenter, isLoading }}>
+    <DataCenterContext.Provider
+      value={{ dataCenter, fetchDataCenters, isLoading }}
+    >
       {children}
     </DataCenterContext.Provider>
   )

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/MaintenanceLicensePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/MaintenanceLicensePage.tsx
@@ -21,7 +21,7 @@ import { useTopLicenseNaggingStore } from '@cube-frontend/web-app/stores/topLice
 import { LicenseActions } from './_components/LicenseActions/LicenseActions'
 
 export const MaintenanceLicensePage = () => {
-  const { dataCenter } = useContext(DataCenterContext)
+  const { dataCenter, fetchDataCenters } = useContext(DataCenterContext)
 
   const [searchKeyword, setSearchKeyword] = useState<string>('')
   const [selectedProducts, setSelectedProducts] = useState<
@@ -52,6 +52,11 @@ export const MaintenanceLicensePage = () => {
     } satisfies LicensesApiGetLicensesRequest
   })
 
+  const handleLicenseImportSuccess = () => {
+    fetchLicenses()
+    fetchDataCenters!()
+  }
+
   const [debouncedSearchKeyword, setDebounceSearchKeyword] = useDebounce(
     searchKeyword,
     300,
@@ -80,7 +85,7 @@ export const MaintenanceLicensePage = () => {
   return (
     <CosGeneralPanel topic="License">
       <div className="flex flex-col gap-y-6 pt-2">
-        <LicenseActions onImportLicenseSuccess={fetchLicenses} />
+        <LicenseActions onImportLicenseSuccess={handleLicenseImportSuccess} />
         <CosStroke type="dot" />
         <div className="flex flex-col gap-y-2">
           <h5 className="primary-h5 text-functional-text">License</h5>


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### Which issue(s) this PR fixes

Fixes #433

#### What this PR does / why we need it

Problem:
The License Nagging should be updated after a license file is imported to reflect the latest license status of the data center. 

Solution:
Re-fetch `dataCenters` after successfully importing the license file .

#### Test Screenshots

https://github.com/user-attachments/assets/3db7b74a-55df-4055-b496-3cc338965c1a
