### PR TITLE
feat(ui-library): 501 button width should remain the same during loading state

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosButton/CosButton.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosButton/CosButton.tsx
@@ -96,11 +96,23 @@ const button = cva(
         lg: 'secondary-body2 h-[42px] px-5 py-3',
       },
       usage: {} as Record<NonNullable<CosButtonUsage>, ClassValue>,
+      loading: {} as Record<'true' | 'false', ClassValue>,
     },
     compoundVariants: [
       { usage: 'icon-only', size: 'sm', className: 'p-[5px]' },
       { usage: 'icon-only', size: 'md', className: 'p-2' },
       { usage: 'icon-only', size: 'lg', className: 'p-3' },
+      /**
+       * We expect the button only show the loading spinner when the usage is 'text-only'.
+       *
+       * disabled:relative => position the absolute positioned spinner relative to the button.
+       * disabled:text-transparent => hide the text but keep the button's width and height.
+       */
+      {
+        usage: 'text-only',
+        loading: true,
+        className: 'disabled:relative disabled:text-transparent',
+      },
     ],
   },
 )
@@ -124,17 +136,29 @@ const loadingSpinner = cva(undefined, {
       warning: 'text-red-100',
       light: 'text-functional-disable-text',
     },
+    /**
+     * The button should only show the loading spinner when the usage is 'text-only',
+     * so we need to center the absolute positioned spinner within the button.
+     */
+    usage: {
+      'text-only':
+        'absolute left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
+    } as Record<NonNullable<CosButtonUsage>, ClassValue>,
   },
 })
 
 type ButtonLoadingSpinnerProps = {
   type: CosButtonType
+  usage: CosButtonUsage
 }
 
 const ButtonLoadingSpinner = (props: ButtonLoadingSpinnerProps) => {
-  const { type } = props
+  const { type, usage } = props
   return (
-    <CosLoadingSpinner variant="dot45" className={loadingSpinner({ type })} />
+    <CosLoadingSpinner
+      variant="dot45"
+      className={loadingSpinner({ type, usage })}
+    />
   )
 }
 
@@ -168,7 +192,7 @@ export const CosButton = (props: CosButtonProps) => {
     return (
       <div className={twMerge(iconContainer({ size }))}>
         {loading ? (
-          <ButtonLoadingSpinner type={type} />
+          <ButtonLoadingSpinner type={type} usage={usage} />
         ) : (
           <Icon className={getIconSizeByButtonSize(size)} />
         )}
@@ -199,7 +223,7 @@ export const CosButton = (props: CosButtonProps) => {
         return (
           <>
             {props.children}
-            {loading && <ButtonLoadingSpinner type={type} />}
+            {loading && <ButtonLoadingSpinner type={type} usage={usage} />}
           </>
         )
     }
@@ -208,7 +232,7 @@ export const CosButton = (props: CosButtonProps) => {
   return (
     <button
       type={htmlType}
-      className={twMerge(button({ type, size, usage }), className)}
+      className={twMerge(button({ type, size, usage, loading }), className)}
       disabled={disabled}
       onClick={onClick}
       {...omit(restProps, 'Icon')}


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

feat(ui-library): 501 button width should remain the same during loading state

Before:
<img width="1777" alt="Screenshot 2025-06-16 at 2 15 20 PM" src="https://github.com/user-attachments/assets/f0842e11-1582-4e6c-acb3-c94881529a34" />

After:
<img width="1628" alt="Screenshot 2025-06-16 at 2 16 24 PM" src="https://github.com/user-attachments/assets/ac623d7e-dbe7-49da-a4fc-76fbe46f389b" />

Example:
Web App Example:

https://github.com/user-attachments/assets/6f439e24-bb45-4588-a592-149e09c5c428

Strategy:
Please see the comments in the code change.

#### Which issue(s) this PR fixes
 
Fixes #501
