### PR TITLE
504/feat update the status component to the latest design guideline

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosStatus/CosStatus.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosStatus/CosStatus.tsx
@@ -8,7 +8,7 @@ export type CosStatusProps = {
 
 const statusCva = cva(
   [
-    'flex h-[17px] w-fit cursor-default items-center rounded-[20px] border px-2.5',
+    'flex h-[19px] w-fit cursor-default items-center rounded-[20px] border px-2.5',
     'secondary-body6 font-semibold',
   ],
   {


### PR DESCRIPTION
#### What type of PR is this?

Feature

#### Which issue(s) this PR fixes

Closes #504

#### What this PR does / why we need it

Updated the status component to follow the latest [design guideline](https://www.figma.com/design/T95ymFSTSDKdmr9WEjylQE/COS-Design-System-2024?node-id=530-9429&m=dev).

Before:
![image](https://github.com/user-attachments/assets/816a83d2-cc19-4aa4-ad9e-e5fc41e6942f)

After:
<img width="610" alt="Screenshot 2025-06-16 at 3 16 10 PM" src="https://github.com/user-attachments/assets/18579e75-15a9-4c70-80d7-b46cdd49a31b" />

#### Special notes for your reviewer

Although the design guideline suggests using `padding padding-top: 2px` and `padding-bottom: 5px`, I prefer using `flex items-center`, which is more maintainable. Therefore, I only adjusted the height to match the design guidelines.