### PR TITLE
fix: prevent DatePicker from resetting current month view on re-render

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePicker.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDatePicker/CosDatePicker.tsx
@@ -42,11 +42,13 @@ export const CosDatePicker = (props: CosDatePickerProps) => {
 
   const [isCalendarOpen, setIsCalendarOpen] = useState(false)
 
-  const [currentMonth, setCurrentMonth] = useState(now)
-
-  useEffect(() => {
-    setCurrentMonth(now)
-  }, [now])
+  const [currentMonth, setCurrentMonth] = useState(
+    /**
+     * Initialize `currentMonth` to either `displayDates.start` (if available) or `now`.
+     * Also, the value only needs to be computed once.
+     */
+    () => displayDates.start ?? now,
+  )
 
   const onApply = () => {
     const { start, end } = displayDates


### PR DESCRIPTION
#### What type of PR is this?

- Fix

#### What this PR does / why we need it

1. Keep the calendar view fixed to the selected month

2. When a time range is selected, ensure the calendar displays the month of the start date by default for better UX

https://github.com/user-attachments/assets/df4ea454-50d3-4b63-b693-b841902e68c0

#### Which issue(s) this PR fixes

Fixes #531 

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
