### PR TITLE
444 fix(web-app): error ui does not go away when navigating to another page

### DIFF
--- a/packages/cube-frontend-web-app/src/components/ErrorDisplay/CosErrorBoundary.tsx
+++ b/packages/cube-frontend-web-app/src/components/ErrorDisplay/CosErrorBoundary.tsx
@@ -1,6 +1,7 @@
 import { AxiosError } from 'axios'
-import { ReactNode } from 'react'
+import { ReactNode, useMemo } from 'react'
 import { ErrorBoundary, FallbackProps } from 'react-error-boundary'
+import { Location, useLocation } from 'react-router'
 import { ClassNameValue, twMerge } from 'tailwind-merge'
 import { GeneralErrorDisplay } from './GeneralErrorDisplay'
 import { HttpErrorDisplay } from './HttpErrorDisplay'
@@ -10,8 +11,22 @@ type CosErrorBoundaryProps = {
   children: ReactNode
 }
 
+// Use customized serialize function because `location.key` changes
+// every time even for the same route.
+const serializeLocation = (location: Location): string => {
+  const { pathname, search, hash } = location
+  return `${pathname}${search}${hash}`
+}
+
 export const CosErrorBoundary = (props: CosErrorBoundaryProps) => {
   const { containerClassName, children } = props
+
+  const location = useLocation()
+
+  const serializedLocation = useMemo<string>(
+    () => serializeLocation(location),
+    [location],
+  )
 
   const renderErrorDisplay = (fallbackProps: FallbackProps) => {
     const { error } = fallbackProps
@@ -42,7 +57,11 @@ export const CosErrorBoundary = (props: CosErrorBoundaryProps) => {
   }
 
   return (
-    <ErrorBoundary fallbackRender={renderErrorDisplay} onError={onError}>
+    <ErrorBoundary
+      resetKeys={[serializedLocation]}
+      fallbackRender={renderErrorDisplay}
+      onError={onError}
+    >
       {children}
     </ErrorBoundary>
   )

--- a/packages/cube-frontend-web-app/src/components/ErrorDisplay/ErrorDisplay.tsx
+++ b/packages/cube-frontend-web-app/src/components/ErrorDisplay/ErrorDisplay.tsx
@@ -1,5 +1,4 @@
 import { CosButton } from '@cube-frontend/ui-library'
-import { useErrorBoundary } from 'react-error-boundary'
 import { twMerge } from 'tailwind-merge'
 
 type ErrorDisplayProps = {
@@ -10,11 +9,10 @@ type ErrorDisplayProps = {
 export const ErrorDisplay = (props: ErrorDisplayProps) => {
   const { title, message } = props
 
-  const { resetBoundary } = useErrorBoundary()
-
   const onGoBackClick = (): void => {
+    // Error boundary will be reset by the `resetKeys` property on
+    // the nearest `<ErrorBoundary>` element.
     history.back()
-    resetBoundary()
   }
 
   return (


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix error UI does not go away when navigating to another page bug.

#### Which issue(s) this PR fixes

Close #444

#### Special notes for your reviewer

Simply throw an error at the top of any page to test it out:

<img width="759" alt="{A7C03710-409B-4290-900F-5A1D2E3F2775}" src="https://github.com/user-attachments/assets/59f19c97-ef23-4af6-af48-b92308b26a37" />

#### Additional documentation

Docs for the [resetKeys](https://www.npmjs.com/package/react-error-boundary/v/3.1.4#error-recovery) prop.

- Before

   https://github.com/user-attachments/assets/e75684aa-a033-4635-84cf-118e32478183

- After

   https://github.com/user-attachments/assets/faa43112-f6ee-4fb9-bc35-c15dc0daa2fc

