### PR TITLE
618 feat(web-app): maintenance update page firmware list

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosPanel/CosGeneralPanel/CosGeneralPanel.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosPanel/CosGeneralPanel/CosGeneralPanel.tsx
@@ -11,6 +11,7 @@ import {
 
 export type CosGeneralPanelContentProps = PropsWithChildren &
   PropsWithClassName & {
+    containerClassName?: string
     topic?: string
     button?: React.ReactElement<CosButtonProps>
     icon?: React.ReactNode
@@ -23,6 +24,7 @@ export const CosGeneralPanel = (props: CosGeneralPanelContentProps) => {
   const {
     children,
     className: classNameProps,
+    containerClassName,
     topic,
     button,
     icon,
@@ -59,7 +61,7 @@ export const CosGeneralPanel = (props: CosGeneralPanelContentProps) => {
   }
 
   return (
-    <CosGeneralPanelContainer>
+    <CosGeneralPanelContainer className={containerClassName}>
       {titleBarProps && <CosGeneralPanelTitleBar {...titleBarProps} />}
       <div
         className={twMerge(

--- a/packages/cube-frontend-web-app/src/CosRoutes.tsx
+++ b/packages/cube-frontend-web-app/src/CosRoutes.tsx
@@ -28,6 +28,8 @@ import { IntegrationsLayout } from './pages/integrations/IntegrationsLayout'
 import { CreateStoragePage } from './pages/integrations/storages/create/CreateStoragePage'
 import { EditStoragePage } from './pages/integrations/storages/edit/EditStoragePage'
 import { NotificationsPage } from './pages/notifications/NotificationsPage'
+import { MaintenanceUpdateFirmwarePage } from './pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage'
+import { MaintenanceUpdateFixpackPage } from './pages/maintenance/update/fixpack/MaintenanceUpdateFixpackPage'
 
 export const CosRoutes = () => {
   return (
@@ -97,6 +99,14 @@ export const CosRoutes = () => {
         <Route
           path={CosRoutesEnum.MAINTENANCE_LICENSE_PAGE}
           element={<MaintenanceLicensePage />}
+        />
+        <Route
+          path={CosRoutesEnum.MAINTENANCE_UPDATE_FIRMWARE_PAGE}
+          element={<MaintenanceUpdateFirmwarePage />}
+        />
+        <Route
+          path={CosRoutesEnum.MAINTENANCE_UPDATE_FIXPACK_PAGE}
+          element={<MaintenanceUpdateFixpackPage />}
         />
       </Route>
       <Route path={CosRoutesEnum.EVENTS_PAGE} element={<EventsLayout />}>

--- a/packages/cube-frontend-web-app/src/api/cosApi.ts
+++ b/packages/cube-frontend-web-app/src/api/cosApi.ts
@@ -4,6 +4,7 @@ import {
   Configuration,
   DataCentersApi,
   EventsApi,
+  FirmwaresApi,
   GrafanaApi,
   HealthApi,
   IntegrationsApi,
@@ -81,6 +82,7 @@ export const supportFilesApi = createApiInstance(SupportFilesApi)
 export const triggersApi = createApiInstance(TriggersApi)
 export const tuningsApi = createApiInstance(TuningsApi)
 export const userInfoApi = createApiInstance(UserInfoApi)
+export const firmwaresApi = createApiInstance(FirmwaresApi)
 
 if (import.meta.env.DEV) {
   cosApi.interceptors.request.use(devAccessTokenRequestInterceptor)

--- a/packages/cube-frontend-web-app/src/enum/routes.ts
+++ b/packages/cube-frontend-web-app/src/enum/routes.ts
@@ -26,6 +26,9 @@ export const CosRoutesEnum = {
   MAINTENANCE_TUNINGS_CREATE_PAGE: '/maintenance/tunings/create',
   MAINTENANCE_TUNINGS_EDIT_PAGE: '/maintenance/tunings/edit',
   MAINTENANCE_LICENSE_PAGE: '/maintenance/license',
+  MAINTENANCE_UPDATE_PAGE: '/maintenance/update',
+  MAINTENANCE_UPDATE_FIRMWARE_PAGE: '/maintenance/update/firmware',
+  MAINTENANCE_UPDATE_FIXPACK_PAGE: '/maintenance/update/fixpack',
   /** Events Page */
   EVENTS_PAGE: '/events',
   EVENTS_TRIGGERS_PAGE: '/events/triggers',

--- a/packages/cube-frontend-web-app/src/pages/maintenance/MaintenanceLayout.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/MaintenanceLayout.tsx
@@ -24,6 +24,11 @@ export const MaintenanceLayout = () => {
             License
           </CosTabs.Tab>
         </Link>
+        <Link to={links.updateFirmware}>
+          <CosTabs.Tab isActive={location.pathname === links.updateFirmware}>
+            Update
+          </CosTabs.Tab>
+        </Link>
       </CosTabs>
       <Outlet />
     </div>

--- a/packages/cube-frontend-web-app/src/pages/maintenance/links.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/links.ts
@@ -4,4 +4,5 @@ export const links = {
   supportFiles: CosRoutesEnum.MAINTENANCE_SUPPORT_FILES_PAGE,
   tunings: CosRoutesEnum.MAINTENANCE_TUNINGS_PAGE,
   license: CosRoutesEnum.MAINTENANCE_LICENSE_PAGE,
+  updateFirmware: CosRoutesEnum.MAINTENANCE_UPDATE_FIRMWARE_PAGE,
 }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/MaintenanceUpdateLayout.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/MaintenanceUpdateLayout.tsx
@@ -1,0 +1,74 @@
+import { CosContentSwitcher, CosGeneralPanel } from '@cube-frontend/ui-library'
+import { CosRoutesEnum } from '@cube-frontend/web-app/enum/routes'
+import dayjs from 'dayjs'
+import { ReactNode } from 'react'
+import { useLocation, useNavigate } from 'react-router'
+
+type MaintenanceUpdateLayoutProps = {
+  currentVersion: string
+  lastUpdated: string
+  children: ReactNode
+}
+
+export const MaintenanceUpdateLayout = (
+  props: MaintenanceUpdateLayoutProps,
+) => {
+  const { currentVersion, lastUpdated, children } = props
+
+  const location = useLocation()
+  const navigate = useNavigate()
+
+  // TODO: Add support for custom elements (like the <Link> component from react-router) to `CosContentSwitcherItem`
+  // for native hyperlink navigation.
+  const onContentSwitcherItemClick = (to: string): void => {
+    if (location.pathname !== to) {
+      navigate(to)
+    }
+  }
+
+  const formatLastUpdated = (): string => {
+    return dayjs.respectTzOffset(lastUpdated).format('YYYY/MM/DD HH:mm A')
+  }
+
+  return (
+    <div className="flex flex-col gap-y-4">
+      <CosGeneralPanel topic={currentVersion}>
+        <div className="flex flex-col gap-y-1">
+          <div className="primary-body4 text-functional-text-light">
+            Last Updated
+          </div>
+          <div className="primary-h5 text-functional-text">
+            {formatLastUpdated()}
+          </div>
+        </div>
+      </CosGeneralPanel>
+      <CosContentSwitcher variant="default">
+        <CosContentSwitcher.Item
+          isActive={
+            location.pathname === CosRoutesEnum.MAINTENANCE_UPDATE_FIRMWARE_PAGE
+          }
+          onClick={() =>
+            onContentSwitcherItemClick(
+              CosRoutesEnum.MAINTENANCE_UPDATE_FIRMWARE_PAGE,
+            )
+          }
+        >
+          Firmware list
+        </CosContentSwitcher.Item>
+        <CosContentSwitcher.Item
+          isActive={
+            location.pathname === CosRoutesEnum.MAINTENANCE_UPDATE_FIXPACK_PAGE
+          }
+          onClick={() =>
+            onContentSwitcherItemClick(
+              CosRoutesEnum.MAINTENANCE_UPDATE_FIXPACK_PAGE,
+            )
+          }
+        >
+          Fixpack list
+        </CosContentSwitcher.Item>
+      </CosContentSwitcher>
+      {children}
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/ReleaseNotePanel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/ReleaseNotePanel.tsx
@@ -1,0 +1,43 @@
+import { CosGeneralPanel } from '@cube-frontend/ui-library'
+import X from '@cube-frontend/ui-library/icons/monochrome/x.svg?react'
+import { LogConsole } from '@cube-frontend/web-app/components/LogConsole'
+import { cva } from 'class-variance-authority'
+
+type ReleaseNotePanelProps = {
+  isOpen: boolean
+  fallbackTitle: string
+  version?: string
+  releaseNote?: string
+  onClose: () => void
+}
+
+const panel = cva('self-end overflow-hidden transition-all duration-300', {
+  variants: {
+    isOpen: {
+      true: 'w-[480px]',
+      false: 'w-0 px-0',
+    },
+  },
+})
+
+export const ReleaseNotePanel = (props: ReleaseNotePanelProps) => {
+  const { isOpen, version, fallbackTitle, releaseNote = '', onClose } = props
+
+  return (
+    <CosGeneralPanel
+      className={panel({ isOpen })}
+      topic={version || fallbackTitle}
+      dropdown={
+        <button
+          type="button"
+          className="inline-flex size-8 cursor-pointer items-center justify-center"
+          onClick={onClose}
+        >
+          <X className="icon-md text-functional-text" />
+        </button>
+      }
+    >
+      <LogConsole>{releaseNote || 'No data'}</LogConsole>
+    </CosGeneralPanel>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/useReleaseNotePanel.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/useReleaseNotePanel.ts
@@ -1,0 +1,35 @@
+import { useState } from 'react'
+
+type UseReleaseNotePanel<T> = {
+  rowForReleaseNote: T | undefined
+  isReleaseNotePanelOpen: boolean
+  showReleaseNoteFor: (row: T) => void
+  onReleaseNotePanelClose: () => void
+  toggleReleaseNotePanel: () => void
+}
+
+export const useReleaseNotePanel = <T>(): UseReleaseNotePanel<T> => {
+  const [selectedRow, setSelectedRow] = useState<T | undefined>()
+  const [isOpen, setIsOpen] = useState(false)
+
+  const showReleaseNoteFor = (row: T): void => {
+    setSelectedRow(row)
+    setIsOpen(true)
+  }
+
+  const onReleaseNotePanelClose = (): void => {
+    setIsOpen(false)
+  }
+
+  const toggleReleaseNotePanel = (): void => {
+    setIsOpen((prev) => !prev)
+  }
+
+  return {
+    rowForReleaseNote: selectedRow,
+    isReleaseNotePanelOpen: isOpen,
+    showReleaseNoteFor,
+    onReleaseNotePanelClose,
+    toggleReleaseNotePanel,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
@@ -60,23 +60,27 @@ export const MaintenanceUpdateFirmwarePage = () => {
           }
         >
           <div className="flex flex-col gap-y-6">
-            <FirmwareTable rows={rows} isLoading={showLoading}>
+            <FirmwareTable
+              rows={rows}
+              isLoading={showLoading}
+              rowClassName="cursor-pointer"
+              onRowClick={showReleaseNoteFor}
+            >
               <FirmwareTable.Column
                 label="Firmware"
                 property="version"
                 fitContent={true}
                 emphasize={true}
               >
-                {(version, row) => (
-                  <span
-                    className="cursor-pointer whitespace-nowrap text-primary"
-                    onClick={() => showReleaseNoteFor(row)}
-                  >
-                    {version}
-                  </span>
+                {(version) => (
+                  <div className="whitespace-nowrap">{version}</div>
                 )}
               </FirmwareTable.Column>
-              <FirmwareTable.Column label="Last Updated" property="updatedAt">
+              <FirmwareTable.Column
+                label="Last Updated"
+                property="updatedAt"
+                fitContent={true}
+              >
                 {formatUpdatedAt}
               </FirmwareTable.Column>
               <FirmwareTable.Column label="Note" property="releaseNotes" />
@@ -86,8 +90,18 @@ export const MaintenanceUpdateFirmwarePage = () => {
               >
                 {() => (
                   <div className="flex items-center">
-                    <CosButton type="ghost">Update</CosButton>
-                    <CosButton type="ghost" usage="icon-only" Icon={Trash} />
+                    <CosButton
+                      type="ghost"
+                      onClick={(e) => e.stopPropagation()}
+                    >
+                      Update
+                    </CosButton>
+                    <CosButton
+                      type="ghost"
+                      usage="icon-only"
+                      Icon={Trash}
+                      onClick={(e) => e.stopPropagation()}
+                    />
                   </div>
                 )}
               </FirmwareTable.Column>

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
@@ -1,0 +1,115 @@
+import {
+  CosButton,
+  CosGeneralPanel,
+  CosPagination,
+  GetCosBasicTable,
+} from '@cube-frontend/ui-library'
+import Trash from '@cube-frontend/ui-library/icons/monochrome/delete.svg?react'
+import InformationCircle from '@cube-frontend/ui-library/icons/monochrome/information_circle.svg?react'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import dayjs from 'dayjs'
+import { useContext } from 'react'
+import { MaintenanceUpdateLayout } from '../_components/MaintenanceUpdateLayout'
+import { ReleaseNotePanel } from '../_components/ReleaseNotePanel'
+import { useReleaseNotePanel } from '../_components/useReleaseNotePanel'
+import { FirmwareRow } from './listFirmwaresUtils'
+import { useListFirmwares } from './useListFirmwares'
+import { useListFirmwaresQuery } from './useListFirmwaresQuery'
+
+const FirmwareTable = GetCosBasicTable<FirmwareRow>()
+
+export const MaintenanceUpdateFirmwarePage = () => {
+  const { dataCenter } = useContext(DataCenterContext)
+
+  const { query, onPageChange, onItemsPerPageChange } = useListFirmwaresQuery()
+
+  const { showLoading, rows, totalItemCount } = useListFirmwares(query)
+
+  const {
+    rowForReleaseNote,
+    isReleaseNotePanelOpen,
+    showReleaseNoteFor,
+    onReleaseNotePanelClose,
+    toggleReleaseNotePanel,
+  } = useReleaseNotePanel<FirmwareRow>()
+
+  const formatUpdatedAt = (updatedAt: string): string => {
+    return dayjs.respectTzOffset(updatedAt).format('YYYY/MM/DD')
+  }
+
+  return (
+    <MaintenanceUpdateLayout
+      currentVersion={dataCenter!.firmware.version}
+      lastUpdated={dataCenter!.firmware.updatedAt}
+    >
+      <div className="flex items-start gap-x-4">
+        <CosGeneralPanel
+          containerClassName="grow"
+          topic="Firmware List"
+          dropdown={
+            <div className="flex items-center gap-x-4">
+              <CosButton disabled={showLoading}>Upload PKG File</CosButton>
+              <button
+                type="button"
+                className="inline-flex size-8 cursor-pointer items-center justify-center rounded-full bg-primary-50"
+                onClick={toggleReleaseNotePanel}
+              >
+                <InformationCircle className="icon-md text-functional-text" />
+              </button>
+            </div>
+          }
+        >
+          <div className="flex flex-col gap-y-6">
+            <FirmwareTable rows={rows} isLoading={showLoading}>
+              <FirmwareTable.Column
+                label="Firmware"
+                property="version"
+                fitContent={true}
+                emphasize={true}
+              >
+                {(version, row) => (
+                  <span
+                    className="cursor-pointer whitespace-nowrap text-primary"
+                    onClick={() => showReleaseNoteFor(row)}
+                  >
+                    {version}
+                  </span>
+                )}
+              </FirmwareTable.Column>
+              <FirmwareTable.Column label="Last Updated" property="updatedAt">
+                {formatUpdatedAt}
+              </FirmwareTable.Column>
+              <FirmwareTable.Column label="Note" property="releaseNotes" />
+              <FirmwareTable.Column
+                fitContent={true}
+                skeletonVariant="icon-right"
+              >
+                {() => (
+                  <div className="flex items-center">
+                    <CosButton type="ghost">Update</CosButton>
+                    <CosButton type="ghost" usage="icon-only" Icon={Trash} />
+                  </div>
+                )}
+              </FirmwareTable.Column>
+            </FirmwareTable>
+            <CosPagination
+              isLoading={showLoading}
+              totalItems={totalItemCount}
+              currentPage={query.page}
+              itemsPerPage={query.pageSize}
+              onPageChange={onPageChange}
+              onItemsPerPageChange={onItemsPerPageChange}
+            />
+          </div>
+        </CosGeneralPanel>
+        <ReleaseNotePanel
+          isOpen={isReleaseNotePanelOpen}
+          fallbackTitle="Firmware Version"
+          version={rowForReleaseNote?.version}
+          releaseNote={rowForReleaseNote?.releaseNotes}
+          onClose={onReleaseNotePanelClose}
+        />
+      </div>
+    </MaintenanceUpdateLayout>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/listFirmwaresUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/listFirmwaresUtils.ts
@@ -1,0 +1,52 @@
+import { ListFirmwaresResponseDataFirmwaresInner } from '@cube-frontend/api'
+import {
+  CosTableRow,
+  DEFAULT_ITEMS_PER_PAGE,
+  ItemsPerPage,
+} from '@cube-frontend/ui-library'
+import { paginationQuerySchema } from '@cube-frontend/web-app/utils/pagination'
+
+enum FirmwareParamKeyEnum {
+  CurrentPage = 'page',
+  ItemsPerPage = 'pageSize',
+}
+
+export type ListFirmwaresQuery = {
+  [FirmwareParamKeyEnum.CurrentPage]: number
+  [FirmwareParamKeyEnum.ItemsPerPage]: ItemsPerPage
+}
+
+export const queryToSearchParams = (
+  query: ListFirmwaresQuery,
+): URLSearchParams => {
+  const searchParams = new URLSearchParams()
+  searchParams.set(FirmwareParamKeyEnum.CurrentPage, query.page.toString())
+  searchParams.set(FirmwareParamKeyEnum.ItemsPerPage, query.pageSize.toString())
+  return searchParams
+}
+
+export const searchParamsToQuery = (
+  searchParams: URLSearchParams,
+): ListFirmwaresQuery => {
+  const currentPage = searchParams.get('pageNum')
+  const itemsPerPage = searchParams.get('pageSize')
+
+  const parsedQuery = paginationQuerySchema.safeParse({
+    currentPage,
+    itemsPerPage,
+  }).data
+
+  return {
+    page: parsedQuery?.currentPage ?? 1,
+    pageSize: parsedQuery?.itemsPerPage ?? DEFAULT_ITEMS_PER_PAGE,
+  }
+}
+
+export type FirmwareRow = CosTableRow & ListFirmwaresResponseDataFirmwaresInner
+
+export const firmwareToRow = (
+  firmware: ListFirmwaresResponseDataFirmwaresInner,
+): FirmwareRow => ({
+  ...firmware,
+  id: firmware.version,
+})

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useListFirmwares.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useListFirmwares.ts
@@ -1,0 +1,59 @@
+import { FirmwaresApiListFirmwaresRequest } from '@cube-frontend/api'
+import { firmwaresApi } from '@cube-frontend/web-app/api/cosApi'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
+import { usePolling } from '@cube-frontend/web-app/hooks/usePolling'
+import { shouldDisplayLoading } from '@cube-frontend/web-app/utils/loadingDisplay'
+import { useContext, useMemo } from 'react'
+import {
+  FirmwareRow,
+  firmwareToRow,
+  ListFirmwaresQuery,
+} from './listFirmwaresUtils'
+
+type UseListFirmwares = {
+  showLoading: boolean
+  rows: FirmwareRow[]
+  totalItemCount: number
+}
+
+const POLLING_INTERVAL = 5 * 1000
+
+export const useListFirmwares = (
+  query: ListFirmwaresQuery,
+): UseListFirmwares => {
+  const { dataCenter } = useContext(DataCenterContext)
+
+  const {
+    isLoading,
+    hasResponseBeenReceived,
+    data: pagedFirmwares,
+    getResource: listFirmwares,
+  } = useCosGetRequest(
+    firmwaresApi.listFirmwares,
+    (): FirmwaresApiListFirmwaresRequest => ({
+      dataCenter: dataCenter!.name,
+      pageNum: query.page,
+      pageSize: query.pageSize,
+    }),
+  )
+
+  const { isPolling } = usePolling(listFirmwares, POLLING_INTERVAL)
+
+  const rows = useMemo<FirmwareRow[]>(() => {
+    if (!pagedFirmwares?.firmwares) return []
+    return pagedFirmwares.firmwares.map(firmwareToRow)
+  }, [pagedFirmwares?.firmwares])
+
+  const showLoading = shouldDisplayLoading({
+    isLoading,
+    isPolling,
+    hasResponseBeenReceived,
+  })
+
+  return {
+    rows,
+    totalItemCount: pagedFirmwares?.page.totalItemCount ?? 0,
+    showLoading,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useListFirmwaresQuery.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useListFirmwaresQuery.ts
@@ -1,0 +1,40 @@
+import { ItemsPerPage } from '@cube-frontend/ui-library'
+import { useSearchParamsQuery } from '@cube-frontend/web-app/hooks/useSearchParamsQuery'
+import {
+  ListFirmwaresQuery,
+  queryToSearchParams,
+  searchParamsToQuery,
+} from './listFirmwaresUtils'
+
+type UseListFirmwaresQuery = {
+  query: ListFirmwaresQuery
+  onPageChange: (page: number) => void
+  onItemsPerPageChange: (itemsPerPage: ItemsPerPage) => void
+}
+
+export const useListFirmwaresQuery = (): UseListFirmwaresQuery => {
+  const { query, setQuery } = useSearchParamsQuery({
+    searchParamsToQuery,
+    queryToSearchParams,
+  })
+
+  const onPageChange = (page: number): void => {
+    setQuery((prev) => ({
+      ...prev,
+      pageNum: page,
+    }))
+  }
+
+  const onItemsPerPageChange = (itemsPerPage: ItemsPerPage): void => {
+    setQuery((prev) => ({
+      ...prev,
+      pageSize: itemsPerPage,
+    }))
+  }
+
+  return {
+    query,
+    onPageChange,
+    onItemsPerPageChange,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/fixpack/MaintenanceUpdateFixpackPage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/fixpack/MaintenanceUpdateFixpackPage.tsx
@@ -1,0 +1,16 @@
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { useContext } from 'react'
+import { MaintenanceUpdateLayout } from '../_components/MaintenanceUpdateLayout'
+
+export const MaintenanceUpdateFixpackPage = () => {
+  const { dataCenter } = useContext(DataCenterContext)
+
+  return (
+    <MaintenanceUpdateLayout
+      currentVersion={dataCenter!.fixpack.version}
+      lastUpdated={dataCenter!.fixpack.updatedAt}
+    >
+      <div className="flex items-start gap-x-4">Fixpack List</div>
+    </MaintenanceUpdateLayout>
+  )
+}


### PR DESCRIPTION
#### What type of PR is this?
Feat

#### What this PR does / why we need it
Implement the Maintenance Update Page firmware list layout.

#### Which issue(s) this PR fixes

Fixes #618

#### Special notes for your reviewer

- Functionalities for firmware upload, update, remove, and fixpack list are not included in this PR. They will be handled in other issues.
- The current UI doesn't have an obvious way to open the release notes panel for a specific firmware. So, I changed the text color of the first table column to match the hyperlink color. I'll discuss this with the designers shortly.
   - Mockup
      <img width="300" height="455" alt="image" src="https://github.com/user-attachments/assets/ae550ac7-83b7-492d-9fb7-ab4f679bf21d" />
   - Implementation
      <img width="494" height="336" alt="image" src="https://github.com/user-attachments/assets/9b6e6e20-89e9-4f04-9cda-44f6bbc4478e" />

#### Additional documentation

None

https://github.com/user-attachments/assets/03010d87-4d4b-48a5-8431-f69767312819
