### PR TITLE
Fix/469 chart percentage should use api response percentage

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
@@ -9,6 +9,10 @@ export type CosPercentagePieChartProps = {
   total: number
   used: number
   /**
+   * If not provided, the percentage will be calculated based on used and total.
+   */
+  percentage?: number
+  /**
    * @default 100
    */
   thresholdPercentage?: number
@@ -43,6 +47,7 @@ export const CosPercentagePieChart = (props: CosPercentagePieChartProps) => {
     unit,
     total,
     used,
+    percentage: percentageProp,
     color: colorProp,
     thresholdPercentage = 100,
     percentageFormatter = defaultPercentageFormatter,
@@ -51,7 +56,12 @@ export const CosPercentagePieChart = (props: CosPercentagePieChartProps) => {
   } = props
 
   // Default to 0 to avoid NaN when total is 0.
-  const percentage = Math.floor((used / total) * 100) || 0
+  const getPercentage = () => {
+    const percentage = percentageProp ?? ((used / total) * 100 || 0)
+    return Math.floor(percentage)
+  }
+
+  const percentage = getPercentage()
   const color = colorProp ?? getPercentageColor(percentage)
   const isOverThreshold = percentage > thresholdPercentage
 

--- a/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPercentagePieChart/CosPercentagePieChart.tsx
@@ -32,6 +32,11 @@ const defaultPercentageFormatter = (value: number) => {
   return `${value}%`
 }
 
+const calculatePercentage = (used: number, total: number) => {
+  // Default to 0 to avoid NaN when total is 0.
+  return (used / total) * 100 || 0
+}
+
 const getPercentageColor = (percentage: number): StrokeColorClass => {
   if (percentage <= 50) {
     return 'stroke-chart-1'
@@ -55,15 +60,19 @@ export const CosPercentagePieChart = (props: CosPercentagePieChartProps) => {
     isLoading = false,
   } = props
 
-  // Default to 0 to avoid NaN when total is 0.
-  const getPercentage = () => {
-    const percentage = percentageProp ?? ((used / total) * 100 || 0)
-    return Math.floor(percentage)
+  const getChartPercentage = () => {
+    const percentage = percentageProp ?? calculatePercentage(used, total)
+
+    if (percentage === 0) return 0
+    /**
+     * UX Enhancement: Show at least 1% in CosPercentagePieChart when percentage > 0.
+     */
+    return Math.max(Math.floor(percentage), 1)
   }
 
-  const percentage = getPercentage()
-  const color = colorProp ?? getPercentageColor(percentage)
-  const isOverThreshold = percentage > thresholdPercentage
+  const chartPercentage = getChartPercentage()
+  const color = colorProp ?? getPercentageColor(chartPercentage)
+  const isOverThreshold = chartPercentage > thresholdPercentage
 
   return (
     <div className="flex flex-col items-center gap-y-4">
@@ -91,12 +100,12 @@ export const CosPercentagePieChart = (props: CosPercentagePieChartProps) => {
           <div className="relative">
             <PercentagePie
               color={color}
-              percentage={percentage}
+              percentage={chartPercentage}
               thresholdPercentage={thresholdPercentage}
             />
             <div className="absolute left-1/2 top-[50px] flex -translate-x-1/2 flex-col items-center gap-y-1">
               <span className="primary-h3 text-functional-title">
-                {percentageFormatter(percentage)}
+                {percentageFormatter(chartPercentage)}
               </span>
               <div className="flex flex-col items-center">
                 <span className="primary-body5 text-functional-text-light">{`${total} ${unit}`}</span>

--- a/packages/cube-frontend-ui-library/src/stories/components/CosPercentagePieChart/CosPercentagePieChart.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosPercentagePieChart/CosPercentagePieChart.stories.tsx
@@ -32,6 +32,14 @@ const PercentagePieChartGallery = () => {
             used={0}
             total={755.1}
           />
+          {/* Show at least 1% in CosPercentagePieChart when percentage > 0. */}
+          <CosPercentagePieChart
+            title="Memory"
+            unit="GB"
+            overThresholdText="Over Limit"
+            used={0.01}
+            total={755.1}
+          />
           <CosPercentagePieChart
             title="Memory"
             unit="GB"
@@ -140,6 +148,16 @@ const PercentagePieChartGallery = () => {
               percentageFormatter={formatCpuPercentage}
               thresholdPercentage={400}
               used={0}
+              total={10}
+            />
+            {/* Show at least 1% in CosPercentagePieChart when percentage > 0. */}
+            <CosPercentagePieChart
+              title="vCPU"
+              unit="vCPU"
+              color="stroke-chart-2"
+              percentageFormatter={formatCpuPercentage}
+              thresholdPercentage={400}
+              used={0.01}
               total={10}
             />
             <CosPercentagePieChart

--- a/packages/cube-frontend-web-app/src/pages/home/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/utils.ts
@@ -120,16 +120,19 @@ export const toMetricsChart = (
       unit: 'vCPU',
       total: metrics.vm.usage.vcpu.totalCores,
       used: metrics.vm.usage.vcpu.usedCores,
+      percentage: metrics.vm.usage.vcpu.usedPercent,
     },
     memoryPieChart: {
       unit: memoryReadableSizeUnit,
       total: memoryTotalReadableSize,
       used: memoryUsedReadableSize,
+      percentage: metrics.vm.usage.memory.usedPercent,
     },
     storagePieChart: {
       unit: storageReadableSizeUnit,
       total: storageTotalReadableSize,
       used: storageUsedReadableSize,
+      percentage: metrics.vm.usage.storage.usedPercent,
     },
   }
 }


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Adjust VM Allocation Chart Panel percentage source (use the percentage returned by the API instead of calculating it in the frontend).

#### Which issue(s) this PR fixes

Related: https://github.com/bigstack-oss/cubecos/issues/112

This PR reviews all related charts to ensure they use the percentage provided by the API rather than performing calculations on the frontend.