### PR TITLE
441 fix(web-app): home charts page storage iops chart title

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/StoragePanels/StorageIopsPanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/StoragePanels/StorageIopsPanel.tsx
@@ -33,7 +33,7 @@ export const StorageIopsPanel = () => {
   const showLoading = !hasResponseBeenReceived && isLoading
 
   return (
-    <CosGeneralPanel topic="Storage IOPs" className="flex-1">
+    <CosGeneralPanel topic="Storage IOPS" className="flex-1">
       <StorageChart
         read={diskIopsHistory.read}
         write={diskIopsHistory.write}


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix Home Charts page -> Storage IOPS chart title casing issue.

#### Which issue(s) this PR fixes

Close #441 

![image](https://github.com/user-attachments/assets/218a1938-f1a7-4807-97e3-235c7434e4f2)
