### PR TITLE
fix: loading skeleton not shown during first load

### DIFF
--- a/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosRequestHandler.ts
+++ b/packages/cube-frontend-web-app/src/hooks/useCosRequest/useCosRequestHandler.ts
@@ -50,6 +50,7 @@ export const INTERNAL_useCosRequestHandler = <Data>(
       const response = await request()
       setData(response.data.data)
       setHasResponseBeenReceived(true)
+      setIsLoading(false)
       return response.data.data as Data
     } catch (error) {
       if (isAxiosError(error) && isCosApiResponse(error.response)) {
@@ -68,6 +69,7 @@ export const INTERNAL_useCosRequestHandler = <Data>(
 
         setErrorState(nextErrorState)
         setData(undefined)
+        setIsLoading(false)
 
         throw nextErrorState
       } else if (!isCancel(error)) {
@@ -76,11 +78,10 @@ export const INTERNAL_useCosRequestHandler = <Data>(
           api: undefined,
         })
         setData(undefined)
+        setIsLoading(false)
       }
 
       throw error
-    } finally {
-      setIsLoading(false)
     }
   }
 


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it

Loading skeleton not shown during first load.

Problem Screen Record:

https://github.com/user-attachments/assets/dde129aa-9b1f-4842-a7b3-41ff87f34cc9

Fixed Screen Record:

https://github.com/user-attachments/assets/6640c180-a18f-46d4-b307-16eebf7a9349


#### Special notes for your reviewer

Root Cause:

Since the [React StrictMode](https://react.dev/reference/react/StrictMode) runs an extra setup+cleanup cycle for every Effect, the extra setup will executes `getResource` again and aborts previous fetch. Because the cancel error is caught in the  `next tick`, it overrides loading state to false.

<img width="1629" height="904" alt="Screenshot 2025-08-12 at 4 57 40 PM" src="https://github.com/user-attachments/assets/48e830b2-34b0-4137-9f4e-347713a6b862" />

<img width="937" height="337" alt="image" src="https://github.com/user-attachments/assets/0b6c615f-1cdc-4921-8961-ba2ef6f0b9c0" />

Solution:

Since `cancel` is only executed on `unMount` or `refetch`, it's fine not to set the loading state to false.
