### PR TITLE
506 settings page email recipients bug

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/createEmailRecipient.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/actions/createEmailRecipient.ts
@@ -28,12 +28,11 @@ export const createEmailRecipient = async (
     patchRow(row.id, {
       id: getRowId(),
       originalState: newEmailRecipient,
-      status: {
-        current: SettingStatusCurrentEnum.Ok,
-        isUpdating: false,
-      },
       isNew: false,
       isEditing: false,
+      // Don't set `status.isUpdating` to false after creation because
+      // email recipients are in an updating state by default upon creation.
+      // Status will be synced by polling later.
     })
     onSuccess?.()
   } catch (error) {

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useEmailRecipientRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useEmailRecipientRows.ts
@@ -1,4 +1,7 @@
-import { EmailRecipientResponse } from '@cube-frontend/api'
+import {
+  EmailRecipientResponse,
+  SettingStatusCurrentEnum,
+} from '@cube-frontend/api'
 import { DeepPartial } from '@cube-frontend/utils'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useShowErrorToast } from '@cube-frontend/web-app/hooks/useShowErrorToast/useShowErrorToast'
@@ -121,7 +124,12 @@ export const useEmailRecipientRows = (
       row,
       patchRow,
       onSuccess: () => {
-        setRows((prevRows) => prevRows.filter((row) => row.id !== rowId))
+        patchRow(rowId, {
+          status: {
+            current: SettingStatusCurrentEnum.Updating,
+            isUpdating: true,
+          },
+        })
       },
       onError: showErrorToast,
     })

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useSyncRecipientRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useSyncRecipientRows.ts
@@ -35,16 +35,25 @@ export const useSyncRecipientRows = (
     )
 
     setRows((prev) => {
-      const newRows = [...prev]
-      newRows.forEach((row) => {
-        if (row.isEditing || !row.status.isUpdating) return
+      const rowsToKeep = prev.filter(
+        (row) =>
+          row.isNew ||
+          row.isEditing ||
+          // Rows marked for removal are first set to an updating status by the API.
+          // Once removed, they won't appear in the API response, so a missing existing
+          // row indicates it has been deleted, and should be removed from UI as well.
+          newStatusMap.has(row.address),
+      )
 
+      rowsToKeep.forEach((row) => {
+        if (row.isEditing) return
         const newStatus = newStatusMap.get(row.address)
         if (newStatus) {
           row.status = newStatus
         }
       })
-      return newRows
+
+      return rowsToKeep
     })
   }, [recipientsFromApi, setRows])
 

--- a/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useSyncRecipientRows.ts
+++ b/packages/cube-frontend-web-app/src/pages/settings/_components/email/recipients/useSyncRecipientRows.ts
@@ -35,18 +35,22 @@ export const useSyncRecipientRows = (
     )
 
     setRows((prev) => {
-      const rowsToKeep = prev.filter(
-        (row) =>
-          row.isNew ||
-          row.isEditing ||
-          // Rows marked for removal are first set to an updating status by the API.
-          // Once removed, they won't appear in the API response, so a missing existing
-          // row indicates it has been deleted, and should be removed from UI as well.
-          newStatusMap.has(row.address),
-      )
+      // TODO: Revisit this part in M2 when issues on the API side are fixed.
+      const rowsToKeep = prev.filter((row) => {
+        if (row.isDeleting) {
+          // Currently when multiple email recipients are created simultaneously,
+          // only the most recently initiated one will be included in the API response.
+          // Any other email recipients in an updating status will be invisible until
+          // the most recent one has completed its creation (when its `isUpdating` turns to `false`).
+          // To avoid recipients abruptly vanishing during polling, we could only remove rows that
+          // have an explicit deleting status.
+          return newStatusMap.has(row.address)
+        }
+        return true
+      })
 
       rowsToKeep.forEach((row) => {
-        if (row.isEditing) return
+        if (row.isNew || row.isEditing) return
         const newStatus = newStatusMap.get(row.address)
         if (newStatus) {
           row.status = newStatus


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

On Settings Page:

- Fix created row is not in a loading status by default bug.
- Fix deleted row is not in a loading status by default bug.
- Fix deleted row won't be removed from UI during polling bug.

#### Which issue(s) this PR fixes

Close #506

- Create email recipient

   https://github.com/user-attachments/assets/160d3f37-28fc-4f83-8698-48ea5d21c385


- Delete email recipient

   https://github.com/user-attachments/assets/8169c50e-e9af-43ed-b506-d585c1f0978c

