### PR TITLE
Fix/448 node support files and license page should return to page 1 after filters changed

### DIFF
--- a/packages/cube-frontend-web-app/src/hooks/useSearchParamsQuery.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useSearchParamsQuery.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react'
+import { useSearchParams } from 'react-router'
+
+export type BaseQuery = Record<string, unknown>
+
+export type UseSearchParamsQueryOptions<Query extends BaseQuery> = {
+  searchParamsToQuery: (searchParams: URLSearchParams) => Query
+  queryToSearchParams: (query: Query) => URLSearchParams
+}
+
+export const useSearchParamsQuery = <Query extends BaseQuery>(
+  options: UseSearchParamsQueryOptions<Query>,
+) => {
+  const { queryToSearchParams, searchParamsToQuery } = options
+  const [searchParams, setSearchParams] = useSearchParams()
+
+  const [query, setQuery] = useState<Query>(() =>
+    searchParamsToQuery(searchParams),
+  )
+
+  useEffect(() => {
+    const timeoutId = setTimeout(() => {
+      const nextSearchParams = queryToSearchParams(query)
+      setSearchParams(nextSearchParams, { replace: true })
+    }, 250)
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
+  }, [query, queryToSearchParams, setSearchParams])
+
+  return {
+    query,
+    setQuery,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/tuningsUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/tuningsUtils.ts
@@ -1,11 +1,8 @@
 import { ListTuningResponseDataTuningsInner } from '@cube-frontend/api'
-import {
-  CosTableRow,
-  DEFAULT_ITEMS_PER_PAGE,
-  ItemsPerPage,
-} from '@cube-frontend/ui-library'
+import { CosTableRow, DEFAULT_ITEMS_PER_PAGE } from '@cube-frontend/ui-library'
 import { z } from 'zod'
 import { ListTuningsQuery } from './useListTuningsQuery'
+import { paginationQuerySchema } from '@cube-frontend/web-app/utils/pagination'
 
 export type TuningRow = ListTuningResponseDataTuningsInner & CosTableRow
 
@@ -27,36 +24,26 @@ export const tuningToRow = (
 
 export const modifiedOptions = [true, false] as const
 
-const querySchema = z.object({
-  keyword: z.string().nullable(),
+export const tuningListQuerySchema = paginationQuerySchema.extend({
+  keyword: z
+    .string()
+    .nullable()
+    .transform((value) => {
+      return value ?? ''
+    }),
   modified: z
     .enum(['true', 'false'])
     .array()
     .nullable()
     .transform((array) => {
-      return array?.map((value) => value === 'true')
+      return array?.map((value) => value === 'true') ?? []
     }),
   hosts: z
     .string()
     .array()
     .nullable()
     .transform((array) => {
-      return array?.filter((value) => !!value)
-    }),
-  currentPage: z
-    .string()
-    .nullable()
-    .transform((value) => {
-      return value ? parseInt(value, 10) : 1
-    }),
-  itemsPerPage: z
-    .string()
-    .nullable()
-    .transform((value) => {
-      if (!value) {
-        return DEFAULT_ITEMS_PER_PAGE
-      }
-      return parseInt(value, 10) as ItemsPerPage
+      return array?.filter((value) => !!value) ?? []
     }),
 })
 
@@ -77,7 +64,7 @@ export const searchParamsToQuery = (
   const currentPage = searchParams.get(ParamKeyEnum.CurrentPage)
   const itemsPerPage = searchParams.get(ParamKeyEnum.ItemsPerPage)
 
-  const parsedQuery = querySchema.safeParse({
+  const parsedQuery = tuningListQuerySchema.safeParse({
     keyword,
     modified,
     hosts,
@@ -87,7 +74,7 @@ export const searchParamsToQuery = (
 
   return {
     keyword: parsedQuery?.keyword ?? '',
-    modified: (parsedQuery?.modified ?? []) as boolean[],
+    modified: parsedQuery?.modified ?? [],
     hosts: parsedQuery?.hosts ?? [],
     currentPage: parsedQuery?.currentPage ?? 1,
     itemsPerPage: parsedQuery?.itemsPerPage ?? DEFAULT_ITEMS_PER_PAGE,

--- a/packages/cube-frontend-web-app/src/pages/events/tunings/useListTuningsQuery.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/tunings/useListTuningsQuery.ts
@@ -1,11 +1,13 @@
+import { ChangeEvent } from 'react'
+import { z } from 'zod'
 import { Node } from '@cube-frontend/api'
 import { ItemsPerPage } from '@cube-frontend/ui-library'
-import { ChangeEvent, useEffect, useState } from 'react'
-import { useSearchParams } from 'react-router'
+import { useSearchParamsQuery } from '@cube-frontend/web-app/hooks/useSearchParamsQuery'
 import {
   modifiedOptions,
   queryToSearchParams,
   searchParamsToQuery,
+  tuningListQuerySchema,
 } from './tuningsUtils'
 
 type UseListTuningsQuery = {
@@ -20,31 +22,13 @@ type UseListTuningsQuery = {
   onItemsPerPageChange: (itemsPerPage: ItemsPerPage) => void
 }
 
-export type ListTuningsQuery = {
-  keyword: string
-  modified: boolean[]
-  hosts: string[]
-  currentPage: number
-  itemsPerPage: ItemsPerPage
-}
+export type ListTuningsQuery = z.output<typeof tuningListQuerySchema>
 
 export const useListTuningsQuery = (): UseListTuningsQuery => {
-  const [searchParams, setSearchParams] = useSearchParams()
-
-  const [query, setQuery] = useState<ListTuningsQuery>(() =>
-    searchParamsToQuery(searchParams),
-  )
-
-  useEffect(() => {
-    const timeoutId = setTimeout(() => {
-      const nextSearchParams = queryToSearchParams(query)
-      setSearchParams(nextSearchParams, { replace: true })
-    }, 250)
-
-    return () => {
-      clearTimeout(timeoutId)
-    }
-  }, [query, setSearchParams])
+  const { query, setQuery } = useSearchParamsQuery({
+    queryToSearchParams,
+    searchParamsToQuery,
+  })
 
   const onKeywordChange = (e: ChangeEvent<HTMLInputElement>): void => {
     const { value } = e.target

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/MaintenanceLicensePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/MaintenanceLicensePage.tsx
@@ -1,15 +1,9 @@
-import { useContext, useEffect, useState } from 'react'
-import {
-  GetLicensesProductsEnum,
-  ListLicenseCurrentStatus,
-  GetLicensesTypesEnum,
-  LicensesApiGetLicensesRequest,
-} from '@cube-frontend/api'
+import { useContext, useEffect } from 'react'
+import { LicensesApiGetLicensesRequest } from '@cube-frontend/api'
 import {
   CosGeneralPanel,
   CosPagination,
   CosStroke,
-  DEFAULT_ITEMS_PER_PAGE,
 } from '@cube-frontend/ui-library'
 import { licenseApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
@@ -19,22 +13,29 @@ import { useDebounce } from '@cube-frontend/web-app/hooks/useDebounce'
 import { LicenseRow, LicenseTable } from './_components/LicenseTable'
 import { useTopLicenseNaggingStore } from '@cube-frontend/web-app/stores/topLicenseNaggingStore'
 import { LicenseActions } from './_components/LicenseActions/LicenseActions'
+import { useLicenseListQuery } from './_components/useLicenseListQuery'
 
 export const MaintenanceLicensePage = () => {
   const { dataCenter, fetchDataCenters } = useContext(DataCenterContext)
 
-  const [searchKeyword, setSearchKeyword] = useState<string>('')
-  const [selectedProducts, setSelectedProducts] = useState<
-    GetLicensesProductsEnum[]
-  >([])
-  const [selectedLicenseTypes, setSelectedLicenseTypes] = useState<
-    GetLicensesTypesEnum[]
-  >([])
-  const [selectedLicenseStatuses, setSelectedLicenseStatuses] = useState<
-    ListLicenseCurrentStatus[]
-  >([])
-  const [pageNum, setPageNum] = useState(1)
-  const [pageSize, setPageSize] = useState(DEFAULT_ITEMS_PER_PAGE)
+  const {
+    query,
+    onKeywordChange,
+    onProductsChange,
+    onStatusesChange,
+    onTypesChange,
+    onPageChange,
+    onItemsPerPageChange,
+  } = useLicenseListQuery()
+
+  const [debouncedSearchKeyword, setDebounceSearchKeyword] = useDebounce(
+    query.keyword,
+    300,
+  )
+  const handleSearchKeywordClear = () => {
+    onKeywordChange('')
+    setDebounceSearchKeyword('')
+  }
 
   const {
     data: licenseData,
@@ -43,12 +44,12 @@ export const MaintenanceLicensePage = () => {
   } = useCosGetRequest(licenseApi.getLicenses, () => {
     return {
       dataCenter: dataCenter!.name,
-      pageNum,
-      pageSize,
+      pageNum: query.currentPage,
+      pageSize: query.itemsPerPage,
       keyword: debouncedSearchKeyword,
-      products: selectedProducts,
-      types: selectedLicenseTypes,
-      statuses: selectedLicenseStatuses,
+      products: query.products,
+      types: query.types,
+      statuses: query.statuses,
     } satisfies LicensesApiGetLicensesRequest
   })
 
@@ -57,21 +58,11 @@ export const MaintenanceLicensePage = () => {
     fetchDataCenters!()
   }
 
-  const [debouncedSearchKeyword, setDebounceSearchKeyword] = useDebounce(
-    searchKeyword,
-    300,
-  )
-
   const rows: LicenseRow[] =
     licenseData?.licenses?.map((license) => ({
       ...license,
       id: license.serial,
     })) || []
-
-  const handleSearchKeywordClear = () => {
-    setSearchKeyword('')
-    setDebounceSearchKeyword('')
-  }
 
   const { restoreDefault: restoreTopLicenseNaggingStore } =
     useTopLicenseNaggingStore()
@@ -90,29 +81,29 @@ export const MaintenanceLicensePage = () => {
         <div className="flex flex-col gap-y-2">
           <h5 className="primary-h5 text-functional-text">License</h5>
           <LicenseFilters
-            searchKeyword={searchKeyword}
-            handleSearchKeywordChange={setSearchKeyword}
+            searchKeyword={query.keyword}
+            handleSearchKeywordChange={onKeywordChange}
             handleSearchKeywordClear={handleSearchKeywordClear}
-            selectedProducts={selectedProducts}
-            handleProductsSelect={setSelectedProducts}
-            selectedLicenseStatuses={selectedLicenseStatuses}
-            handleLicenseStatusesSelect={setSelectedLicenseStatuses}
-            selectedLicenseTypes={selectedLicenseTypes}
-            handleLicenseTypesSelect={setSelectedLicenseTypes}
+            selectedProducts={query.products}
+            handleProductsSelect={onProductsChange}
+            selectedLicenseStatuses={query.statuses}
+            handleLicenseStatusesSelect={onStatusesChange}
+            selectedLicenseTypes={query.types}
+            handleLicenseTypesSelect={onTypesChange}
           />
           <LicenseTable
             rows={rows}
             isLoading={isLoading}
-            skeletonRowCount={pageSize}
+            skeletonRowCount={query.itemsPerPage}
           />
         </div>
         <CosPagination
           isLoading={isLoading}
           totalItems={licenseData?.page?.totalItemCount ?? 0}
-          currentPage={pageNum}
-          itemsPerPage={pageSize}
-          onPageChange={setPageNum}
-          onItemsPerPageChange={setPageSize}
+          currentPage={query.currentPage}
+          itemsPerPage={query.itemsPerPage}
+          onPageChange={onPageChange}
+          onItemsPerPageChange={onItemsPerPageChange}
         />
       </div>
     </CosGeneralPanel>

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/useLicenseListQuery.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/useLicenseListQuery.ts
@@ -1,0 +1,73 @@
+import { ItemsPerPage } from '@cube-frontend/ui-library'
+import { useSearchParamsQuery } from '@cube-frontend/web-app/hooks/useSearchParamsQuery'
+import {
+  GetLicensesProductsEnum,
+  GetLicensesTypesEnum,
+  ListLicenseCurrentStatus,
+} from '@cube-frontend/api'
+import { queryToSearchParams, searchParamsToQuery } from './utils'
+
+export const useLicenseListQuery = () => {
+  const { query, setQuery } = useSearchParamsQuery({
+    queryToSearchParams,
+    searchParamsToQuery,
+  })
+
+  const onProductsChange = (products: GetLicensesProductsEnum[]) => {
+    setQuery((prev) => ({
+      ...prev,
+      products,
+      currentPage: 1,
+    }))
+  }
+
+  const onStatusesChange = (statuses: ListLicenseCurrentStatus[]) => {
+    setQuery((prev) => ({
+      ...prev,
+      statuses,
+      currentPage: 1,
+    }))
+  }
+
+  const onTypesChange = (types: GetLicensesTypesEnum[]) => {
+    setQuery((prev) => ({
+      ...prev,
+      types,
+      currentPage: 1,
+    }))
+  }
+
+  const onKeywordChange = (value: string): void => {
+    setQuery((prev) => ({
+      ...prev,
+      keyword: value,
+      currentPage: 1,
+    }))
+  }
+
+  const onPageChange = (page: number): void => {
+    setQuery((prev) => ({
+      ...prev,
+      currentPage: page,
+    }))
+  }
+
+  const onItemsPerPageChange = (itemsPerPage: ItemsPerPage): void => {
+    setQuery((prev) => ({
+      ...prev,
+      itemsPerPage,
+      currentPage: 1,
+    }))
+  }
+
+  return {
+    query,
+    setQuery,
+    onKeywordChange,
+    onProductsChange,
+    onStatusesChange,
+    onTypesChange,
+    onPageChange,
+    onItemsPerPageChange,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/utils.ts
@@ -1,10 +1,16 @@
+import { z } from 'zod'
+import pluralize from 'pluralize'
 import {
   GetDataCentersResponseDataInnerAdditionalNodeLicenseStatus,
   GetLicenseAttachmentsResponseDataInner,
+  GetLicensesProductsEnum,
   GetLicensesResponseDataLicensesInnerExpiry,
+  GetLicensesTypesEnum,
+  ListLicenseCurrentStatus,
 } from '@cube-frontend/api'
 import { toPluralizeDisplay } from '@cube-frontend/utils'
-import pluralize from 'pluralize'
+import { DEFAULT_ITEMS_PER_PAGE } from '@cube-frontend/ui-library'
+import { paginationQuerySchema } from '@cube-frontend/web-app/utils/pagination'
 import { BatchLicenseAttachmentTableRow } from './LicenseActions/HardwareSerialNumberModal/LicenseAttachmentTable'
 
 export type InvalidLicenseMessageKey = Exclude<
@@ -98,4 +104,114 @@ export const mapToTableRows = (
   licenseAttachments: GetLicenseAttachmentsResponseDataInner[] | undefined,
 ): BatchLicenseAttachmentTableRow[] => {
   return licenseAttachments?.map(mapToTableRow) ?? []
+}
+
+enum LicenseParamKeyEnum {
+  Keyword = 'keyword',
+  Products = 'products',
+  Statuses = 'statuses',
+  Types = 'types',
+  CurrentPage = 'page',
+  ItemsPerPage = 'pageSize',
+}
+
+const licenseListQuerySchema = paginationQuerySchema.extend({
+  keyword: z
+    .string()
+    .nullable()
+    .transform((value) => {
+      return value ?? ''
+    }),
+  products: z
+    .enum(Object.values(GetLicensesProductsEnum) as [string, ...string[]])
+    .array()
+    .nullable()
+    .transform((array) => {
+      return (array ?? []) as GetLicensesProductsEnum[]
+    }),
+  statuses: z
+    .enum(Object.values(ListLicenseCurrentStatus) as [string, ...string[]])
+    .array()
+    .nullable()
+    .transform((array) => {
+      return (array ?? []) as ListLicenseCurrentStatus[]
+    }),
+  types: z
+    .enum(Object.values(GetLicensesTypesEnum) as [string, ...string[]])
+    .array()
+    .nullable()
+    .transform((array) => {
+      return (array ?? []) as GetLicensesTypesEnum[]
+    }),
+})
+
+export type LicenseListQuery = z.output<typeof licenseListQuerySchema>
+
+export const queryToSearchParams = (
+  query: LicenseListQuery,
+): URLSearchParams => {
+  const { keyword, products, statuses, types, currentPage, itemsPerPage } =
+    query
+  const nextSearchParams = new URLSearchParams()
+
+  if (keyword) {
+    nextSearchParams.set(LicenseParamKeyEnum.Keyword, keyword)
+  }
+
+  products.forEach((product) => {
+    nextSearchParams.append(LicenseParamKeyEnum.Products, product)
+  })
+
+  statuses.forEach((status) => {
+    nextSearchParams.append(LicenseParamKeyEnum.Statuses, status)
+  })
+
+  types.forEach((type) => {
+    nextSearchParams.append(LicenseParamKeyEnum.Types, type)
+  })
+
+  if (currentPage) {
+    nextSearchParams.set(
+      LicenseParamKeyEnum.CurrentPage,
+      currentPage.toString(),
+    )
+  }
+
+  if (itemsPerPage) {
+    nextSearchParams.set(
+      LicenseParamKeyEnum.ItemsPerPage,
+      itemsPerPage.toString(),
+    )
+  }
+
+  return nextSearchParams
+}
+
+export const searchParamsToQuery = (
+  searchParams: URLSearchParams,
+): LicenseListQuery => {
+  const keyword = searchParams.get(LicenseParamKeyEnum.Keyword)
+  const products = searchParams.getAll(LicenseParamKeyEnum.Products)
+  const statuses = searchParams.getAll(LicenseParamKeyEnum.Statuses)
+  const types = searchParams.getAll(LicenseParamKeyEnum.Types)
+  const currentPage = searchParams.get(LicenseParamKeyEnum.CurrentPage)
+  const itemsPerPage = searchParams.get(LicenseParamKeyEnum.ItemsPerPage)
+
+  const parsedQuery = licenseListQuerySchema.safeParse({
+    keyword,
+    products,
+    statuses,
+    types,
+    currentPage,
+    itemsPerPage,
+  }).data
+
+  return {
+    keyword: parsedQuery?.keyword ?? '',
+    products: parsedQuery?.products ?? [],
+    statuses: parsedQuery?.statuses ?? [],
+    types: (parsedQuery?.types as GetLicensesTypesEnum[]) ?? [],
+    currentPage: parsedQuery?.currentPage ?? 1,
+    itemsPerPage: parsedQuery?.itemsPerPage ?? DEFAULT_ITEMS_PER_PAGE,
+  }
 }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/MaintenanceSupportFilesPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/MaintenanceSupportFilesPage.tsx
@@ -1,9 +1,7 @@
 import { useContext, useState } from 'react'
 import { Link } from 'react-router'
-import { Dayjs } from 'dayjs'
 import { noop } from 'lodash'
 import {
-  GetNodesRolesEnum,
   SupportFilesApiGetSupportFilesRequest,
   SupportFileSet,
 } from '@cube-frontend/api'
@@ -13,7 +11,6 @@ import {
   CosPagination,
   CosStroke,
   CosTableRow,
-  DEFAULT_ITEMS_PER_PAGE,
 } from '@cube-frontend/ui-library'
 import ChevronRight from '@cube-frontend/ui-library/icons/monochrome/chevron_right.svg?react'
 import { supportFilesApi } from '@cube-frontend/web-app/api/cosApi'
@@ -24,44 +21,47 @@ import { SupportFilesFilters } from './_components/SupportFilesFilters'
 import { DownloadSupportFilesModal } from './_components/DownloadSupportFilesModal'
 import { SupportFilesTable } from './_components/SupportFilesTable'
 import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
+import { useSupportFileListQuery } from './_components/useSupportFileListQuery'
 
 export type SupportFileRow = SupportFileSet & CosTableRow
 
 export const MaintenanceSupportFilesPage = () => {
   const { dataCenter } = useContext(DataCenterContext)
 
-  const [searchKeyword, setSearchKeyword] = useState<string>('')
-  const [selectedRoles, setSelectedRoles] = useState<GetNodesRolesEnum[]>([])
-  const [startDate, setStartDate] = useState<Dayjs>()
-  const [endDate, setEndDate] = useState<Dayjs>()
-  const [pageNum, setPageNum] = useState(1)
-  const [pageSize, setPageSize] = useState(DEFAULT_ITEMS_PER_PAGE)
+  const {
+    query,
+    onKeywordChange,
+    onRolesChange,
+    onStartDateChange,
+    onEndDateChange,
+    onPageChange,
+    onItemsPerPageChange,
+  } = useSupportFileListQuery()
 
   const [debouncedSearchKeyword, setDebounceSearchKeyword] = useDebounce(
-    searchKeyword,
+    query.keyword,
     300,
   )
+
+  const onSearchKeywordClear = () => {
+    onKeywordChange('')
+    setDebounceSearchKeyword('')
+  }
 
   const { data: supportFilesData, isLoading } = useCosGetRequest(
     supportFilesApi.getSupportFiles,
     () => {
       return {
         dataCenter: dataCenter!.name,
-        pageNum,
-        pageSize,
+        pageNum: query.currentPage,
+        pageSize: query.itemsPerPage,
         keyword: debouncedSearchKeyword,
-        start: startDate?.format(),
-        stop: endDate?.format(),
-        roles: selectedRoles,
+        roles: query.roles,
+        start: query.startDate?.format(),
+        stop: query.endDate?.format(),
       } satisfies SupportFilesApiGetSupportFilesRequest
     },
   )
-
-  const handleSearchKeywordClear = () => {
-    setSearchKeyword('')
-    setDebounceSearchKeyword('')
-  }
-
   const rows: SupportFileRow[] =
     supportFilesData?.supportFileSet.map((supportFileSet) => ({
       ...supportFileSet,
@@ -92,30 +92,30 @@ export const MaintenanceSupportFilesPage = () => {
           <div className="flex flex-col gap-y-6">
             <div className="flex flex-col gap-y-2">
               <SupportFilesFilters
-                searchKeyword={searchKeyword}
-                handleSearchKeywordChange={setSearchKeyword}
-                handleSearchKeywordClear={handleSearchKeywordClear}
-                selectedRoles={selectedRoles}
-                handleRolesSelect={setSelectedRoles}
-                startDate={startDate}
-                endDate={endDate}
-                handleStartDateChange={setStartDate}
-                handleEndDateChange={setEndDate}
+                keyword={query.keyword}
+                handleSearchKeywordChange={onKeywordChange}
+                handleSearchKeywordClear={onSearchKeywordClear}
+                roles={query.roles}
+                handleRolesSelect={onRolesChange}
+                startDate={query.startDate}
+                endDate={query.endDate}
+                handleStartDateChange={onStartDateChange}
+                handleEndDateChange={onEndDateChange}
               />
               <SupportFilesTable
                 rows={rows}
                 isLoading={isLoading}
-                skeletonRowCount={pageSize}
+                skeletonRowCount={query.itemsPerPage}
                 onDownloadClick={setDownloadTarget}
               />
             </div>
             <CosPagination
               isLoading={isLoading}
               totalItems={supportFilesData?.page.totalItemCount ?? 0}
-              currentPage={pageNum}
-              itemsPerPage={pageSize}
-              onPageChange={setPageNum}
-              onItemsPerPageChange={setPageSize}
+              currentPage={query.currentPage}
+              itemsPerPage={query.itemsPerPage}
+              onPageChange={onPageChange}
+              onItemsPerPageChange={onItemsPerPageChange}
             />
           </div>
         </div>

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/SupportFilesFilters.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/SupportFilesFilters.tsx
@@ -10,10 +10,10 @@ import { RoleFilter } from '@cube-frontend/web-app/components/RoleFilter'
 import { GetNodesRolesEnum } from '@cube-frontend/api'
 
 export type SupportFilesFiltersProps = {
-  searchKeyword: string
+  keyword: string
   handleSearchKeywordChange: (value: string) => void
   handleSearchKeywordClear: () => void
-  selectedRoles: GetNodesRolesEnum[]
+  roles: GetNodesRolesEnum[]
   handleRolesSelect: (roles: GetNodesRolesEnum[]) => void
   startDate?: Dayjs
   endDate?: Dayjs
@@ -23,10 +23,10 @@ export type SupportFilesFiltersProps = {
 
 export const SupportFilesFilters = (props: SupportFilesFiltersProps) => {
   const {
-    searchKeyword,
+    keyword,
     handleSearchKeywordChange,
     handleSearchKeywordClear,
-    selectedRoles,
+    roles,
     handleRolesSelect,
     startDate,
     endDate,
@@ -69,21 +69,21 @@ export const SupportFilesFilters = (props: SupportFilesFiltersProps) => {
   }
 
   const showClearAllFilter =
-    !!searchKeyword || selectedRoles.length > 0 || !!startDate || !!endDate
+    !!keyword || roles.length > 0 || !!startDate || !!endDate
 
   return (
     <div className="flex items-center gap-x-3">
       <div className="flex items-center gap-x-2">
         <CosSearchBarFilter
           className="w-[320px]"
-          value={searchKeyword}
+          value={keyword}
           onChange={(e) => handleSearchKeywordChange(e.target.value)}
           onInputClear={handleSearchKeywordClear}
           placeholder="Search"
           showDropdown={false}
         />
         <RoleFilter
-          selectedRoles={selectedRoles}
+          selectedRoles={roles}
           handleRolesSelect={handleRolesSelect}
         />
         <CosDatePicker

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/useSupportFileListQuery.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/useSupportFileListQuery.ts
@@ -1,0 +1,69 @@
+import { Dayjs } from 'dayjs'
+import { GetNodesRolesEnum } from '@cube-frontend/api'
+import { ItemsPerPage } from '@cube-frontend/ui-library'
+import { useSearchParamsQuery } from '@cube-frontend/web-app/hooks/useSearchParamsQuery'
+import { queryToSearchParams, searchParamsToQuery } from './utils'
+
+export const useSupportFileListQuery = () => {
+  const { query, setQuery } = useSearchParamsQuery({
+    queryToSearchParams,
+    searchParamsToQuery,
+  })
+
+  const onRolesChange = (roles: GetNodesRolesEnum[]) => {
+    setQuery((prev) => ({
+      ...prev,
+      roles,
+      currentPage: 1,
+    }))
+  }
+
+  const onKeywordChange = (value: string): void => {
+    setQuery((prev) => ({
+      ...prev,
+      keyword: value,
+      currentPage: 1,
+    }))
+  }
+
+  const onStartDateChange = (date: Dayjs | undefined): void => {
+    setQuery((prev) => ({
+      ...prev,
+      startDate: date,
+      currentPage: 1,
+    }))
+  }
+  const onEndDateChange = (date: Dayjs | undefined): void => {
+    setQuery((prev) => ({
+      ...prev,
+      endDate: date,
+      currentPage: 1,
+    }))
+  }
+
+  const onPageChange = (page: number): void => {
+    setQuery((prev) => ({
+      ...prev,
+      currentPage: page,
+    }))
+  }
+
+  const onItemsPerPageChange = (itemsPerPage: ItemsPerPage): void => {
+    setQuery((prev) => ({
+      ...prev,
+      itemsPerPage,
+      currentPage: 1,
+    }))
+  }
+
+  return {
+    query,
+    setQuery,
+    onStartDateChange,
+    onEndDateChange,
+    onKeywordChange,
+    onRolesChange,
+    onPageChange,
+    onItemsPerPageChange,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/utils.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod'
+import { GetNodesRolesEnum } from '@cube-frontend/api'
+import { DEFAULT_ITEMS_PER_PAGE } from '@cube-frontend/ui-library'
+import dayjs from 'dayjs'
+import { paginationQuerySchema } from '@cube-frontend/web-app/utils/pagination'
+
+enum SupportFileParamKeyEnum {
+  Keyword = 'keyword',
+  Roles = 'roles',
+  StartDate = 'startDate',
+  EndDate = 'endDate',
+  CurrentPage = 'page',
+  ItemsPerPage = 'pageSize',
+}
+
+const transformDate = (value: string | null) => {
+  if (!value) {
+    return undefined
+  }
+  const date = dayjs(value)
+  if (!date.isValid()) {
+    return undefined
+  }
+  return date
+}
+
+const supportFileListQuerySchema = paginationQuerySchema.extend({
+  keyword: z
+    .string()
+    .nullable()
+    .transform((value) => {
+      return value ?? ''
+    }),
+  roles: z
+    .enum(Object.values(GetNodesRolesEnum) as [string, ...string[]])
+    .array()
+    .nullable()
+    .transform((array) => {
+      return (array ?? []) as GetNodesRolesEnum[]
+    }),
+  startDate: z.string().nullable().transform(transformDate),
+  endDate: z.string().nullable().transform(transformDate),
+})
+
+export type SupportFileListQuery = z.output<typeof supportFileListQuerySchema>
+
+export const queryToSearchParams = (
+  query: SupportFileListQuery,
+): URLSearchParams => {
+  const { keyword, roles, startDate, endDate, currentPage, itemsPerPage } =
+    query
+  const nextSearchParams = new URLSearchParams()
+
+  if (keyword) {
+    nextSearchParams.set(SupportFileParamKeyEnum.Keyword, keyword)
+  }
+
+  roles.forEach((role) => {
+    nextSearchParams.append(SupportFileParamKeyEnum.Roles, role)
+  })
+
+  if (startDate) {
+    nextSearchParams.set(SupportFileParamKeyEnum.StartDate, startDate.format())
+  }
+
+  if (endDate) {
+    nextSearchParams.set(SupportFileParamKeyEnum.EndDate, endDate.format())
+  }
+
+  if (currentPage) {
+    nextSearchParams.set(
+      SupportFileParamKeyEnum.CurrentPage,
+      currentPage.toString(),
+    )
+  }
+
+  if (itemsPerPage) {
+    nextSearchParams.set(
+      SupportFileParamKeyEnum.ItemsPerPage,
+      itemsPerPage.toString(),
+    )
+  }
+
+  return nextSearchParams
+}
+
+export const searchParamsToQuery = (
+  searchParams: URLSearchParams,
+): SupportFileListQuery => {
+  const keyword = searchParams.get(SupportFileParamKeyEnum.Keyword)
+  const roles = searchParams.getAll(SupportFileParamKeyEnum.Roles)
+  const startDate = searchParams.get(SupportFileParamKeyEnum.StartDate)
+  const endDate = searchParams.get(SupportFileParamKeyEnum.EndDate)
+  const currentPage = searchParams.get(SupportFileParamKeyEnum.CurrentPage)
+  const itemsPerPage = searchParams.get(SupportFileParamKeyEnum.ItemsPerPage)
+
+  const parsedQuery = supportFileListQuerySchema.safeParse({
+    keyword,
+    roles,
+    startDate,
+    endDate,
+    currentPage,
+    itemsPerPage,
+  }).data
+
+  return {
+    keyword: parsedQuery?.keyword ?? '',
+    roles: parsedQuery?.roles ?? [],
+    startDate: parsedQuery?.startDate,
+    endDate: parsedQuery?.endDate,
+    currentPage: parsedQuery?.currentPage ?? 1,
+    itemsPerPage: parsedQuery?.itemsPerPage ?? DEFAULT_ITEMS_PER_PAGE,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/node/NodeListPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/NodeListPage.tsx
@@ -1,14 +1,10 @@
-import { useContext, useMemo, useState } from 'react'
-import {
-  GetNodesRolesEnum,
-  Node,
-  NodesApiGetNodesRequest,
-} from '@cube-frontend/api'
+import { useContext, useEffect, useMemo, useState } from 'react'
+import { uniqueId } from 'lodash'
+import { Node, NodesApiGetNodesRequest } from '@cube-frontend/api'
 import {
   CosButton,
   CosGeneralPanel,
   CosPagination,
-  DEFAULT_ITEMS_PER_PAGE,
 } from '@cube-frontend/ui-library'
 import { nodesApi } from '@cube-frontend/web-app/api/cosApi'
 import { useDebounce } from '@cube-frontend/web-app/hooks/useDebounce'
@@ -18,30 +14,35 @@ import { NodeTable } from './_components/NodeTable'
 import { NodeFilters } from './_components/NodeFilters'
 import { CreateSupportFilesModal } from './_components/CreateSupportFilesModal'
 import { useCreateSupportFilesModal } from './_components/useCreateSupportFilesModal'
-import { uniqueId } from 'lodash'
+import { useNodeListQuery } from './_components/useNodeListQuery'
 
 export const NodeListPage = () => {
   const { dataCenter } = useContext(DataCenterContext)
 
-  const [searchKeyword, setSearchKeyword] = useState('')
-  const [selectedRoles, setSelectedRoles] = useState<GetNodesRolesEnum[]>([])
-  const [pageNum, setPageNum] = useState(1)
-  const [pageSize, setPageSize] = useState(DEFAULT_ITEMS_PER_PAGE)
+  const {
+    query,
+    onKeywordChange,
+    onRolesChange,
+    onPageChange,
+    onItemsPerPageChange,
+  } = useNodeListQuery()
 
-  const [debouncedSearchKeyword, setDebounceSearchKeyword] = useDebounce(
-    searchKeyword,
-    300,
-  )
+  const [debouncedKeyword, setDebounceKeyword] = useDebounce(query.keyword, 300)
+
+  const onSearchKeywordClear = () => {
+    onKeywordChange('')
+    setDebounceKeyword('')
+  }
 
   const { data: nodesData, isLoading } = useCosGetRequest(
     nodesApi.getNodes,
     () => {
       return {
         dataCenter: dataCenter!.name,
-        pageNum,
-        pageSize,
-        roles: selectedRoles,
-        keyword: debouncedSearchKeyword,
+        keyword: debouncedKeyword,
+        roles: query.roles,
+        pageNum: query.currentPage,
+        pageSize: query.itemsPerPage,
       } satisfies NodesApiGetNodesRequest
     },
   )
@@ -54,11 +55,6 @@ export const NodeListPage = () => {
       id: node.id || uniqueId('node'),
     }))
   }, [nodesData?.nodes])
-
-  const handleSearchKeywordClear = () => {
-    setSearchKeyword('')
-    setDebounceSearchKeyword('')
-  }
 
   const [selectedNodeIds, setSelectedNodeIds] = useState<string[]>([])
 
@@ -77,6 +73,10 @@ export const NodeListPage = () => {
     })
   }
 
+  useEffect(() => {
+    setSelectedNodeIds([])
+  }, [nodesData])
+
   const {
     isCreateSupportFilesModalOpen,
     comments,
@@ -91,11 +91,11 @@ export const NodeListPage = () => {
         <div className="flex flex-col gap-y-3">
           <div className="flex items-center justify-between">
             <NodeFilters
-              searchKeyword={searchKeyword}
-              handleSearchKeywordChange={setSearchKeyword}
-              handleSearchKeywordClear={handleSearchKeywordClear}
-              selectedRoles={selectedRoles}
-              handleRolesSelect={setSelectedRoles}
+              keyword={query.keyword}
+              handleKeywordChange={onKeywordChange}
+              handleKeywordClear={onSearchKeywordClear}
+              roles={query.roles}
+              handleRolesSelect={onRolesChange}
             />
             <CosButton
               onClick={openCreateSupportFilesModal}
@@ -107,7 +107,7 @@ export const NodeListPage = () => {
           <NodeTable
             rows={rows}
             isLoading={isLoading}
-            skeletonRowCount={pageSize}
+            skeletonRowCount={query.itemsPerPage}
             selectedRowIds={selectedNodeIds}
             showHeaderCheckbox={false}
             onCheckChange={handleRowCheckChange}
@@ -115,10 +115,10 @@ export const NodeListPage = () => {
           <CosPagination
             isLoading={isLoading}
             totalItems={nodesData?.page.totalItemCount ?? 0}
-            currentPage={pageNum}
-            itemsPerPage={pageSize}
-            onPageChange={setPageNum}
-            onItemsPerPageChange={setPageSize}
+            currentPage={query.currentPage}
+            itemsPerPage={query.itemsPerPage}
+            onPageChange={onPageChange}
+            onItemsPerPageChange={onItemsPerPageChange}
           />
         </div>
       </CosGeneralPanel>

--- a/packages/cube-frontend-web-app/src/pages/node/_components/NodeFilters.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/NodeFilters.tsx
@@ -4,42 +4,42 @@ import { RoleFilter } from '@cube-frontend/web-app/components/RoleFilter'
 import { GetNodesRolesEnum } from '@cube-frontend/api'
 
 export type NodeFiltersProps = {
-  searchKeyword: string
-  handleSearchKeywordChange: (value: string) => void
-  handleSearchKeywordClear: () => void
-  selectedRoles: GetNodesRolesEnum[]
+  keyword: string
+  handleKeywordChange: (value: string) => void
+  handleKeywordClear: () => void
+  roles: GetNodesRolesEnum[]
   handleRolesSelect: (roles: GetNodesRolesEnum[]) => void
 }
 
 export const NodeFilters = (props: NodeFiltersProps) => {
   const {
-    searchKeyword,
-    handleSearchKeywordChange,
-    handleSearchKeywordClear,
-    selectedRoles,
+    keyword,
+    handleKeywordChange,
+    handleKeywordClear,
+    roles,
     handleRolesSelect,
   } = props
 
   const handleClearAllFilter = () => {
     handleRolesSelect([])
-    handleSearchKeywordClear()
+    handleKeywordClear()
   }
 
-  const showClearAllFilter = !!searchKeyword || selectedRoles.length > 0
+  const showClearAllFilter = !!keyword || roles.length > 0
 
   return (
     <div className="flex items-center gap-x-3">
       <div className="flex items-center gap-x-2">
         <CosSearchBarFilter
           className="w-[320px]"
-          value={searchKeyword}
-          onChange={(e) => handleSearchKeywordChange(e.target.value)}
-          onInputClear={handleSearchKeywordClear}
+          value={keyword}
+          onChange={(e) => handleKeywordChange(e.target.value)}
+          onInputClear={handleKeywordClear}
           placeholder="Search"
           showDropdown={false}
         />
         <RoleFilter
-          selectedRoles={selectedRoles}
+          selectedRoles={roles}
           handleRolesSelect={handleRolesSelect}
         />
       </div>

--- a/packages/cube-frontend-web-app/src/pages/node/_components/useNodeListQuery.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/useNodeListQuery.ts
@@ -1,0 +1,51 @@
+import { GetNodesRolesEnum } from '@cube-frontend/api'
+import { ItemsPerPage } from '@cube-frontend/ui-library'
+import { useSearchParamsQuery } from '@cube-frontend/web-app/hooks/useSearchParamsQuery'
+import { queryToSearchParams, searchParamsToQuery } from './utils'
+
+export const useNodeListQuery = () => {
+  const { query, setQuery } = useSearchParamsQuery({
+    queryToSearchParams,
+    searchParamsToQuery,
+  })
+
+  const onRolesChange = (roles: GetNodesRolesEnum[]) => {
+    setQuery((prev) => ({
+      ...prev,
+      roles,
+      currentPage: 1,
+    }))
+  }
+
+  const onKeywordChange = (value: string): void => {
+    setQuery((prev) => ({
+      ...prev,
+      keyword: value,
+      currentPage: 1,
+    }))
+  }
+
+  const onPageChange = (page: number): void => {
+    setQuery((prev) => ({
+      ...prev,
+      currentPage: page,
+    }))
+  }
+
+  const onItemsPerPageChange = (itemsPerPage: ItemsPerPage): void => {
+    setQuery((prev) => ({
+      ...prev,
+      itemsPerPage,
+      currentPage: 1,
+    }))
+  }
+
+  return {
+    query,
+    setQuery,
+    onKeywordChange,
+    onRolesChange,
+    onPageChange,
+    onItemsPerPageChange,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/node/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/utils.ts
@@ -1,0 +1,75 @@
+import { z } from 'zod'
+import { GetNodesRolesEnum } from '@cube-frontend/api'
+import { DEFAULT_ITEMS_PER_PAGE } from '@cube-frontend/ui-library'
+import { paginationQuerySchema } from '@cube-frontend/web-app/utils/pagination'
+
+enum NodeParamKeyEnum {
+  Keyword = 'keyword',
+  Roles = 'roles',
+  CurrentPage = 'page',
+  ItemsPerPage = 'pageSize',
+}
+
+const nodeListQuerySchema = paginationQuerySchema.extend({
+  keyword: z
+    .string()
+    .nullable()
+    .transform((value) => {
+      return value ?? ''
+    }),
+  roles: z
+    .enum(Object.values(GetNodesRolesEnum) as [string, ...string[]])
+    .array()
+    .nullable()
+    .transform((array) => {
+      return (array ?? []) as GetNodesRolesEnum[]
+    }),
+})
+
+export type NodeListQuery = z.output<typeof nodeListQuerySchema>
+
+export const queryToSearchParams = (query: NodeListQuery): URLSearchParams => {
+  const { keyword, roles, currentPage, itemsPerPage } = query
+  const nextSearchParams = new URLSearchParams()
+
+  if (keyword) {
+    nextSearchParams.set(NodeParamKeyEnum.Keyword, keyword)
+  }
+
+  roles.forEach((role) => {
+    nextSearchParams.append(NodeParamKeyEnum.Roles, role)
+  })
+
+  if (currentPage) {
+    nextSearchParams.set(NodeParamKeyEnum.CurrentPage, currentPage.toString())
+  }
+
+  if (itemsPerPage) {
+    nextSearchParams.set(NodeParamKeyEnum.ItemsPerPage, itemsPerPage.toString())
+  }
+
+  return nextSearchParams
+}
+
+export const searchParamsToQuery = (
+  searchParams: URLSearchParams,
+): NodeListQuery => {
+  const keyword = searchParams.get(NodeParamKeyEnum.Keyword)
+  const roles = searchParams.getAll(NodeParamKeyEnum.Roles)
+  const currentPage = searchParams.get(NodeParamKeyEnum.CurrentPage)
+  const itemsPerPage = searchParams.get(NodeParamKeyEnum.ItemsPerPage)
+
+  const parsedQuery = nodeListQuerySchema.safeParse({
+    keyword,
+    roles,
+    currentPage,
+    itemsPerPage,
+  }).data
+
+  return {
+    keyword: parsedQuery?.keyword ?? '',
+    roles: parsedQuery?.roles ?? [],
+    currentPage: parsedQuery?.currentPage ?? 1,
+    itemsPerPage: parsedQuery?.itemsPerPage ?? DEFAULT_ITEMS_PER_PAGE,
+  }
+}

--- a/packages/cube-frontend-web-app/src/utils/pagination.ts
+++ b/packages/cube-frontend-web-app/src/utils/pagination.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+import { DEFAULT_ITEMS_PER_PAGE, ItemsPerPage } from '@cube-frontend/ui-library'
+
+export const paginationQuerySchema = z.object({
+  currentPage: z
+    .string()
+    .nullable()
+    .transform((value) => {
+      return value ? parseInt(value, 10) : 1
+    }),
+  itemsPerPage: z
+    .string()
+    .nullable()
+    .transform((value) => {
+      if (!value) {
+        return DEFAULT_ITEMS_PER_PAGE
+      }
+      return parseInt(value, 10) as ItemsPerPage
+    }),
+})
+
+export type PaginationQuery = z.output<typeof paginationQuerySchema>


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### Which issue(s) this PR fixes

Fixes #448

#### What this PR does / why we need it

Fixes:

1. The Node, Support Files and License page should retain filter conditions after a page refresh by using URLSearchParams.
2. The Node, Support Files and License page should return to page 1 when filters are changed.

Solution:

1. Extract `useSearchParamsQuery` hook to sync request query and URLSearchParams.
3. Define request query schemas using Zod.
4. Infer  request query types from the Zod schema.

#### Screenshots

1.) The Node List Page

https://github.com/user-attachments/assets/820525c4-e54f-4b11-8ad7-eeb736a249b5

2.) The Support Files List Page

https://github.com/user-attachments/assets/a446117b-19c0-4589-af1f-1ad8b280e2bd

3.) The License List Page

https://github.com/user-attachments/assets/ea864726-dd0c-41cf-a104-11f67e1928bf

4.) The Tuning List Page

https://github.com/user-attachments/assets/11b1dbb5-bbc5-436c-8734-967067f92532
