### PR TITLE
469 fix: node resource usage percentage

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBar.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosProgressBar/CosProgressBar.tsx
@@ -1,4 +1,4 @@
-import { CSSProperties } from 'react'
+import { CSSProperties, useMemo } from 'react'
 import { cva } from 'class-variance-authority'
 import { twMerge } from 'tailwind-merge'
 import { PropsWithClassName } from '@cube-frontend/utils'
@@ -61,6 +61,12 @@ export const CosProgressBar = (props: CosProgressBarProps) => {
 
   const color = getProgressColor(progress)
 
+  const displayPercentage = useMemo<number>(() => {
+    if (progress === 0) return 0
+    const rounded = Math.round(progress)
+    return Math.max(1, rounded)
+  }, [progress])
+
   return (
     <div className={className}>
       <div
@@ -88,7 +94,7 @@ export const CosProgressBar = (props: CosProgressBarProps) => {
           />
         )}
       </div>
-      <span className="primary-body5 text-functional-text">{`${Math.round(progress)}%`}</span>
+      <span className="primary-body5 text-functional-text">{`${displayPercentage}%`}</span>
     </div>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/UsageMetricsItem.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/chart/_components/UsagePanel/UsageMetricsItem.tsx
@@ -32,12 +32,12 @@ export const UsageMetricsItem = (props: UsageMetricsItemProps) => {
       <div className="flex gap-x-6">
         <CosProgressBarChart
           isLoading={isLoading}
-          progress={Math.floor(cpuUsedPercent)}
+          progress={cpuUsedPercent}
           title="CPU"
         />
         <CosProgressBarChart
           isLoading={isLoading}
-          progress={Math.floor(memoryUsedPercent)}
+          progress={memoryUsedPercent}
           title="Memory"
         />
       </div>

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
@@ -14,7 +14,6 @@ import {
   toLicenseExpirationDate,
 } from '@cube-frontend/web-app/utils/date'
 import { ipv4CompareFnMap } from '@cube-frontend/web-app/utils/ip'
-import { toPercentage } from '@cube-frontend/web-app/utils/number'
 import { noop } from 'lodash'
 import { ComponentProps } from 'react'
 import { Link } from 'react-router'
@@ -76,7 +75,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(cpu) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={toPercentage(cpu.usedCores, cpu.totalCores)}
+            progress={Math.floor(cpu.usedPercent)}
           />
         )}
       </BasicNodeTable.Column>
@@ -88,7 +87,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(memory) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={toPercentage(memory.usedMiB, memory.totalMiB)}
+            progress={Math.floor(memory.usedPercent)}
           />
         )}
       </BasicNodeTable.Column>
@@ -100,7 +99,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(storage) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={toPercentage(storage.usedMiB, storage.totalMiB)}
+            progress={Math.floor(storage.usedPercent)}
           />
         )}
       </BasicNodeTable.Column>

--- a/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/overview/_components/NodePanel/NodeTable.tsx
@@ -73,10 +73,7 @@ export const NodeTable = (props: NodeTableProps) => {
         skeletonVariant="with-barchart"
       >
         {(cpu) => (
-          <CosProgressBar
-            className="min-w-[90px]"
-            progress={Math.floor(cpu.usedPercent)}
-          />
+          <CosProgressBar className="min-w-[90px]" progress={cpu.usedPercent} />
         )}
       </BasicNodeTable.Column>
       <BasicNodeTable.Column
@@ -87,7 +84,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(memory) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={Math.floor(memory.usedPercent)}
+            progress={memory.usedPercent}
           />
         )}
       </BasicNodeTable.Column>
@@ -99,7 +96,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(storage) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={Math.floor(storage.usedPercent)}
+            progress={storage.usedPercent}
           />
         )}
       </BasicNodeTable.Column>

--- a/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
@@ -77,10 +77,7 @@ export const NodeTable = (props: NodeTableProps) => {
         skeletonVariant="with-barchart"
       >
         {(cpu) => (
-          <CosProgressBar
-            className="min-w-[90px]"
-            progress={Math.floor(cpu.usedPercent)}
-          />
+          <CosProgressBar className="min-w-[90px]" progress={cpu.usedPercent} />
         )}
       </BatchActionNodeTable.Column>
       <BatchActionNodeTable.Column
@@ -91,7 +88,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(memory) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={Math.floor(memory.usedPercent)}
+            progress={memory.usedPercent}
           />
         )}
       </BatchActionNodeTable.Column>
@@ -103,7 +100,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(storage) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={Math.floor(storage.usedPercent)}
+            progress={storage.usedPercent}
           />
         )}
       </BatchActionNodeTable.Column>

--- a/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/NodeTable.tsx
@@ -14,7 +14,6 @@ import {
   toLicenseExpirationDate,
 } from '@cube-frontend/web-app/utils/date'
 import { ipv4CompareFnMap } from '@cube-frontend/web-app/utils/ip'
-import { toPercentage } from '@cube-frontend/web-app/utils/number'
 import { noop } from 'lodash'
 import { ComponentProps } from 'react'
 import { Link } from 'react-router'
@@ -80,7 +79,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(cpu) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={toPercentage(cpu.usedCores, cpu.totalCores)}
+            progress={Math.floor(cpu.usedPercent)}
           />
         )}
       </BatchActionNodeTable.Column>
@@ -92,7 +91,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(memory) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={toPercentage(memory.usedMiB, memory.totalMiB)}
+            progress={Math.floor(memory.usedPercent)}
           />
         )}
       </BatchActionNodeTable.Column>
@@ -104,7 +103,7 @@ export const NodeTable = (props: NodeTableProps) => {
         {(storage) => (
           <CosProgressBar
             className="min-w-[90px]"
-            progress={toPercentage(storage.usedMiB, storage.totalMiB)}
+            progress={Math.floor(storage.usedPercent)}
           />
         )}
       </BatchActionNodeTable.Column>


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it

- Adjust Node tables and Node Detail resource usage percentage source (use the percentage returned by the API instead of calculating it in the frontend).
- Enhancement:Show at least 1% in CosProgessBar when progress > 0.

   ![image](https://github.com/user-attachments/assets/74f57b88-70dc-422c-b01f-f21395d1d1ff)

   - Before

      ![image](https://github.com/user-attachments/assets/52b281ce-d868-45c3-91ee-0d5da784905c)

   - After

      ![image](https://github.com/user-attachments/assets/5a7f42cf-c715-4490-b7c3-573c9eed595b)

#### Which issue(s) this PR fixes

Close bigstack-oss/cubecos#112 

