### PR TITLE
Fix/99 not able to download support files

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/DownloadSupportFilesModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/DownloadSupportFilesModal.tsx
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import { CosCheckbox, CosModal } from '@cube-frontend/ui-library'
 import { SupportFile } from '@cube-frontend/api'
 import { SupportFileRow } from '../MaintenanceSupportFilesPage'
-import { download } from '@cube-frontend/web-app/utils/download'
 import { formatSupportFilesTimestamp } from '@cube-frontend/web-app/utils/date'
 
 type DownloadSupportFilesModalProps = {
@@ -19,7 +18,7 @@ export const DownloadSupportFilesModal = (
   const [selectedFiles, setSelectedFiles] = useState<SupportFile[]>([])
 
   const handleDownload = () => {
-    selectedFiles.forEach((file) => download(file.url, file.name))
+    selectedFiles.forEach((file) => window.open(file.url, '_blank'))
     onCloseClick()
   }
 

--- a/packages/cube-frontend-web-app/src/utils/download.ts
+++ b/packages/cube-frontend-web-app/src/utils/download.ts
@@ -1,9 +1,0 @@
-export const download = (url: string, filename: string) => {
-  const link = document.createElement('a')
-  document.body.appendChild(link)
-  link.href = url
-  link.download = filename
-  link.target = '_blank'
-  link.click()
-  link.remove()
-}


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### Which issue(s) this PR fixes

Fixes https://github.com/bigstack-oss/cubecos/issues/99

#### What this PR does / why we need it

Use `window.open(url, '_blank')` instead of `<a href={url} target="_blank">` to ensure the browser opens a new tab to download support files.

Reference: https://stackoverflow.com/questions/29444051/link-with-target-blank-does-not-open-in-new-tab-in-chrome

#### Test Screenshots

Local Testing

https://github.com/user-attachments/assets/b06573a5-5570-467d-b852-526dfab8f0ff

This issue cannot be reproduced in the local dev environment, so I performed a simple test on https://10.32.45.10/maintenance/support-files

https://github.com/user-attachments/assets/9db85d38-e372-47f0-ab53-83db04d9116e