### PR TITLE
fix(web-app): edit tunings page back button functionality

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/events/tunings/edit/EditTuningsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/edit/EditTuningsPage.tsx
@@ -9,7 +9,7 @@ import { CosApiResponse } from '@cube-frontend/web-app/hooks/useCosRequest/cosRe
 import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
 import { useEditTuningsStore } from '@cube-frontend/web-app/stores/editTuningsStore'
 import { useContext } from 'react'
-import { Navigate, useNavigate } from 'react-router'
+import { Link, Navigate, useNavigate } from 'react-router'
 
 export const EditTuningsPage = () => {
   const navigate = useNavigate()
@@ -56,7 +56,15 @@ export const EditTuningsPage = () => {
 
   return (
     <div className="mx-2 my-1">
-      <CosBackButton variant="title" onClick={() => history.back()}>
+      <CosBackButton
+        variant="title"
+        backLinkContainer={{
+          Component: Link,
+          props: {
+            to: CosRoutesEnum.EVENTS_TUNINGS_PAGE,
+          },
+        }}
+      >
         {title}
       </CosBackButton>
       <EditTunings


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix the back button functionality in the Edit Tunings page.

#### Which issue(s) this PR fixes

Close #446 

#### Special notes for your reviewer

This page should be updated alongside the other ones in #422, but I missed it. 🫤 

https://github.com/user-attachments/assets/d4b5d559-61bc-4112-8d68-917a3f7ab5dd

