### PR TITLE
chore(bump): bump version for cubecos v3.1.0

### DIFF
--- a/packages/cube-frontend-keycloak-login/package.json
+++ b/packages/cube-frontend-keycloak-login/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cube-frontend/keycloak-login",
-  "version": "17.1.0",
+  "version": "17.2.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",

--- a/packages/cube-frontend-web-app/package.json
+++ b/packages/cube-frontend-web-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cube-frontend/web-app",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "private": true,
   "license": "Apache-2.0",
   "type": "module",


### PR DESCRIPTION
#### What type of PR is this?

- chore

#### What this PR does / why we need it

- Bump web-app (cube-cos-ui) to 3.1.0 and keycloak-login (cube-cos-login) to 17.2.0

#### Which issue(s) this PR fixes

#### Special notes for your reviewer

#### Additional documentation
