### PR TITLE
feat(web-app): add support for request cancellation in the useCosGetRequest hook

### DIFF
--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosGetRequestUtils.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosGetRequestUtils.ts
@@ -1,4 +1,5 @@
 import { AxiosResponse, HttpStatusCode } from 'axios'
+import { UseCosGetRequest } from './useCosGetRequest'
 
 export type CosGetApiRequest<T> = () => Promise<CosGetApiResponse<T>>
 
@@ -10,3 +11,7 @@ export type CosGetApiInnerResponse<T> = {
   status: string
   data: T
 }
+
+export type CosGetRequestMiddleware = <Data>(
+  getRequestHook: UseCosGetRequest<Data>,
+) => UseCosGetRequest<Data>

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosRequestUtils.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/cosRequestUtils.ts
@@ -1,4 +1,4 @@
-import { HttpStatusCode } from 'axios'
+import { HttpStatusCode, isCancel } from 'axios'
 import { isObject } from 'lodash'
 import { CosGetApiResponse } from './cosGetRequestUtils'
 import { CosMutationApiResponse } from './cosMutationRequestUtils'
@@ -47,5 +47,19 @@ export const getNativeError = (error: unknown): Error => {
     return new Error(JSON.stringify(error))
   } catch {
     return new Error(String(error))
+  }
+}
+
+/**
+ * Executes a promise and suppresses any errors that occur.
+ */
+export const silentPromise = async (
+  callback: () => Promise<unknown>,
+): Promise<void> => {
+  try {
+    await callback()
+  } catch (error) {
+    if (isCancel(error)) return
+    console.error(error)
   }
 }

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/getRequestMiddlewares/fetchOnMount.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/getRequestMiddlewares/fetchOnMount.ts
@@ -1,0 +1,20 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { useEffect } from 'react'
+import type { CosGetRequestMiddleware } from '../cosGetRequestUtils'
+import { isNullish, silentPromise } from '../cosRequestUtils'
+
+export const fetchOnMount: CosGetRequestMiddleware = (getRequestHook) => {
+  const { getResource, getParam } = getRequestHook
+
+  useEffect(() => {
+    if (!getParam || !isNullish(getParam())) {
+      silentPromise(getResource)
+    }
+    // `getParam` is intentionally omitted from the dependency array because
+    // its reference changes on every render, and this middleware is designed
+    // to fetch data only once when on mount.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [getResource])
+
+  return getRequestHook
+}

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/getRequestMiddlewares/fetchOnParamChanges.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/getRequestMiddlewares/fetchOnParamChanges.ts
@@ -1,0 +1,37 @@
+/* eslint-disable react-hooks/rules-of-hooks */
+import { isEqual } from 'lodash'
+import { useEffect, useRef } from 'react'
+import type { CosGetRequestMiddleware } from '../cosGetRequestUtils'
+import { isNullish, Nullish, silentPromise } from '../cosRequestUtils'
+import type { UseCosGetRequest } from '../useCosGetRequest'
+
+export const fetchOnParamChanges: CosGetRequestMiddleware = <Data>(
+  getRequestHook: UseCosGetRequest<Data>,
+) => {
+  const { getResource, getParam } = getRequestHook
+
+  const prevParamRef = useRef<Nullish<unknown>>(undefined)
+  // Since `getParam` might return `undefined`, we use this ref to explicitly
+  // track whether prev param has been initialized.
+  const isPrevParamInitializedRef = useRef(false)
+
+  useEffect(() => {
+    if (!isPrevParamInitializedRef.current) {
+      prevParamRef.current = getParam?.()
+      isPrevParamInitializedRef.current = true
+      return
+    }
+
+    const newParam = getParam?.()
+    const isParamChanged =
+      !isNullish(newParam) && !isEqual(prevParamRef.current, newParam)
+
+    if (isParamChanged) {
+      silentPromise(getResource)
+    }
+
+    prevParamRef.current = newParam
+  }, [getParam, getResource])
+
+  return getRequestHook
+}

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosGetRequest.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosGetRequest.ts
@@ -1,8 +1,13 @@
 import { useSyncedRef } from '@cube-frontend/utils'
-import { isEqual } from 'lodash'
-import { useCallback, useEffect, useRef } from 'react'
-import { CosGetApiResponse } from './cosGetRequestUtils'
-import { GetParamFn, isNullish, Nullish } from './cosRequestUtils'
+import { RawAxiosRequestConfig } from 'axios'
+import { useCallback, useEffect } from 'react'
+import {
+  CosGetApiResponse,
+  CosGetRequestMiddleware,
+} from './cosGetRequestUtils'
+import { GetParamFn, Nullish } from './cosRequestUtils'
+import { fetchOnMount } from './getRequestMiddlewares/fetchOnMount'
+import { fetchOnParamChanges } from './getRequestMiddlewares/fetchOnParamChanges'
 import {
   INTERNAL_useCosRequestHandler,
   UseCosRequestHandler,
@@ -10,12 +15,19 @@ import {
 
 export type UseCosGetRequest<Data> = Omit<
   UseCosRequestHandler<Data>,
-  'oversee'
+  'abortControllerRef' | 'oversee'
 > & {
+  /**
+   * The reference of this function is stable.
+   */
   getResource: () => Promise<Data>
+  /**
+   * The reference of this function is unstable.
+   */
+  getParam: GetParamFn<unknown> | undefined
 }
 
-export type UseCosGetRequestOptions = {
+type UseCosGetRequestOptions = {
   /**
    * Whether to automatically fetch data on component mount.
    * @default true
@@ -28,8 +40,13 @@ export type UseCosGetRequestOptions = {
   fetchOnParamChanges?: boolean
 }
 
-type NullaryRequest<T> = () => Promise<CosGetApiResponse<T>>
-type UnaryRequest<T, Param> = (param: Param) => Promise<CosGetApiResponse<T>>
+type NullaryRequest<T> = (
+  config?: RawAxiosRequestConfig,
+) => Promise<CosGetApiResponse<T>>
+type UnaryRequest<T, Param> = (
+  param: Param,
+  config?: RawAxiosRequestConfig,
+) => Promise<CosGetApiResponse<T>>
 
 type UseCosGetRequestHook = {
   <Data>(
@@ -51,93 +68,87 @@ export const useCosGetRequest: UseCosGetRequestHook = <Data, Param>(
    * Dynamic request functions are discouraged and not supported.
    */
   request: NullaryRequest<Data> | UnaryRequest<Data, Param>,
-  getParamOrOptions?: GetParamFn<Param> | UseCosGetRequestOptions,
+  optionsOrGetParam?: UseCosGetRequestOptions | GetParamFn<Param>,
   options?: UseCosGetRequestOptions,
 ) => {
-  const { fetchOnMount = true, fetchOnParamChanges = true } =
-    ((options ?? getParamOrOptions) as UseCosGetRequestOptions | undefined) ??
+  const {
+    fetchOnMount: fetchOnMountOption = true,
+    fetchOnParamChanges: fetchOnParamChangesOption = true,
+  } =
+    ((options ?? optionsOrGetParam) as UseCosGetRequestOptions | undefined) ??
     {}
 
-  const computeGetParamFn = useCallback((): GetParamFn<Param> | undefined => {
-    if (typeof getParamOrOptions === 'function') {
-      return getParamOrOptions
-    } else {
-      return undefined
-    }
-  }, [getParamOrOptions])
-
-  const isMountedRef = useRef(false)
-  const getParamFnRef = useSyncedRef<GetParamFn<Param> | undefined>(
-    computeGetParamFn(),
-  )
-  const prevParamRef = useRef<Nullish<Param>>(undefined)
-
-  const { oversee, ...requestHandlerAttrs } =
+  const { abortControllerRef, oversee, ...requestHandlerAttrs } =
     INTERNAL_useCosRequestHandler<Data>({
       defaultIsLoading: true,
     })
 
+  const getGetParamFn = (): GetParamFn<Param> | undefined => {
+    if (typeof optionsOrGetParam === 'function') {
+      return optionsOrGetParam
+    }
+    return undefined
+  }
+
+  const getMiddlewares = (): CosGetRequestMiddleware[] => {
+    const middlewares: CosGetRequestMiddleware[] = []
+
+    if (fetchOnMountOption) {
+      middlewares.push(fetchOnMount)
+    }
+
+    if (fetchOnParamChangesOption) {
+      middlewares.push(fetchOnParamChanges)
+    }
+
+    return middlewares
+  }
+
+  const getParamFnRef = useSyncedRef<GetParamFn<Param> | undefined>(
+    getGetParamFn(),
+  )
+
   // Dynamic request functions are discouraged and not supported.
   const getResource = useCallback((): Promise<Data> => {
+    // Abort the previous request.
+    abortControllerRef.current.abort()
+    // Create a new abort controller for the next request.
+    abortControllerRef.current = new AbortController()
+
     const getParamFn = getParamFnRef.current
+    const config: RawAxiosRequestConfig = {
+      signal: abortControllerRef.current.signal,
+    }
+
     if (getParamFn) {
-      return oversee(() => request(getParamFn() as Param))
+      return oversee(() =>
+        (request as UnaryRequest<Data, Param>)(getParamFn() as Param, config),
+      )
     } else {
-      return oversee(() => (request as NullaryRequest<Data>)())
+      return oversee(() => (request as NullaryRequest<Data>)(config))
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 
-  const silentGetResource = useCallback(async (): Promise<void> => {
-    try {
-      await getResource()
-    } catch (error) {
-      // Ignore auto-fetch errors because they can't be caught
-      // unless an error boundary is used.
-      console.error(error)
-    }
-  }, [getResource])
-
-  // Effect for getting resource on param changes.
+  // Abort request on unmount.
   useEffect(() => {
-    if (isMountedRef.current && fetchOnParamChanges) {
-      const newParam = getParamFnRef.current?.()
-      if (!isNullish(newParam) && !isEqual(prevParamRef.current, newParam)) {
-        silentGetResource()
-      }
-      prevParamRef.current = newParam
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [fetchOnParamChanges, computeGetParamFn])
-
-  // Effect for getting resource on mount.
-  useEffect(() => {
-    if (!isMountedRef.current) {
-      isMountedRef.current = true
-      if (fetchOnMount) {
-        const getParamFn = getParamFnRef.current
-        if (getParamFn) {
-          const param = getParamFn()
-          if (!isNullish(param)) {
-            silentGetResource()
-          }
-          prevParamRef.current = param
-        } else {
-          silentGetResource()
-        }
-      }
-    }
-
     return () => {
-      // Reset `isMounted` back to `false` for Strict Mode, as another effect
-      // for getting resource on param changes relies on this flag.
-      isMountedRef.current = false
+      abortControllerRef.current.abort()
+      // Create a new abort controller for StrictMode.
+      abortControllerRef.current = new AbortController()
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [abortControllerRef])
 
-  return {
+  const returnValue: ReturnType<UseCosGetRequestHook> = {
     ...requestHandlerAttrs,
     getResource,
+    getParam: getGetParamFn(),
   }
+
+  getMiddlewares()?.reduce(
+    (prevReturn, middleware) => middleware(prevReturn),
+    returnValue,
+  )
+
+  return returnValue
 }

--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosRequestHandler.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosRequestHandler.ts
@@ -1,5 +1,5 @@
-import { isAxiosError } from 'axios'
-import { useCallback, useState } from 'react'
+import { isAxiosError, isCancel } from 'axios'
+import { RefObject, useCallback, useRef, useState } from 'react'
 import { CosGetApiRequest } from './cosGetRequestUtils'
 import { CosMutationApiRequest } from './cosMutationRequestUtils'
 import {
@@ -17,6 +17,7 @@ export type UseCosRequestHandler<Data> = {
   hasResponseBeenReceived: boolean
   data: Data | undefined
   errorState: CosRequestError | undefined
+  abortControllerRef: RefObject<AbortController>
   oversee: (
     request: CosGetApiRequest<Data> | CosMutationApiRequest<Data>,
   ) => Promise<Data>
@@ -37,6 +38,8 @@ export const INTERNAL_useCosRequestHandler = <Data>(
   const [data, setData] = useState<Data | undefined>()
   const [errorState, setErrorState] = useState<CosRequestError | undefined>()
 
+  const abortControllerRef = useRef(new AbortController())
+
   const oversee = async (
     request: CosGetApiRequest<Data> | CosMutationApiRequest<Data>,
   ): Promise<Data> => {
@@ -47,6 +50,7 @@ export const INTERNAL_useCosRequestHandler = <Data>(
       const response = await request()
       setData(response.data.data)
       setHasResponseBeenReceived(true)
+      setIsLoading(false)
       return response.data.data as Data
     } catch (error) {
       if (isAxiosError(error) && isCosApiResponse(error.response)) {
@@ -67,17 +71,16 @@ export const INTERNAL_useCosRequestHandler = <Data>(
         setData(undefined)
 
         throw nextErrorState
-      } else {
+      } else if (!isCancel(error)) {
         setErrorState({
           native: getNativeError(error),
           api: undefined,
         })
         setData(undefined)
+        setIsLoading(false)
       }
 
       throw error
-    } finally {
-      setIsLoading(false)
     }
   }
 
@@ -90,6 +93,7 @@ export const INTERNAL_useCosRequestHandler = <Data>(
     hasResponseBeenReceived,
     data,
     errorState,
+    abortControllerRef,
     oversee,
     clearError,
   }


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Add support for request cancellation in the `useCosGetRequest` hook.

#### Which issue(s) this PR fixes

Fixes #193

#### Special notes for your reviewer

The logic for fetching on mount and on parameter changes has been refactored from a combined approach into a separate middleware pattern for better readability and maintainability.

- Before: Multiple ongoing requests made with the same `useCosGetRequest` instance are all active, causing UI data to be overridden randomly.

   https://github.com/user-attachments/assets/ebfe7f1d-d2cf-4fd3-8cfd-8faac5d001e0

- After: When multiple requests are made with the same `useCosGetRequest` instance, only the most recent one is kept. All previous requests are canceled to ensure the UI only displays the latest data.

   https://github.com/user-attachments/assets/f42ad27c-db48-4eee-83b9-fcc4f89a5d3a

