### PR TITLE
fix: set start and end of day when selected dates are the same

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/SupportFilesFilters.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/SupportFilesFilters.tsx
@@ -48,8 +48,12 @@ export const SupportFilesFilters = (props: SupportFilesFiltersProps) => {
     const { start, end } = displayDates
     if (!start || !end) return
 
-    handleStartDateChange(displayDates.start)
-    handleEndDateChange(displayDates.end)
+    /**
+     * When the user selects a start and end date from the date picker,
+     * we need to set the `start` to the beginning of the `startDate` and the `end` to the end of the `endDate`.
+     */
+    handleStartDateChange(start.startOf('day'))
+    handleEndDateChange(end.endOf('day'))
   }
 
   const handleDatePickerReset = () => {


### PR DESCRIPTION
#### What type of PR is this?

- Fix

#### What this PR does / why we need it

- When the user selects the same day with the `DatePicker`, it will set the start and end times to the beginning and end of that day.

<img width="1509" alt="Screenshot 2025-05-20 at 3 05 37 PM" src="https://github.com/user-attachments/assets/77522f0a-9f39-43b8-8fd7-7f6ed8dcd07b" />

#### Which issue(s) this PR fixes

Fixes https://github.com/bigstack-oss/cubecos/issues/84

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
