### PR TITLE
feat: 623 show an empty screen before retrieving the user authentication status

### DIFF
--- a/packages/cube-frontend-web-app/src/App.tsx
+++ b/packages/cube-frontend-web-app/src/App.tsx
@@ -19,7 +19,6 @@ import './tailwind.css'
 
 function App() {
   return (
-    // TODO: inject global css, setup global store here.
     <DataCenterProvider>
       <UserContextProvider>
         <ApplicationIntegrationsContextProvider>

--- a/packages/cube-frontend-web-app/src/layout/Layout.tsx
+++ b/packages/cube-frontend-web-app/src/layout/Layout.tsx
@@ -60,6 +60,17 @@ const Layout = (props: PropsWithChildren) => {
 
   usePollNotifications()
 
+  /**
+   * The UI should display an empty screen until the user's authentication status is confirmed,
+   * instead of showing the header and sidebar skeletons, since users may have security concerns.
+   *
+   * The token is cookie-based, so the UI cannot access its expiration time in the browser.
+   * We can only rely on the `userInfoApi.getMe` response to determine the user's authentication status.
+   */
+  if (!userInfo) {
+    return null
+  }
+
   return (
     <div className="h-svh min-w-full overflow-hidden bg-scene-background">
       <div className="flex h-svh flex-row">


### PR DESCRIPTION
feat: 623 show an empty screen before retrieving the user authentication status

#### What type of PR is this?

feat

#### What this PR does / why we need it

The UI should display an empty screen until the user's authentication status is confirmed,
instead of showing the header and sidebar skeletons, since users may have security concerns.

The token is cookie-based, so the UI cannot access its expiration time in the browser.
We can only rely on the `userInfoApi.getMe` response to determine the user's authentication status.

#### Which issue(s) this PR fixes

Fixes #623

#### Screen Recording

https://github.com/user-attachments/assets/318523ff-bd8f-40f3-9bfa-692392851f87
