### PR TITLE
Fix/420 set auto height of modal

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosModal/cosModalStyles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosModal/cosModalStyles.ts
@@ -22,7 +22,8 @@ export const backdrop = cva(
 export const modal = cva(
   [
     'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
-    'flex max-h-[min(600px,_100dvh)] min-h-[204px] flex-col',
+    'max-h-[min(600px,_100dvh)] min-h-[204px] max-w-[min(1080px,_100dvw)]',
+    'flex flex-col',
     'rounded-[5px] border border-functional-border-divider bg-grey-0',
     'transition-opacity duration-200',
   ],

--- a/packages/cube-frontend-ui-library/src/components/CosModal/cosModalStyles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosModal/cosModalStyles.ts
@@ -22,7 +22,7 @@ export const backdrop = cva(
 export const modal = cva(
   [
     'fixed left-1/2 top-1/2 -translate-x-1/2 -translate-y-1/2',
-    'flex max-h-[600px] min-h-[204px] flex-col',
+    'flex max-h-[min(600px,_100dvh)] min-h-[204px] flex-col',
     'rounded-[5px] border border-functional-border-divider bg-grey-0',
     'transition-opacity duration-200',
   ],

--- a/packages/cube-frontend-ui-library/src/stories/components/CosModal/CosModal.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosModal/CosModal.stories.tsx
@@ -142,6 +142,12 @@ export const Gallery: StoryObj = {
              */
             className="h-[780px] max-h-screen"
           />
+          <ModalStoryRow
+            label="Custom Width"
+            size="sm"
+            content="This is a custom width modal."
+            className="min-w-[min(1000px,_100dvw)]"
+          />
         </StoryLayout.Section>
       </StoryLayout>
     )

--- a/packages/cube-frontend-ui-library/src/stories/components/CosModal/CosModal.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosModal/CosModal.stories.tsx
@@ -131,6 +131,18 @@ export const Gallery: StoryObj = {
             }
           />
         </StoryLayout.Section>
+        <StoryLayout.Section title="Custom">
+          <ModalStoryRow
+            label="Custom Height"
+            size="sm"
+            content="This is a custom height modal."
+            /**
+             * The default `max-height` of CosModal is `min(600px, 100dvh)`.
+             * so we need to override it to display  a height of 780px.
+             */
+            className="h-[780px] max-h-screen"
+          />
+        </StoryLayout.Section>
       </StoryLayout>
     )
   },

--- a/packages/cube-frontend-ui-library/src/stories/components/CosModal/ModalStoryRow.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosModal/ModalStoryRow.tsx
@@ -4,10 +4,10 @@ import { Fragment, ReactNode, useState } from 'react'
 type ModalStoryRowProps = {
   label: string
   content: ReactNode
-} & Pick<CosModalProps, 'size' | 'footerMessage' | 'actionText'>
+} & Pick<CosModalProps, 'className' | 'size' | 'footerMessage' | 'actionText'>
 
 export const ModalStoryRow = (props: ModalStoryRowProps) => {
-  const { label, content, size, footerMessage, actionText } = props
+  const { className, label, content, size, footerMessage, actionText } = props
 
   const [isOpen, setIsOpen] = useState(false)
 
@@ -26,6 +26,7 @@ export const ModalStoryRow = (props: ModalStoryRowProps) => {
         Open
       </CosButton>
       <CosModal
+        className={className}
         size={size}
         isOpen={isOpen}
         title={label}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/HardwareSerialNumberModal/HardwareSerialNumberModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/HardwareSerialNumberModal/HardwareSerialNumberModal.tsx
@@ -51,7 +51,7 @@ export const HardwareSerialNumberModal = (
 
   return (
     <CosModal
-      className="min-w-[1000px]"
+      className="min-w-[min(1000px,_100dvw)]"
       title="Get Hardware Serial Number"
       footerMessage={
         showCopySuccess && (


### PR DESCRIPTION
#### What type of PR is this?

Fix 

#### What this PR does / why we need it

1. Set the modal's `max-height` to `min(600px, 100dvh)` to ensure the entire modal stays within the browser window.
2. Set the modal's `max-width` to `min(1080px, 100dvw)` to ensure the entire modal stays within the browser window.
3. Add custom height and custom width stories. In `web-app`, the `HardwareSerialNumberModal.tsx` uses custom width,  and  `ImportLicenseModal.tsx` uses custom height.

Please refer to the [design guideline](https://www.figma.com/design/T95ymFSTSDKdmr9WEjylQE/COS-Design-System-2024?node-id=648-11781&m=dev).


#### Screenshots

Storybook:

https://github.com/user-attachments/assets/c3148ec5-2284-4b01-8de2-12d1c78d9a05

https://github.com/user-attachments/assets/5418fdd3-0abb-4855-b438-fc5ac48f4598

https://github.com/user-attachments/assets/5f691af3-c300-494e-bc84-7e9f894b3070

Web App:

https://github.com/user-attachments/assets/4d9bf61d-2536-4a4d-aec4-fe8beacd87a8


#### Which issue(s) this PR fixes

Fixes #420
