### PR TITLE
235 show toast notifications

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToast.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/CosToastNotification/CosToast.tsx
@@ -60,7 +60,7 @@ export const CosToast = (props: CosToastProps) => {
   return (
     <div className={toastStyles({ type })}>
       <div className="flex gap-4">
-        <div className="flex flex-1 flex-col gap-3">
+        <div className="flex flex-1 flex-col gap-3 break-all">
           {renderHeader()}
           {message}
         </div>

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/cosNotificationTypes.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/cosNotificationTypes.ts
@@ -1,3 +1,6 @@
+import { PropsWithChildren, ReactElement } from 'react'
+import { CosHyperlinkProps } from '../CosHyperlink/CosHyperlink'
+
 export type CosNotificationType = 'neutral' | 'positive' | 'warning' | 'error'
 
 export type CosNotificationBaseProps = {
@@ -6,9 +9,9 @@ export type CosNotificationBaseProps = {
    */
   type?: CosNotificationType
   title?: string
-  link?: {
+  link?: Pick<CosHyperlinkProps, 'href' | 'onClick'> & {
+    Container?: ReactElement<PropsWithChildren>
     text: string
-    href: string
   }
   onClose?: () => void
 }

--- a/packages/cube-frontend-ui-library/src/components/CosNotification/cosNotificationUtils.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNotification/cosNotificationUtils.tsx
@@ -3,8 +3,11 @@ import WarningFilled from '../../components/CosIcon/monochrome/warning_filled.sv
 import WarningAltFilled from '../../components/CosIcon/monochrome/warning_alt_filled.svg?react'
 import CloseIcon from '../../components/CosIcon/monochrome/x_small.svg?react'
 import { CosHyperlink } from '../CosHyperlink/CosHyperlink'
-
-import { CosNotificationType } from './cosNotificationTypes'
+import {
+  CosNotificationType,
+  CosNotificationBaseProps,
+} from './cosNotificationTypes'
+import { cloneElement } from 'react'
 
 export const renderIcon = (type: CosNotificationType) => {
   switch (type) {
@@ -28,15 +31,26 @@ export const renderTitle = (title?: string) => {
   return <div className="font-semibold text-functional-title">{title}</div>
 }
 
-export const renderLink = (link?: { text: string; href: string }) => {
+export const renderLink = (link?: CosNotificationBaseProps['link']) => {
   if (!link) {
     return null
   }
-  return (
-    <CosHyperlink size="sm" variant="text-inline" href={link.href}>
-      {link.text}
+
+  const { href, onClick, Container, text } = link
+
+  const cosHyperlink = (
+    <CosHyperlink size="sm" variant="text-inline" href={href} onClick={onClick}>
+      {text}
     </CosHyperlink>
   )
+
+  if (Container) {
+    return cloneElement(Container, {
+      children: cosHyperlink,
+    })
+  }
+
+  return cosHyperlink
 }
 
 export const renderCloseButton = (handleClose: () => void) => {

--- a/packages/cube-frontend-web-app/src/api/cosApi.ts
+++ b/packages/cube-frontend-web-app/src/api/cosApi.ts
@@ -17,6 +17,7 @@ import {
   SupportFilesApi,
   TriggersApi,
   GrafanaApi,
+  NotificationsApi,
 } from '@cube-frontend/api'
 import {
   devAccessTokenRequestInterceptor,
@@ -79,6 +80,7 @@ export const licenseApi = createApiInstance(LicensesApi)
 export const supportFilesApi = createApiInstance(SupportFilesApi)
 export const triggersApi = createApiInstance(TriggersApi)
 export const grafanaApi = createApiInstance(GrafanaApi)
+export const notificationsApi = createApiInstance(NotificationsApi)
 
 if (import.meta.env.DEV) {
   cosApi.interceptors.request.use(devAccessTokenRequestInterceptor)

--- a/packages/cube-frontend-web-app/src/hooks/usePollNotifications/mockI18n.ts
+++ b/packages/cube-frontend-web-app/src/hooks/usePollNotifications/mockI18n.ts
@@ -1,0 +1,27 @@
+import { get } from 'lodash'
+import en from './mockI18n_en.json'
+
+export const mockI18n = (
+  path: string,
+  args?: Record<string, unknown>,
+): string => {
+  const raw = get(en, path)
+
+  if (raw === undefined) {
+    console.warn(`${path} is not a valid path`)
+    return path
+  } else if (typeof raw !== 'string') {
+    console.warn(`${path} is not a string`)
+    return path
+  }
+
+  if (!args) return raw
+
+  let interpolated = raw
+  Object.entries(args).forEach(([key, value]) => {
+    const regex = new RegExp(`{{${key}}}`, 'g')
+    interpolated = interpolated.replace(regex, String(value))
+  })
+
+  return interpolated
+}

--- a/packages/cube-frontend-web-app/src/hooks/usePollNotifications/mockI18n_en.json
+++ b/packages/cube-frontend-web-app/src/hooks/usePollNotifications/mockI18n_en.json
@@ -1,0 +1,60 @@
+{
+  "notifications": {
+    "DEV00001I": {
+      "title": "Device added successfully.",
+      "message": "Successfully added device {{device}} to {{node}}."
+    },
+    "DEV00001E": {
+      "title": "Failed to add device.",
+      "message": "Failed to add device {{device}} to {{node}}."
+    },
+    "DEV00002I": {
+      "title": "Device promoted successfully.",
+      "message": "Successfully promoted device {{device}} in {{node}}."
+    },
+    "DEV00002E": {
+      "title": "Failed to promote device.",
+      "message": "Failed to promote device {{device}} in {{node}}."
+    },
+    "DEV00003I": {
+      "title": "Device demoted successfully.",
+      "message": "Successfully demoted {{device}} in {{node}}."
+    },
+    "DEV00003E": {
+      "title": "Failed to demote device.",
+      "message": "Failed to demote device {{device}} in {{node}}."
+    },
+    "DEV00004I": {
+      "title": "Device removed successfully.",
+      "message": "Successfully removed device {{device}} from {{node}}."
+    },
+    "DEV00004E": {
+      "title": "Failed to remove device.",
+      "message": "Failed to remove device {{device}} from {{node}}."
+    },
+    "OSD00001I": {
+      "title": "OSD restarted successfully.",
+      "message": "Successfully restarted OSD {{osd}} in {{node}}."
+    },
+    "OSD00001E": {
+      "title": "Failed to restart OSD.",
+      "message": "Failed to restart OSD {{osd}} in {{node}}."
+    },
+    "OSD00002I": {
+      "title": "OSD reweighted successfully.",
+      "message": "Successfully reweighted OSD {{osd}} in {{node}}."
+    },
+    "OSD00002E": {
+      "title": "Failed to reweight OSD.",
+      "message": "Failed to reweight OSD {{osd}} in {{node}}."
+    },
+    "OSD00003I": {
+      "title": "OSD removed successfully.",
+      "message": "Successfully removed OSD {{osd}} from {{node}}."
+    },
+    "OSD00003E": {
+      "title": "Failed to remove OSD.",
+      "message": "Failed to remove OSD {{osd}} from {{node}}."
+    }
+  }
+}

--- a/packages/cube-frontend-web-app/src/hooks/usePollNotifications/pollNotificationUtils.ts
+++ b/packages/cube-frontend-web-app/src/hooks/usePollNotifications/pollNotificationUtils.ts
@@ -1,0 +1,44 @@
+import { GetDataCentersResponseDataInner } from '@cube-frontend/api'
+import dayjs from 'dayjs'
+
+export const computeLastNotificationTimeLocalStorageKey = (
+  username: string,
+  dataCenterName: string,
+): string => {
+  return `${username}-${dataCenterName}-last-notification-time`
+}
+
+const getLastNotificationTime = (
+  username: string,
+  dataCenterName: string,
+): dayjs.Dayjs | null => {
+  const key = computeLastNotificationTimeLocalStorageKey(
+    username,
+    dataCenterName,
+  )
+  const time = localStorage.getItem(key)
+  const dateTime = dayjs(time)
+  if (!time || !dateTime.isValid()) {
+    return null
+  }
+  return dateTime
+}
+
+export const computeStartFrom = (
+  username: string,
+  dataCenter: GetDataCentersResponseDataInner,
+): string => {
+  const lastNotificationTime = getLastNotificationTime(
+    username,
+    dataCenter.name,
+  )
+  const now = dayjs.utc().utcOffset(dataCenter.utcTimeZone)
+
+  if (!lastNotificationTime || now.diff(lastNotificationTime, 'hours') > 6) {
+    // Only show notifications from the past 6 hours.
+    return now.subtract(6, 'hours').format()
+  }
+
+  // Add 1 second to avoid the last notification from being returned by the API again.
+  return lastNotificationTime.add(1, 'second').format()
+}

--- a/packages/cube-frontend-web-app/src/hooks/usePollNotifications/pollNotificationUtils.ts
+++ b/packages/cube-frontend-web-app/src/hooks/usePollNotifications/pollNotificationUtils.ts
@@ -16,8 +16,8 @@ const getLastNotificationTime = (
     username,
     dataCenterName,
   )
-  const time = localStorage.getItem(key)
-  const dateTime = dayjs(time)
+  const time = localStorage.getItem(key) ?? ''
+  const dateTime = dayjs.respectTzOffset(time)
   if (!time || !dateTime.isValid()) {
     return null
   }

--- a/packages/cube-frontend-web-app/src/hooks/usePollNotifications/usePollNotifications.ts
+++ b/packages/cube-frontend-web-app/src/hooks/usePollNotifications/usePollNotifications.ts
@@ -1,0 +1,110 @@
+import {
+  GetDataCentersResponseDataInner,
+  Notification,
+} from '@cube-frontend/api'
+import { CosNotificationType, useToast } from '@cube-frontend/ui-library'
+import { UserContext } from '@cube-frontend/web-app/context/UserContext'
+import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
+import dayjs from 'dayjs'
+import { noop, uniqueId } from 'lodash'
+import { createElement, useContext } from 'react'
+import { Link } from 'react-router'
+import { notificationsApi } from '../../api/cosApi'
+import { DataCenterContext } from '../../context/DataCenterContext'
+import { useSequentialInterval } from '../useSequentialInterval/useSequentialInterval'
+import { mockI18n } from './mockI18n'
+import {
+  computeLastNotificationTimeLocalStorageKey,
+  computeStartFrom,
+} from './pollNotificationUtils'
+
+const createId = (): string => {
+  return uniqueId('cos-notification')
+}
+
+export const usePollNotifications = (): void => {
+  const { userInfo } = useContext(UserContext)
+  const { dataCenter } = useContext(DataCenterContext)
+
+  const { addToast } = useToast()
+
+  const pollAndShow = async (): Promise<void> => {
+    const username = userInfo?.name
+    if (!username || !dataCenter) return
+
+    const notifications = await getNotifications(username, dataCenter)
+    notifications.forEach(showNotification)
+
+    const lastNotification: Notification | undefined =
+      notifications[notifications.length - 1]
+
+    if (lastNotification) {
+      const key = computeLastNotificationTimeLocalStorageKey(
+        username,
+        dataCenter.name,
+      )
+      localStorage.setItem(key, lastNotification.time)
+    }
+  }
+
+  const getNotifications = async (
+    username: string,
+    dataCenter: GetDataCentersResponseDataInner,
+  ): Promise<Notification[]> => {
+    const start = computeStartFrom(username, dataCenter)
+    try {
+      const {
+        data: { data: notifications },
+      } = await notificationsApi.getNotifications({
+        dataCenter: dataCenter.name,
+        start,
+      })
+      return notifications
+    } catch (error) {
+      console.error('Get notifications error: ', error)
+      throw error
+    }
+  }
+
+  const showNotification = (notification: Notification): void => {
+    const notificationId = notification.id
+    const type: CosNotificationType = notificationId.endsWith('I')
+      ? 'positive'
+      : 'neutral'
+    addToast({
+      id: createId(),
+      type,
+      title: mockI18n(`notifications.${notificationId}.title`),
+      message: mockI18n(
+        `notifications.${notificationId}.message`,
+        getI18nArgs(notification),
+      ),
+      link: {
+        Container: createElement(Link, {
+          to: CosRoutesEnum.NODE_DETAIL_PAGE(notification.nodeName),
+        }),
+        text: 'Check',
+        onClick: noop,
+      },
+      time: dayjs.respectTzOffset(notification.time).format('HH:mm:ss A'),
+    })
+  }
+
+  useSequentialInterval(pollAndShow, 3000)
+}
+
+const getI18nArgs = (notification: Notification): Record<string, unknown> => {
+  const { nodeName, additionalInfo } = notification
+
+  const args: Record<string, unknown> = { node: nodeName }
+
+  if ('device' in additionalInfo) {
+    args.device = additionalInfo.device
+  }
+
+  if ('osdId' in additionalInfo) {
+    args.osd = additionalInfo.osdId
+  }
+
+  return args
+}

--- a/packages/cube-frontend-web-app/src/hooks/useSequentialInterval/useSequentialInterval.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useSequentialInterval/useSequentialInterval.ts
@@ -49,7 +49,11 @@ export const useSequentialInterval = (
     }
 
     if (immediate) {
-      sequentialRun()
+      // Wrap immediate sequential run in a 0ms timeout to correctly stop the
+      // first run in strict mode.
+      firstRunTimerIdRef.current = setTimeout(() => {
+        sequentialRun()
+      }, 0)
     } else {
       firstRunTimerIdRef.current = setTimeout(() => {
         sequentialRun()

--- a/packages/cube-frontend-web-app/src/layout/Layout.tsx
+++ b/packages/cube-frontend-web-app/src/layout/Layout.tsx
@@ -11,6 +11,7 @@ import { useSidebarBottomLinks } from './useSidebarBottomLinks'
 import { useSideBarNagging } from './useSideBarNagging'
 import { useSidebarOptions } from './useSidebarOptions'
 import { IntegrationKey, integrationUIData } from '../utils/integration'
+import { usePollNotifications } from '../hooks/usePollNotifications/usePollNotifications'
 
 const Layout = (props: PropsWithChildren) => {
   const { children } = props
@@ -47,6 +48,8 @@ const Layout = (props: PropsWithChildren) => {
   })
 
   const functionBarItems = useFunctionBarItems()
+
+  usePollNotifications()
 
   return (
     <div className="h-svh min-w-full overflow-hidden bg-scene-background">


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Poll and show notifications.

#### Which issue(s) this PR fixes

Fixes https://github.com/bigstack-oss/cubecos/issues/235

#### Special notes for your reviewer

1. Currently notifications can only be generated through device and OSD related operations.
2. Access the [getNotifications API](https://10.32.45.10/api/v1/datacenters/control/apidocs/index.html#/Notifications/getNotifications) with `start` or `past` parameters to view existing notifications.
3. Notifications are currently limited to the past 6 hours on the frontend. This is to prevent an overwhelming number of toasts for users who haven't logged in recently (suggested by the backend developer who got the idea from AWS).
4. Notification IDs follow the event ID naming convention of COS:
   - `OSD00001I`: "I" indicates "info" for successful or info messages.
   - `OSD00001E`: "E" indicates "error" for failed messages.

#### Additional documentation

- UI data reference (for toast title and message): https://docs.google.com/spreadsheets/d/196Xy8s6K4PcvpJjQIxX4VAFQzI_ETY2DTbOAODT7AaY/edit?gid=1674446536#gid=1674446536

https://github.com/user-attachments/assets/4260520c-5c79-467c-97e2-9bdd12a2f6ea
