### PR TITLE
fix(web-app): upsert tunings value sent to api does not match spec type

### DIFF
--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/CreateTunings.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/CreateTunings.tsx
@@ -74,6 +74,7 @@ export const CreateTunings = (props: CreateTuningsProps) => {
     publish: () => (
       <PublishTuning
         payload={payload}
+        selectedSpec={selectedSpec!}
         errorMessage={errorMessage}
         onPublishClick={onPublishClick}
       />

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/CreateTunings.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/CreateTunings.tsx
@@ -11,6 +11,7 @@ import { Navigate } from 'react-router'
 import { PublishTuning } from './_components/Publish/PublishTuning'
 import { SelectHosts } from './_components/SelectHosts/SelectHosts'
 import { SelectKeyValue } from './_components/SelectKeyValue/SelectKeyValue'
+import { useSpecFilter } from './_components/SelectKeyValue/useSpecFilter'
 import { UpsertTuningsSteps } from './_components/UpsertTuningsSteps'
 import { useCreateTuningsPayload } from './_components/useCreateTuningsPayload'
 import { useStepParam } from './_components/useStepParam'
@@ -50,12 +51,15 @@ export const CreateTunings = (props: CreateTuningsProps) => {
 
   const { step, goToSelectHosts, goToPublish } = useStepParam()
 
+  const specFilter = useSpecFilter()
+
   const renderContentFnMap: Record<UpsertTuningsStep, () => ReactNode> = {
     keyValue: () => (
       <SelectKeyValue
         isLoading={!specs}
         specs={specs}
         selectedSpec={selectedSpec}
+        specFilter={specFilter}
         value={payload.value}
         onSpecSelect={onSpecSelect}
         onValueChange={onValueChange}

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/EditTunings.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/EditTunings.tsx
@@ -5,7 +5,7 @@ import {
 import { nodesApi, tuningsApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
-import { EditTuningsDefaultData } from '@cube-frontend/web-app/stores/editTuningsStore'
+import { EditTuningsInitialData } from '@cube-frontend/web-app/stores/editTuningsStore'
 import { ReactNode, useContext } from 'react'
 import { EditValue } from './_components/EditValue/EditValue'
 import { PublishTuning } from './_components/Publish/PublishTuning'
@@ -19,13 +19,13 @@ import {
 } from './upsertTuningsUtils'
 
 type EditTuningsProps = {
-  defaultData: EditTuningsDefaultData
+  initialData: EditTuningsInitialData
   errorMessage?: string | undefined
   onPublishClick: (payload: NonNullableUpsertTuningsPayload) => Promise<void>
 }
 
 export const EditTunings = (props: EditTuningsProps) => {
-  const { defaultData, errorMessage, onPublishClick } = props
+  const { initialData, errorMessage, onPublishClick } = props
 
   const { dataCenter } = useContext(DataCenterContext)
 
@@ -51,7 +51,7 @@ export const EditTunings = (props: EditTuningsProps) => {
     selectedSpec,
     onValueChange,
     onHostsChange,
-  } = useEditTuningsPayload(specs, nodes, defaultData)
+  } = useEditTuningsPayload(specs, nodes, initialData)
 
   const { step, goToSelectHosts, goToPublish } = useStepParam()
 
@@ -77,6 +77,7 @@ export const EditTunings = (props: EditTuningsProps) => {
     publish: () => (
       <PublishTuning
         payload={payload!}
+        selectedSpec={selectedSpec!}
         errorMessage={errorMessage}
         onPublishClick={onPublishClick}
       />

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/Publish/PublishTuning.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/Publish/PublishTuning.tsx
@@ -1,8 +1,10 @@
+import { ListTuningSpecResponseDataInner } from '@cube-frontend/api'
 import { CosButton, GetCosBasicTable } from '@cube-frontend/ui-library'
 import { useMemo, useState } from 'react'
 import {
   hostToPreviewRow,
   NonNullableUpsertTuningsPayload,
+  payloadValueToLimitationValue,
   PreviewRow,
   UpsertTuningsPayload,
 } from '../../upsertTuningsUtils'
@@ -12,6 +14,7 @@ import { TuningsPreviousButton } from '../TuningsPreviousButton'
 
 type PublishTuningProps = {
   payload: UpsertTuningsPayload
+  selectedSpec: ListTuningSpecResponseDataInner
   errorMessage?: string | undefined
   onPublishClick: (payload: NonNullableUpsertTuningsPayload) => Promise<void>
 }
@@ -19,7 +22,12 @@ type PublishTuningProps = {
 const PreviewTable = GetCosBasicTable<PreviewRow>()
 
 export const PublishTuning = (props: PublishTuningProps) => {
-  const { payload, errorMessage, onPublishClick: onPublishClickProp } = props
+  const {
+    payload,
+    selectedSpec,
+    errorMessage,
+    onPublishClick: onPublishClickProp,
+  } = props
 
   const { selectedSpecName, value, selectedHosts } = payload
 
@@ -33,7 +41,15 @@ export const PublishTuning = (props: PublishTuningProps) => {
   const onPublishClick = async () => {
     setIsLoading(true)
     try {
-      await onPublishClickProp(payload as NonNullableUpsertTuningsPayload)
+      const transformedPayload = {
+        ...payload,
+        value: payloadValueToLimitationValue(
+          selectedSpec.limitation.type,
+          payload.value!,
+        ),
+      } as NonNullableUpsertTuningsPayload
+
+      await onPublishClickProp(transformedPayload)
     } finally {
       setIsLoading(false)
     }

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/SelectKeyValue.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/SelectKeyValue.tsx
@@ -7,12 +7,14 @@ import { Board } from '../Board'
 import { SpecEntry } from '../SpecEntry'
 import { TuningSpecTableSection } from './TuningSpecTableSection'
 import { TuningValueControl } from './TuningValueControl'
+import { UseSpecFilter } from './useSpecFilter'
 import { validateTuningValue } from './validateTuningValue'
 
 type SelectKeyValueProps = {
   isLoading: boolean
   specs: ListTuningSpecResponseDataInner[] | undefined
   selectedSpec: ListTuningSpecResponseDataInner | undefined
+  specFilter: UseSpecFilter
   value: UpsertTuningsPayloadValue
   onSpecSelect: (spec: ListTuningSpecResponseDataInner) => void
   onValueChange: (e: ChangeEvent<HTMLInputElement> | boolean) => void
@@ -24,6 +26,7 @@ export const SelectKeyValue = (props: SelectKeyValueProps) => {
     isLoading,
     specs,
     selectedSpec,
+    specFilter,
     value,
     onSpecSelect,
     onValueChange,
@@ -44,6 +47,7 @@ export const SelectKeyValue = (props: SelectKeyValueProps) => {
         isLoading={isLoading}
         specs={specs}
         selectedSpec={selectedSpec}
+        specFilter={specFilter}
         onSpecSelect={onSpecSelect}
       />
       <CosStroke type="regular" />

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/SelectKeyValue.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/SelectKeyValue.tsx
@@ -1,10 +1,8 @@
-import {
-  ListTuningResponseDataTuningsInnerLimitationDefault,
-  ListTuningSpecResponseDataInner,
-} from '@cube-frontend/api'
+import { ListTuningSpecResponseDataInner } from '@cube-frontend/api'
 import { CosButton, CosStroke } from '@cube-frontend/ui-library'
 import ChevronRight from '@cube-frontend/ui-library/icons/monochrome/chevron_right.svg?react'
 import { ChangeEvent, useMemo } from 'react'
+import { UpsertTuningsPayloadValue } from '../../upsertTuningsUtils'
 import { Board } from '../Board'
 import { SpecEntry } from '../SpecEntry'
 import { TuningSpecTableSection } from './TuningSpecTableSection'
@@ -15,7 +13,7 @@ type SelectKeyValueProps = {
   isLoading: boolean
   specs: ListTuningSpecResponseDataInner[] | undefined
   selectedSpec: ListTuningSpecResponseDataInner | undefined
-  value: ListTuningResponseDataTuningsInnerLimitationDefault | undefined
+  value: UpsertTuningsPayloadValue
   onSpecSelect: (spec: ListTuningSpecResponseDataInner) => void
   onValueChange: (e: ChangeEvent<HTMLInputElement> | boolean) => void
   onNextClick: () => void

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/TuningSpecTableSection.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/TuningSpecTableSection.tsx
@@ -1,18 +1,19 @@
 import { ListTuningSpecResponseDataInner } from '@cube-frontend/api'
 import { CosPagination, CosSearchBarFilter } from '@cube-frontend/ui-library'
 import { TuningSpecTable } from './TuningSpecTable'
-import { useSpecFilter } from './useSpecFilter'
+import { UseSpecFilter } from './useSpecFilter'
 import { useSpecRows } from './useSpecRows'
 
 type TuningSpecTableSectionProps = {
   isLoading: boolean
   specs: ListTuningSpecResponseDataInner[] | undefined
   selectedSpec: ListTuningSpecResponseDataInner | undefined
+  specFilter: UseSpecFilter
   onSpecSelect: (spec: ListTuningSpecResponseDataInner) => void
 }
 
 export const TuningSpecTableSection = (props: TuningSpecTableSectionProps) => {
-  const { isLoading, specs, selectedSpec, onSpecSelect } = props
+  const { isLoading, specs, selectedSpec, specFilter, onSpecSelect } = props
 
   const {
     filter,
@@ -20,7 +21,7 @@ export const TuningSpecTableSection = (props: TuningSpecTableSectionProps) => {
     onKeywordClear,
     onPageChange,
     onItemsPerPageChange,
-  } = useSpecFilter()
+  } = specFilter
 
   const { matchedRows, paginatedRows } = useSpecRows(specs, filter)
 

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/useSpecFilter.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/useSpecFilter.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_ITEMS_PER_PAGE, ItemsPerPage } from '@cube-frontend/ui-library'
 import { ChangeEvent, useState } from 'react'
 
-type UseSpecFilter = {
+export type UseSpecFilter = {
   filter: SpecFilterValue
   onKeywordChange: (e: ChangeEvent<HTMLInputElement>) => void
   onKeywordClear: () => void

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/validateTuningValue.test.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/validateTuningValue.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it, suite } from 'vitest'
+import { validateTuningValue } from './validateTuningValue'
+import { ListTuningSpecResponseDataInnerLimitation } from '@cube-frontend/api'
+
+describe('Validate Tuning Value', () => {
+  suite('int', () => {
+    const limitation: ListTuningSpecResponseDataInnerLimitation = {
+      type: 'int',
+      default: 0,
+    }
+
+    it('returns true for valid int strings', () => {
+      ;['-1', '0', '1', '99', '123', '987654'].forEach((str) => {
+        expect(validateTuningValue(limitation, str)).toEqual(true)
+      })
+    })
+
+    it('returns false for invalid int strings', () => {
+      ;['', ' ', '  ', 'a', 'e', '1a', '1e', '1e2', '14 a', 'a b c'].forEach(
+        (str) => {
+          expect(validateTuningValue(limitation, str)).toEqual(false)
+        },
+      )
+    })
+  })
+
+  suite('uint', () => {
+    const limitation: ListTuningSpecResponseDataInnerLimitation = {
+      type: 'uint',
+      default: 0,
+    }
+
+    it('returns true for valid uint strings', () => {
+      ;['0', '1', '99', '123', '987654'].forEach((str) => {
+        expect(validateTuningValue(limitation, str)).toEqual(true)
+      })
+    })
+
+    it('returns false for invalid uint strings', () => {
+      ;[
+        '-1',
+        '',
+        ' ',
+        '  ',
+        'a',
+        'e',
+        '1a',
+        '1e',
+        '1e2',
+        '14 a',
+        'a b c',
+      ].forEach((str) => {
+        expect(validateTuningValue(limitation, str)).toEqual(false)
+      })
+    })
+  })
+
+  suite('bool', () => {
+    const limitation: ListTuningSpecResponseDataInnerLimitation = {
+      type: 'bool',
+      default: true,
+    }
+
+    it('returns true for valid boolean values', () => {
+      ;[true, false].forEach((boolean) => {
+        expect(validateTuningValue(limitation, boolean)).toEqual(true)
+      })
+    })
+
+    it('returns false for invalid boolean values', () => {
+      ;['true', 'false', '0', '1', '-1', '', ' ', 'a', '14 a'].forEach(
+        (invalidValue) => {
+          expect(validateTuningValue(limitation, invalidValue)).toEqual(false)
+        },
+      )
+    })
+  })
+})

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/validateTuningValue.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/validateTuningValue.ts
@@ -1,13 +1,13 @@
 import {
-  ListTuningResponseDataTuningsInnerLimitationDefault,
   ListTuningSpecResponseDataInnerLimitation,
   TuningLimitationType,
 } from '@cube-frontend/api'
 import { z } from 'zod'
+import { UpsertTuningsPayloadValue } from '../../upsertTuningsUtils'
 
 export const validateTuningValue = (
   limitation: ListTuningSpecResponseDataInnerLimitation | undefined,
-  value: ListTuningResponseDataTuningsInnerLimitationDefault | undefined,
+  value: UpsertTuningsPayloadValue,
 ): boolean => {
   if (!limitation) {
     return false
@@ -18,7 +18,7 @@ export const validateTuningValue = (
 
 type ValidateFn = (
   limitation: ListTuningSpecResponseDataInnerLimitation,
-  value: ListTuningResponseDataTuningsInnerLimitationDefault | undefined,
+  value: UpsertTuningsPayloadValue,
 ) => boolean
 
 const validateString: ValidateFn = (limitation, value) => {
@@ -40,11 +40,14 @@ const validateString: ValidateFn = (limitation, value) => {
   return schema.safeParse(value).success
 }
 
+const intRegex = /^-?\d+$/
+
 const validateInt: ValidateFn = (limitation, value) => {
+  const stringifiedValue = value?.toString() ?? ''
+  if (!intRegex.test(stringifiedValue)) return false
+
   const { min, max } = limitation
   let schema = z.number().int()
-
-  const parsedValue = Number(value?.toString())
 
   if (min !== undefined) {
     schema = schema.min(min)
@@ -54,10 +57,16 @@ const validateInt: ValidateFn = (limitation, value) => {
     schema = schema.max(max)
   }
 
+  const parsedValue = parseInt(stringifiedValue)
   return schema.safeParse(parsedValue).success
 }
 
-const validateFloat: ValidateFn = (limitation, value) => {
+const uIntRegex = /^\d+$/
+
+const validateUInt: ValidateFn = (limitation, value) => {
+  const stringifiedValue = value?.toString() ?? ''
+  if (!uIntRegex.test(stringifiedValue)) return false
+
   const { min, max } = limitation
   let schema = z.number()
 
@@ -69,7 +78,8 @@ const validateFloat: ValidateFn = (limitation, value) => {
     schema = schema.max(max)
   }
 
-  return schema.safeParse(value).success
+  const parsedValue = parseInt(stringifiedValue)
+  return schema.safeParse(parsedValue).success
 }
 
 const validateBool: ValidateFn = (_, value) => {
@@ -79,6 +89,6 @@ const validateBool: ValidateFn = (_, value) => {
 const validateFnMap: Record<TuningLimitationType, ValidateFn> = {
   str: validateString,
   int: validateInt,
-  uint: validateFloat,
+  uint: validateUInt,
   bool: validateBool,
 }

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/useCreateTuningsPayload.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/useCreateTuningsPayload.ts
@@ -1,6 +1,10 @@
 import { ListTuningSpecResponseDataInner } from '@cube-frontend/api'
 import { ChangeEvent, useMemo, useState } from 'react'
-import { HostWithRole, UpsertTuningsPayload } from '../upsertTuningsUtils'
+import {
+  HostWithRole,
+  limitationValueToPayloadValue,
+  UpsertTuningsPayload,
+} from '../upsertTuningsUtils'
 
 type UseCreateTuningsPayload = {
   payload: UpsertTuningsPayload
@@ -34,7 +38,7 @@ export const useCreateTuningsPayload = (
       setPayload((prev) => ({
         ...prev,
         selectedSpecName: spec.name,
-        value: spec.limitation.default,
+        value: limitationValueToPayloadValue(spec.limitation.default),
       }))
     }
   }

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/useEditTuningsPayload.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/useEditTuningsPayload.ts
@@ -1,9 +1,10 @@
 import { ListTuningSpecResponseDataInner, Node } from '@cube-frontend/api'
-import { EditTuningsDefaultData } from '@cube-frontend/web-app/stores/editTuningsStore'
+import { EditTuningsInitialData } from '@cube-frontend/web-app/stores/editTuningsStore'
 import { ChangeEvent, useEffect, useState } from 'react'
 import {
   computeValidHosts,
   HostWithRole,
+  limitationValueToPayloadValue,
   UpsertTuningsPayload,
 } from '../upsertTuningsUtils'
 
@@ -16,13 +17,16 @@ type UseEditTuningsPayload = {
 }
 
 const initializePayload = (
-  defaultData: EditTuningsDefaultData,
+  initialData: EditTuningsInitialData,
   selectedSpec: ListTuningSpecResponseDataInner | undefined,
 ): UpsertTuningsPayload => {
-  const { specName, value } = defaultData
+  const { specName, value } = initialData
   return {
     selectedSpecName: specName,
-    value: value === undefined ? selectedSpec?.limitation.default : value,
+    value:
+      value === undefined
+        ? limitationValueToPayloadValue(selectedSpec?.limitation.default)
+        : limitationValueToPayloadValue(value),
     selectedHosts: [],
   }
 }
@@ -30,7 +34,7 @@ const initializePayload = (
 export const useEditTuningsPayload = (
   specs: ListTuningSpecResponseDataInner[] | undefined,
   nodes: Node[] | undefined,
-  defaultData: EditTuningsDefaultData,
+  initialData: EditTuningsInitialData,
 ): UseEditTuningsPayload => {
   const [isInitializing, setIsInitializing] = useState(true)
   const [payload, setPayload] = useState<UpsertTuningsPayload | undefined>(
@@ -45,18 +49,18 @@ export const useEditTuningsPayload = (
       return
     }
     const selectedSpec = specs.find(
-      (spec) => spec.name === defaultData.specName,
+      (spec) => spec.name === initialData.specName,
     )
     setIsInitializing(false)
-    setPayload(initializePayload(defaultData, selectedSpec))
+    setPayload(initializePayload(initialData, selectedSpec))
     setSelectedSpec(selectedSpec)
-  }, [specs, defaultData])
+  }, [specs, initialData])
 
   useEffect(() => {
-    if (!nodes || !defaultData.hosts?.length) {
+    if (!nodes || !initialData.hosts?.length) {
       return
     }
-    const validHosts = computeValidHosts(nodes, defaultData.hosts)
+    const validHosts = computeValidHosts(nodes, initialData.hosts)
     setPayload((prev) => {
       if (!prev) {
         return prev
@@ -66,7 +70,7 @@ export const useEditTuningsPayload = (
         selectedHosts: validHosts,
       }
     })
-  }, [nodes, defaultData])
+  }, [nodes, initialData])
 
   const onValueChange = (e: ChangeEvent<HTMLInputElement> | boolean): void => {
     const value = typeof e === 'boolean' ? e : e.target.value

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/upsertTuningsUtils.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/upsertTuningsUtils.ts
@@ -1,7 +1,8 @@
 import {
-  ListTuningResponseDataTuningsInnerLimitationDefault,
+  ListTuningSpecResponseDataInnerLimitationDefault,
   ListTuningSpecResponseDataInnerRolesInnerHostsInner,
   Node,
+  TuningLimitationType,
 } from '@cube-frontend/api'
 import { CosTableRow } from '@cube-frontend/ui-library'
 
@@ -13,9 +14,11 @@ export enum UpsertTuningsStep {
 
 export type UpsertTuningsPayload = {
   selectedSpecName: string | undefined
-  value: ListTuningResponseDataTuningsInnerLimitationDefault | undefined
+  value: UpsertTuningsPayloadValue
   selectedHosts: HostWithRole[]
 }
+
+export type UpsertTuningsPayloadValue = string | boolean | undefined
 
 export type NonNullableUpsertTuningsPayload = {
   [key in keyof UpsertTuningsPayload]: Exclude<
@@ -57,4 +60,33 @@ export const computeValidHosts = (
   })
 
   return result
+}
+
+export const limitationValueToPayloadValue = (
+  defaultValue: ListTuningSpecResponseDataInnerLimitationDefault | undefined,
+): UpsertTuningsPayloadValue => {
+  if (defaultValue === undefined) return undefined
+  if (typeof defaultValue === 'boolean') return defaultValue
+  return defaultValue.toString()
+}
+
+export const payloadValueToLimitationValue = (
+  limitationType: TuningLimitationType,
+  payloadValue: Exclude<UpsertTuningsPayloadValue, undefined>,
+): ListTuningSpecResponseDataInnerLimitationDefault => {
+  if (limitationType === 'bool' && typeof payloadValue !== 'boolean') {
+    throw new Error('bool limitation type only accept boolean value')
+  }
+
+  if (typeof payloadValue === 'boolean') return payloadValue
+
+  if (limitationType === 'int' || limitationType === 'uint') {
+    const intValue = parseInt(payloadValue, 10)
+    if (isNaN(intValue) || !isFinite(intValue)) {
+      throw new Error(`${payloadValue} is not a valid numeric string`)
+    }
+    return intValue
+  }
+
+  return payloadValue
 }

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/_components/tableCells/ActionCell.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/_components/tableCells/ActionCell.tsx
@@ -8,7 +8,7 @@ import Edit from '@cube-frontend/ui-library/icons/monochrome/edit.svg?react'
 import { IconActionButton } from '@cube-frontend/web-app/components/IconActionButton/IconActionButton'
 import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
 import {
-  EditTuningsDefaultData,
+  EditTuningsInitialData,
   useEditTuningsStore,
 } from '@cube-frontend/web-app/stores/editTuningsStore'
 import { cva } from 'class-variance-authority'
@@ -16,7 +16,7 @@ import { useMemo } from 'react'
 import { Link } from 'react-router'
 import { TuningRow } from '../../tuningsUtils'
 
-const { setDefaultData } = useEditTuningsStore.getState()
+const { setInitialData } = useEditTuningsStore.getState()
 
 export type ActionCellProps = {
   row: TuningRow
@@ -34,7 +34,7 @@ const iconButton = cva('icon-md', {
   },
 })
 
-const computeEditDefaultData = (row: TuningRow): EditTuningsDefaultData => {
+const computeEditInitialData = (row: TuningRow): EditTuningsInitialData => {
   if (row.isModified) {
     return {
       specName: row.name,
@@ -74,7 +74,7 @@ export const ActionCell = (props: ActionCellProps) => {
     }
 
     const onEditClick = (): void => {
-      setDefaultData(computeEditDefaultData(row))
+      setInitialData(computeEditInitialData(row))
     }
 
     return (

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/edit/EditTuningsPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/edit/EditTuningsPage.tsx
@@ -14,7 +14,7 @@ import { Link, Navigate, useNavigate } from 'react-router'
 export const EditTuningsPage = () => {
   const navigate = useNavigate()
 
-  const defaultData = useEditTuningsStore((store) => store.defaultData)
+  const initialData = useEditTuningsStore((store) => store.initialData)
 
   const { dataCenter } = useContext(DataCenterContext)
 
@@ -46,13 +46,13 @@ export const EditTuningsPage = () => {
     }
   }
 
-  if (!defaultData) {
+  if (!initialData) {
     // This happens when users access the edit tunings page by directly
     // entering the URL in the browser.
     return <Navigate to={CosRoutesEnum.EVENTS_TUNINGS_PAGE} replace={true} />
   }
 
-  const title = defaultData.hosts?.length ? 'Edit Tunings' : 'Create Tunings'
+  const title = initialData.hosts?.length ? 'Edit Tunings' : 'Create Tunings'
 
   return (
     <div className="mx-2 my-1">
@@ -68,7 +68,7 @@ export const EditTuningsPage = () => {
         {title}
       </CosBackButton>
       <EditTunings
-        defaultData={defaultData}
+        initialData={initialData}
         errorMessage={errorState?.api?.msg || errorState?.native.message}
         onPublishClick={onPublishClick}
       />

--- a/packages/cube-frontend-web-app/src/stores/editTuningsStore.ts
+++ b/packages/cube-frontend-web-app/src/stores/editTuningsStore.ts
@@ -2,10 +2,10 @@ import { ListTuningResponseDataTuningsInnerLimitationDefault } from '@cube-front
 import { create } from 'zustand'
 
 type EditTuningsStoreState = {
-  defaultData: EditTuningsDefaultData | undefined
+  initialData: EditTuningsInitialData | undefined
 }
 
-export type EditTuningsDefaultData = {
+export type EditTuningsInitialData = {
   specName: string
 } & (
   | {
@@ -19,20 +19,20 @@ export type EditTuningsDefaultData = {
 )
 
 const createDefaultState = (): EditTuningsStoreState => ({
-  defaultData: undefined,
+  initialData: undefined,
 })
 
 type EditTuningsStoreActions = {
-  setDefaultData: (defaultData: EditTuningsDefaultData) => void
+  setInitialData: (initialData: EditTuningsInitialData) => void
 }
 
 export const useEditTuningsStore = create<
   EditTuningsStoreState & EditTuningsStoreActions
 >((set) => ({
   ...createDefaultState(),
-  setDefaultData: (defaultData: EditTuningsDefaultData) => {
+  setInitialData: (initialData: EditTuningsInitialData) => {
     set({
-      defaultData,
+      initialData,
     })
   },
 }))


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix upsert tunings value sent to the API does not match spec type bug.

#### Which issue(s) this PR fixes

Close https://github.com/bigstack-oss/cubecos/issues/100

- Create Tunings

   https://github.com/user-attachments/assets/649f7a7f-f604-4219-a263-1c9e7b56791d

- Edit Tunings

   https://github.com/user-attachments/assets/bbf24e70-3fbb-44a8-860b-e04be2522b57

---

Enhancement: Automatically brings back the filter state for the spec table for the "Select Key-Value" step on Create Tunings page.

- Befor: filter state is lost after step transition.

   https://github.com/user-attachments/assets/953fdc40-4b45-4671-b2e6-bbc92a6d326a

   https://github.com/user-attachments/assets/3a80e1b9-23c9-4938-b2a5-e19d8e122830

- After: filter state is preserved.

   https://github.com/user-attachments/assets/c2020691-2639-4c64-8b78-a549309637a7

   https://github.com/user-attachments/assets/c6487c7d-5c6c-449c-a736-f9f845d75371
