### PR TITLE
fix: 495 support files modal should hint user to allow browser multiple download

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosModal/CosModal.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosModal/CosModal.tsx
@@ -52,6 +52,22 @@ export const CosModal = (props: CosModalProps) => {
     onCloseClick,
   })
 
+  const renderFooterMessage = (footerMessage: ReactNode) => {
+    if (!footerMessage) {
+      return null
+    }
+
+    if (typeof footerMessage === 'string') {
+      return (
+        <div className="primary-body3 flex-1 text-functional-text-light">
+          {footerMessage}
+        </div>
+      )
+    }
+
+    return footerMessage
+  }
+
   return createPortal(
     <>
       <div className={backdrop({ isOpen })} onClick={onCloseClick} />
@@ -76,7 +92,7 @@ export const CosModal = (props: CosModalProps) => {
           </div>
           <div className="flex-1 overflow-auto p-7">{children}</div>
           <div className="flex items-center justify-end gap-x-2.5 border-t border-functional-border-divider px-7 py-4">
-            {footerMessage}
+            {renderFooterMessage(footerMessage)}
             {isActionButtonVisible && (
               <CosButton
                 usage="text-only"

--- a/packages/cube-frontend-ui-library/src/stories/components/CosModal/CosModal.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosModal/CosModal.stories.tsx
@@ -1,4 +1,5 @@
 import { CosCheckbox, CosInput } from '@cube-frontend/ui-library'
+import CheckIcon from '@cube-frontend/ui-library/icons/monochrome/checkmark.svg?react'
 import type { Meta, StoryObj } from '@storybook/react'
 import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
 import { ModalStoryRow } from './ModalStoryRow'
@@ -23,6 +24,30 @@ export const Gallery: StoryObj = {
             label="MD"
             size="md"
             content="This is a medium modal."
+          />
+        </StoryLayout.Section>
+        <StoryLayout.Section title="Footer Message">
+          <ModalStoryRow
+            label="Default (Short)"
+            content="Do you want to delete this resource?"
+            footerMessage="Lorem ipsum dolor sit."
+          />
+          <ModalStoryRow
+            label="Default (Long)"
+            content="Do you want to delete this resource?"
+            footerMessage="Lorem ipsum dolor sit amet consectetur. Duis est netus sit aliquet. At vulputate faucibus diam arcu praesent auctor. Aliquam ipsum consequat facilisis mattis vestibulum gravida arcu."
+          />
+          <ModalStoryRow
+            label="Custom"
+            content="Do you want to delete this resource?"
+            footerMessage={
+              <div className="flex flex-1 items-center justify-end">
+                <div className="flex items-center gap-x-1 text-status-positive-text">
+                  <CheckIcon className="icon-md" />
+                  <span className="primary-body4">Copied to clipboard.</span>
+                </div>
+              </div>
+            }
           />
         </StoryLayout.Section>
         <StoryLayout.Section title="Usage">

--- a/packages/cube-frontend-ui-library/src/stories/components/CosModal/ModalStoryRow.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosModal/ModalStoryRow.tsx
@@ -4,10 +4,10 @@ import { Fragment, ReactNode, useState } from 'react'
 type ModalStoryRowProps = {
   label: string
   content: ReactNode
-} & Pick<CosModalProps, 'size' | 'actionText'>
+} & Pick<CosModalProps, 'size' | 'footerMessage' | 'actionText'>
 
 export const ModalStoryRow = (props: ModalStoryRowProps) => {
-  const { label, content, size, actionText } = props
+  const { label, content, size, footerMessage, actionText } = props
 
   const [isOpen, setIsOpen] = useState(false)
 
@@ -30,6 +30,7 @@ export const ModalStoryRow = (props: ModalStoryRowProps) => {
         isOpen={isOpen}
         title={label}
         actionText={actionText}
+        footerMessage={footerMessage}
         onActionClick={() => alert('Action!')}
         onCloseClick={onCloseClick}
       >

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/HardwareSerialNumberModal/HardwareSerialNumberModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/HardwareSerialNumberModal/HardwareSerialNumberModal.tsx
@@ -55,9 +55,11 @@ export const HardwareSerialNumberModal = (
       title="Get Hardware Serial Number"
       footerMessage={
         showCopySuccess && (
-          <div className="flex items-center gap-x-1 text-status-positive-text">
-            <CheckIcon className="icon-md" />
-            <span className="primary-body4">Copied to clipboard.</span>
+          <div className="flex flex-1 items-center justify-end">
+            <div className="flex items-center gap-x-1 text-status-positive-text">
+              <CheckIcon className="icon-md" />
+              <span className="primary-body4">Copied to clipboard.</span>
+            </div>
           </div>
         )
       }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/DownloadSupportFilesModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/DownloadSupportFilesModal.tsx
@@ -50,6 +50,7 @@ export const DownloadSupportFilesModal = (
       title="Choose hosts to download support files"
       size="sm"
       isOpen={isOpen}
+      footerMessage="Check browser and click “Always allow pop-up” to download all files."
       actionText="Download"
       actionButtonProps={{ disabled: selectedFiles.length === 0 }}
       onActionClick={handleDownload}


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

1.) ui-library: Add default footer message style and Storybook test cases, including `Default` and `Custom`

<img width="1918" alt="Screenshot 2025-06-04 at 2 15 31 PM" src="https://github.com/user-attachments/assets/861ba3c9-3900-478d-9b24-0693124aa7ca" />

<img width="1914" alt="Screenshot 2025-06-04 at 2 15 46 PM" src="https://github.com/user-attachments/assets/6e14dd6a-a10f-40ab-917c-397dd1d3f9d1" />
\
<img width="1920" alt="Screenshot 2025-06-04 at 2 15 51 PM" src="https://github.com/user-attachments/assets/ad085786-50ad-4fc0-b779-2c4c135811b1" />

<img width="1920" alt="Screenshot 2025-06-04 at 2 15 55 PM" src="https://github.com/user-attachments/assets/bc092b09-916d-4d87-b9f4-17c045279305" />

2.) Hint the user to enable multiple downloads in the browser through the support files modal footer message.

<img width="1920" alt="image" src="https://github.com/user-attachments/assets/3609660f-8c29-42d2-ba65-3f8ec2d4bd91" />

#### Which issue(s) this PR fixes

Fixes #495
