### PR TITLE
feat: 582 health details add time bar drag hint

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosTooltip/CosTooltip.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosTooltip/CosTooltip.tsx
@@ -98,12 +98,13 @@ export const CosTooltip = (props: CosTooltipProps) => {
     <>
       {clonedAnchor}
       {visibilityState !== undefined &&
+        infoMap[visibilityState] &&
         createPortal(
           <InfoBox
             // Assign a key to remount the InfoBox to prevent layout shifts
             // when switching from hover content to click content.
             key={visibilityState}
-            information={infoMap[visibilityState]!}
+            information={infoMap[visibilityState]}
             placement={placement}
             mouseX={mouseX}
             anchorRef={anchorRef}

--- a/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthTimeBar/HealthBrushTimeBar.tsx
+++ b/packages/cube-frontend-web-app/src/pages/home/health/[module]/HealthTimeBar/HealthBrushTimeBar.tsx
@@ -1,12 +1,14 @@
 import { GetModuleHealthHistoryResponseDataHistoryInner } from '@cube-frontend/api'
+import { CosTooltip, CosTooltipInformation } from '@cube-frontend/ui-library'
+import { cubeTheme } from '@cube-frontend/ui-theme'
 import {
   BrushFilter,
   DateTimeRange,
 } from '@cube-frontend/web-app/components/HealthSegmentedBar/BrushFilter'
 import { HealthSegmentedBar } from '@cube-frontend/web-app/components/HealthSegmentedBar/HealthSegmentedBar'
-import { TIME_AXIS_HEIGHT, TimeAxis } from './TimeAxis'
+import { useEffect, useState } from 'react'
 import { HealthIndicators } from './HealthIndicators'
-import { cubeTheme } from '@cube-frontend/ui-theme'
+import { TIME_AXIS_HEIGHT, TimeAxis } from './TimeAxis'
 
 export type HealthBrushTimeBarProps = {
   paddingX: number
@@ -19,6 +21,10 @@ export type HealthBrushTimeBarProps = {
 const INDICATOR_SIZE = 7
 const BAR_PADDING_Y = 20
 
+const HOVER_CONTENT = {
+  message: 'Drag to limit visible data points',
+} satisfies CosTooltipInformation
+
 export const HealthBrushTimeBar = (props: HealthBrushTimeBarProps) => {
   const {
     paddingX,
@@ -28,45 +34,62 @@ export const HealthBrushTimeBar = (props: HealthBrushTimeBarProps) => {
     onBrushDateTimeRangeChange,
   } = props
 
+  const [showDragHint, setShowDragHint] = useState(true)
+
+  // Hide the drag hint after the brush range has been activated once.
+  useEffect(() => {
+    if (brushDateTimeRange) {
+      setShowDragHint(false)
+    }
+  }, [brushDateTimeRange])
+
   return (
-    <HealthSegmentedBar
-      history={history ?? []}
-      dateTimeRange={dateTimeRange}
-      paddingX={paddingX}
-      barMarginTop={BAR_PADDING_Y}
-      childrenDimensions={{
-        height: TIME_AXIS_HEIGHT,
-        marginTop: BAR_PADDING_Y,
-      }}
-      overlay={(width, height, segments) => (
-        <>
-          <line
-            x1={0}
-            x2={width}
-            strokeWidth={2}
-            stroke={cubeTheme.colors.functional['border-divider']}
-          />
-          <g transform={`translate(0, ${BAR_PADDING_Y - INDICATOR_SIZE} )`}>
-            <HealthIndicators
-              segments={segments}
-              dateTimeRange={dateTimeRange}
-              xRange={[0, width]}
-              size={INDICATOR_SIZE}
-            />
-          </g>
-          <BrushFilter
-            width={width}
-            height={height - TIME_AXIS_HEIGHT}
-            dateTimeRange={dateTimeRange}
-            selectedDateTimeRange={brushDateTimeRange}
-            onSelectedDateTimeRangeChange={onBrushDateTimeRangeChange}
-          />
-        </>
-      )}
+    <CosTooltip
+      hoverContent={showDragHint ? HOVER_CONTENT : undefined}
+      placement="top-follow-cursor"
     >
-      {(width) => (
-        <TimeAxis dateTimeRange={dateTimeRange} xRange={[0, width]} />
-      )}
-    </HealthSegmentedBar>
+      {/* Add a div wrapper to make the tooltip display correctly. */}
+      <div>
+        <HealthSegmentedBar
+          history={history ?? []}
+          dateTimeRange={dateTimeRange}
+          paddingX={paddingX}
+          barMarginTop={BAR_PADDING_Y}
+          childrenDimensions={{
+            height: TIME_AXIS_HEIGHT,
+            marginTop: BAR_PADDING_Y,
+          }}
+          overlay={(width, height, segments) => (
+            <>
+              <line
+                x1={0}
+                x2={width}
+                strokeWidth={2}
+                stroke={cubeTheme.colors.functional['border-divider']}
+              />
+              <g transform={`translate(0, ${BAR_PADDING_Y - INDICATOR_SIZE} )`}>
+                <HealthIndicators
+                  segments={segments}
+                  dateTimeRange={dateTimeRange}
+                  xRange={[0, width]}
+                  size={INDICATOR_SIZE}
+                />
+              </g>
+              <BrushFilter
+                width={width}
+                height={height - TIME_AXIS_HEIGHT}
+                dateTimeRange={dateTimeRange}
+                selectedDateTimeRange={brushDateTimeRange}
+                onSelectedDateTimeRangeChange={onBrushDateTimeRangeChange}
+              />
+            </>
+          )}
+        >
+          {(width) => (
+            <TimeAxis dateTimeRange={dateTimeRange} xRange={[0, width]} />
+          )}
+        </HealthSegmentedBar>
+      </div>
+    </CosTooltip>
   )
 }


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Why

We need to hint to the user that  the second health bar can be dragged to filter health events using the brush.

Solution

1.) Add a hover tooltip to inform the user that they can drag the filter brush.
2.) Hide the hover tooltip after the user dragged the filter brush, until browser is reloaded or the Health Details Page is revisited.

Screenshot

https://github.com/user-attachments/assets/0b24f074-97f2-4c3b-b50d-6fd29b8fc511

#### Which issue(s) this PR fixes

Fixes #582