### PR TITLE
fix(ui-library): 505 incorrect arrows_expand_02 icon display size

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosIcon/monochrome/arrows_expand_02.svg
+++ b/packages/cube-frontend-ui-library/src/components/CosIcon/monochrome/arrows_expand_02.svg
@@ -1,3 +1,3 @@
-<svg viewBox="0 0 12.531365394592285 12.531370162963867" fill="none" xmlns="http://www.w3.org/2000/svg">
-<path d="M11.6771 2.32288L2.3229 11.6771M11.6771 2.32288L8.5 2.32288M11.6771 2.32288L11.6771 5.5M2.3229 11.6771L5.50001 11.6771M2.3229 11.6771L2.32288 8.49998" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
+<svg viewBox="0 0 16 16" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.9428 3.58856L9.76569 3.58856M12.9428 3.58856L12.9428 6.76568M12.9428 3.58856L8.2657 8.26567L3.58858 12.9428M3.58858 12.9428L6.76569 12.9428M3.58858 12.9428L3.58856 9.76567" stroke="currentColor" stroke-width="1.2" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Root Cause:

The `arrows_expand_02` icon was exported from Figma using the `SVG Exporter` plugin. we accidentally included the outer frame, which caused the icon to display incorrect size.

Solution:

Re-export the `arrows_expand_02` icon without the outer frame.

Before:
![image](https://github.com/user-attachments/assets/84ec9d4e-c33c-4446-9009-eb93d646d5c6)

After:
<img width="1046" alt="image" src="https://github.com/user-attachments/assets/b551736e-8b91-40c3-8df1-d7573cb4940b" />


#### Which issue(s) this PR fixes

Fixes #505