### PR TITLE
fix: 491 license nagging message incorrect display

### DIFF
--- a/packages/cube-frontend-web-app/src/utils/license.ts
+++ b/packages/cube-frontend-web-app/src/utils/license.ts
@@ -21,7 +21,7 @@ export const invalidLicenseMessageMap: Record<
   (count: number) => string
 > = {
   unlicense: (count) =>
-    `${toPluralizeDisplay(count, 'host')} ${toPluralizeDisplay(count, 'is')} unlicensed.`,
+    `${toPluralizeDisplay(count, 'host')} ${pluralize('is', count)} unlicensed.`,
   expired: (count) => `${count} host ${pluralize('license', count)} expired.`,
 }
 


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Before

<img width="1919" alt="Screenshot 2025-06-03 at 2 29 24 PM" src="https://github.com/user-attachments/assets/89b72769-ce16-4a3b-9eaa-78f2dfe58fc5" />

After

<img width="1508" alt="Screenshot 2025-06-04 at 12 36 48 PM" src="https://github.com/user-attachments/assets/3c5c4b7e-b6c9-48fa-8e2e-6e3b196a73d4" />


#### Which issue(s) this PR fixes

fix #491 
