### PR TITLE
592 Handle No Data State in Dropdowns

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
@@ -12,16 +12,22 @@ export type CosCheckboxColor =
   | 'secondary'
   | 'secondary-dark'
 
+export type CosCheckboxSize = 'md' | 'sm' | 'xs'
+
 export type CosCheckboxStatus = 'unselected' | 'selected' | 'indeterminate'
 
 export type CosCheckboxProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  'checked' | 'defaultChecked'
+  'checked' | 'defaultChecked' | 'size'
 > & {
   /**
    * @default primary
    */
   color?: CosCheckboxColor
+  /**
+   * @default md
+   */
+  size?: CosCheckboxSize
   label?: string
   labelClassName?: string
   /**
@@ -39,6 +45,7 @@ export type CosCheckboxProps = Omit<
 export const CosCheckbox = (props: CosCheckboxProps) => {
   const {
     color = 'primary',
+    size = 'md',
     label,
     labelClassName,
     id,
@@ -76,6 +83,12 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
       return effectiveChecked ? CheckboxSelected : CheckboxUnselected
     })()
 
+    const iconSize = () => {
+      if (size === 'xs') return 'icon-sm'
+      if (size === 'sm') return 'icon-md-sm'
+      return 'icon-md'
+    }
+
     return (
       <div
         className={twMerge(
@@ -86,7 +99,7 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
           }),
         )}
       >
-        <IconComponent className="icon-md" />
+        <IconComponent className={iconSize()} />
       </div>
     )
   }
@@ -94,7 +107,10 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
   if (isLoading) return <CosCheckboxSkeleton />
 
   return (
-    <label htmlFor={id} className={twMerge(checkbox.container({ disabled }))}>
+    <label
+      htmlFor={id}
+      className={twMerge(checkbox.container({ size, disabled }))}
+    >
       <input
         {...restProps}
         id={id}

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
@@ -12,23 +12,23 @@ export type CosCheckboxColor =
   | 'secondary'
   | 'secondary-dark'
 
-export type CosCheckboxSize = 'md' | 'sm' | 'xs'
+export type CosCheckboxLabelSize = 'md' | 'sm' | 'xs'
 
 export type CosCheckboxStatus = 'unselected' | 'selected' | 'indeterminate'
 
 export type CosCheckboxProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
-  'checked' | 'defaultChecked' | 'size'
+  'checked' | 'defaultChecked'
 > & {
   /**
    * @default primary
    */
   color?: CosCheckboxColor
+  label?: string
   /**
    * @default md
    */
-  size?: CosCheckboxSize
-  label?: string
+  labelSize?: CosCheckboxLabelSize
   labelClassName?: string
   /**
    * Use `null` for indeterminate state.
@@ -45,8 +45,8 @@ export type CosCheckboxProps = Omit<
 export const CosCheckbox = (props: CosCheckboxProps) => {
   const {
     color = 'primary',
-    size = 'md',
     label,
+    labelSize = 'md',
     labelClassName,
     id,
     defaultChecked = false,
@@ -83,12 +83,6 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
       return effectiveChecked ? CheckboxSelected : CheckboxUnselected
     })()
 
-    const iconSize = () => {
-      if (size === 'xs') return 'icon-sm'
-      if (size === 'sm') return 'icon-md-sm'
-      return 'icon-md'
-    }
-
     return (
       <div
         className={twMerge(
@@ -99,7 +93,7 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
           }),
         )}
       >
-        <IconComponent className={iconSize()} />
+        <IconComponent className="icon-md" />
       </div>
     )
   }
@@ -109,7 +103,7 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
   return (
     <label
       htmlFor={id}
-      className={twMerge(checkbox.container({ size, disabled }))}
+      className={twMerge(checkbox.container({ size: labelSize, disabled }))}
     >
       <input
         {...restProps}

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/styles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/styles.ts
@@ -1,8 +1,13 @@
 import { cva } from 'class-variance-authority'
 
 export const checkbox = {
-  container: cva('primary-body2 inline-flex w-fit cursor-pointer gap-x-2', {
+  container: cva('inline-flex w-fit cursor-pointer items-center gap-x-2', {
     variants: {
+      size: {
+        md: 'primary-body2',
+        sm: 'primary-body3',
+        xs: 'primary-body4',
+      },
       disabled: {
         true: 'cursor-default',
       },

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownItem.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownItem.tsx
@@ -21,38 +21,16 @@ export const CosDropdownItem = <Item,>(props: CosDropdownItemProps<Item>) => {
     onClick: onClickProp,
   } = props
 
-  const {
-    size,
-    type,
-    variant,
-    selectedItems,
-    searchValue,
-    toggleDropdownOpen,
-  } = useContext(CosDropdownContext)
+  const { size, type, variant, selectedItems, toggleDropdownOpen } =
+    useContext(CosDropdownContext)
 
   const isSelected = selectedItems.includes(item)
-
-  const shouldDisplay = (): boolean => {
-    // Items in non-filter dropdowns should always be visible.
-    if (variant !== 'withFilter') return true
-
-    // If there isn't a search value, then show all the items.
-    if (!searchValue) return true
-
-    // If the item's label includes the search value (case-insensitive),
-    // then it should be visible; otherwise, it should be hidden.
-    return label.toLowerCase().includes(searchValue.toLowerCase())
-  }
 
   const onClick = () => {
     if (disabled) return
 
     onClickProp()
     if (type === 'radio') toggleDropdownOpen()
-  }
-
-  if (!shouldDisplay()) {
-    return null
   }
 
   if (type === 'checkbox')

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownMenu.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownMenu.tsx
@@ -67,13 +67,14 @@ export const CosDropdownMenu = (props: CosDropdownMenuProps) => {
       variant !== 'withFilter' || !searchValue
         ? allItems
         : allItems.filter((child) =>
-            String(child.props.children)
+            child.props.children
               .toLowerCase()
               .includes(searchValue.toLowerCase()),
           )
 
-    if (visibleItems.length === 0)
-      return <ItemNoData size={size} type={type} variant={variant} />
+    if (visibleItems.length === 0) {
+      return <ItemNoData size={size} type={type} />
+    }
 
     return visibleItems
   }

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownMenu.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/CosDropdownMenu.tsx
@@ -1,10 +1,12 @@
-import { ReactNode, useCallback, useContext, useMemo } from 'react'
+import { Children, ReactNode, useCallback, useContext, useMemo } from 'react'
 import { createPortal } from 'react-dom'
 import { twMerge } from 'tailwind-merge'
 import { ItemCheckbox } from './_components/ItemCheckbox'
+import { ItemNoData } from './_components/ItemNoData'
 import { CosDropdownFilter } from './CosDropdownFilter'
 import { CosDropdownContext } from './cosDropdownContext'
 import { menu } from './cosDropdownStyles'
+import { checkIsCosDropdownItemElement } from './cosDropdownUtils'
 
 export type CosDropdownMenuProps = {
   children: ReactNode
@@ -41,7 +43,7 @@ export const CosDropdownMenu = (props: CosDropdownMenuProps) => {
   }
 
   const renderSelectAllCheckbox = () => {
-    if (type === 'radio' || searchValue) return null
+    if (type === 'radio' || searchValue || !children) return null
 
     return (
       <ItemCheckbox
@@ -56,6 +58,26 @@ export const CosDropdownMenu = (props: CosDropdownMenuProps) => {
     )
   }
 
+  const renderMenuItems = () => {
+    const allItems = Children.toArray(children).filter(
+      checkIsCosDropdownItemElement,
+    )
+
+    const visibleItems =
+      variant !== 'withFilter' || !searchValue
+        ? allItems
+        : allItems.filter((child) =>
+            String(child.props.children)
+              .toLowerCase()
+              .includes(searchValue.toLowerCase()),
+          )
+
+    if (visibleItems.length === 0)
+      return <ItemNoData size={size} type={type} variant={variant} />
+
+    return visibleItems
+  }
+
   return createPortal(
     <div
       ref={elementRef}
@@ -64,7 +86,7 @@ export const CosDropdownMenu = (props: CosDropdownMenuProps) => {
     >
       {renderFilter()}
       {renderSelectAllCheckbox()}
-      {children}
+      {renderMenuItems()}
     </div>,
     document.body,
   )

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/_components/ItemCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/_components/ItemCheckbox.tsx
@@ -1,5 +1,9 @@
 import { twMerge } from 'tailwind-merge'
-import { CosCheckbox, CosCheckboxColor } from '../../CosCheckbox/CosCheckbox'
+import {
+  CosCheckbox,
+  CosCheckboxColor,
+  CosCheckboxSize,
+} from '../../CosCheckbox/CosCheckbox'
 import { CosDropdownSize, CosDropdownVariant } from '../cosDropdownTypes'
 import { item } from '../cosDropdownStyles'
 
@@ -35,6 +39,11 @@ export const ItemCheckbox = (props: ItemCheckboxProps) => {
     }
   }
 
+  const getSize = (): CosCheckboxSize => {
+    if (size === 'md') return 'sm'
+    return 'xs'
+  }
+
   return (
     <div
       className={twMerge(
@@ -48,6 +57,7 @@ export const ItemCheckbox = (props: ItemCheckboxProps) => {
         checked={isSelected}
         onChange={onClick}
         color={getColor()}
+        size={getSize()}
       />
     </div>
   )

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/_components/ItemCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/_components/ItemCheckbox.tsx
@@ -2,7 +2,7 @@ import { twMerge } from 'tailwind-merge'
 import {
   CosCheckbox,
   CosCheckboxColor,
-  CosCheckboxSize,
+  CosCheckboxLabelSize,
 } from '../../CosCheckbox/CosCheckbox'
 import { CosDropdownSize, CosDropdownVariant } from '../cosDropdownTypes'
 import { item } from '../cosDropdownStyles'
@@ -39,9 +39,8 @@ export const ItemCheckbox = (props: ItemCheckboxProps) => {
     }
   }
 
-  const getSize = (): CosCheckboxSize => {
-    if (size === 'md') return 'sm'
-    return 'xs'
+  const getLabelSize = (): CosCheckboxLabelSize => {
+    return size === 'md' ? 'sm' : 'xs'
   }
 
   return (
@@ -57,7 +56,7 @@ export const ItemCheckbox = (props: ItemCheckboxProps) => {
         checked={isSelected}
         onChange={onClick}
         color={getColor()}
-        size={getSize()}
+        labelSize={getLabelSize()}
       />
     </div>
   )

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/_components/ItemNoData.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/_components/ItemNoData.tsx
@@ -1,0 +1,15 @@
+import { twMerge } from 'tailwind-merge'
+import { CosDropdownSize, CosDropdownType } from '../cosDropdownTypes'
+import { item } from '../cosDropdownStyles'
+
+type ItemNoDataProps = {
+  size: CosDropdownSize
+  type: CosDropdownType
+}
+
+export const ItemNoData = (props: ItemNoDataProps) => {
+  const { size, type } = props
+
+  // TODO: i18n
+  return <div className={twMerge(item.noData({ size, type }))}>No Data</div>
+}

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/cosDropdownStyles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/cosDropdownStyles.ts
@@ -303,52 +303,76 @@ export const filter = {
 // Dropdown Item Style
 // ====================================
 export const item = {
-  radio: cva('cursor-pointer truncate hover:bg-functional-hover-grey', {
+  radio: cva(
+    'cursor-pointer truncate text-functional-text hover:bg-functional-hover-grey',
+    {
+      variants: {
+        size: {
+          md: 'primary-body3',
+          sm: 'primary-body4',
+        },
+        variant: {
+          regular: '',
+          withFilter: '',
+        },
+        isSelected: {
+          true: 'font-semibold',
+        },
+        disabled: {
+          true: 'cursor-default text-functional-disable-text hover:bg-white',
+        },
+      },
+      compoundVariants: [
+        { size: 'md', variant: 'regular', class: 'px-[24px] py-[10px]' },
+        { size: 'md', variant: 'withFilter', class: 'px-[24px] py-[10px]' },
+        { size: 'sm', variant: 'regular', class: 'px-[24px] py-[9px]' },
+        { size: 'sm', variant: 'withFilter', class: 'px-[24px] py-[9px]' },
+      ],
+    },
+  ),
+  checkbox: cva(
+    'truncate text-functional-text hover:bg-functional-hover-grey',
+    {
+      variants: {
+        size: {
+          md: 'primary-body3',
+          sm: 'primary-body4',
+        },
+        variant: {
+          regular: '',
+          withFilter: '',
+        },
+        isSelected: {
+          true: 'font-semibold',
+        },
+        disabled: {
+          true: 'cursor-default text-functional-disable-text hover:bg-white',
+        },
+      },
+      compoundVariants: [
+        { size: 'md', variant: 'regular', class: 'px-[22px] py-[11px]' },
+        { size: 'md', variant: 'withFilter', class: 'px-[22px] py-[11px]' },
+        { size: 'sm', variant: 'regular', class: 'px-[16px] py-[9.5px]' },
+        { size: 'sm', variant: 'withFilter', class: 'px-[16px] py-[9.5px]' },
+      ],
+    },
+  ),
+  noData: cva('text-functional-text', {
     variants: {
       size: {
         md: 'primary-body3',
         sm: 'primary-body4',
       },
-      variant: {
-        regular: '',
-        withFilter: '',
-      },
-      isSelected: {
-        true: 'font-semibold',
-      },
-      disabled: {
-        true: 'cursor-default text-functional-disable-text hover:bg-white',
+      type: {
+        radio: '',
+        checkbox: '',
       },
     },
     compoundVariants: [
-      { size: 'md', variant: 'regular', class: 'px-[24px] py-[10px]' },
-      { size: 'md', variant: 'withFilter', class: 'px-[24px] py-[10px]' },
-      { size: 'sm', variant: 'regular', class: 'px-[24px] py-[9px]' },
-      { size: 'sm', variant: 'withFilter', class: 'px-[24px] py-[9px]' },
-    ],
-  }),
-  checkbox: cva('truncate hover:bg-functional-hover-grey', {
-    variants: {
-      size: {
-        md: 'primary-body3',
-        sm: 'primary-body4',
-      },
-      variant: {
-        regular: '',
-        withFilter: '',
-      },
-      isSelected: {
-        true: 'font-semibold',
-      },
-      disabled: {
-        true: 'cursor-default text-functional-disable-text hover:bg-white',
-      },
-    },
-    compoundVariants: [
-      { size: 'md', variant: 'regular', class: 'px-[22px] py-[11px]' },
-      { size: 'md', variant: 'withFilter', class: 'px-[22px] py-[11px]' },
-      { size: 'sm', variant: 'regular', class: 'px-[16px] py-[9.5px]' },
-      { size: 'sm', variant: 'withFilter', class: 'px-[16px] py-[9.5px]' },
+      { size: 'md', type: 'radio', class: 'px-[24px] py-[10px]' },
+      { size: 'md', type: 'checkbox', class: 'px-[22px] py-[11px]' },
+      { size: 'sm', type: 'radio', class: 'px-[24px] py-[9px]' },
+      { size: 'sm', type: 'checkbox', class: 'px-[16px] py-[9.5px]' },
     ],
   }),
 }

--- a/packages/cube-frontend-ui-library/src/components/CosDropdown/cosDropdownUtils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosDropdown/cosDropdownUtils.ts
@@ -1,4 +1,6 @@
+import { isValidElement, ReactElement, ReactNode } from 'react'
 import { CosDropdownProps } from './cosDropdownTypes'
+import { CosDropdownItem, CosDropdownItemProps } from './CosDropdownItem'
 
 export const getOptionalProps = <Item>(props: CosDropdownProps<Item>) => {
   return {
@@ -10,3 +12,8 @@ export const getOptionalProps = <Item>(props: CosDropdownProps<Item>) => {
         : undefined,
   }
 }
+
+export const checkIsCosDropdownItemElement = (
+  child: ReactNode,
+): child is ReactElement<CosDropdownItemProps<unknown>> =>
+  isValidElement(child) && child.type === CosDropdownItem

--- a/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarFilter/CosSearchBarFilter.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarFilter/CosSearchBarFilter.tsx
@@ -15,6 +15,7 @@ import Clear from '../../CosIcon/monochrome/x_small.svg?react'
 import { CosSearchBarSkeleton } from '../CosSearchBarSkeleton'
 import { FilterDropdownMenu } from './FilterDropdownMenu'
 import { FilterDropdownItem } from './FilterDropdownItem'
+import { checkIsDropdownChildValid } from '../utils'
 
 const input = cva(
   [
@@ -39,7 +40,6 @@ export type CosSearchBarFilterProps = DetailedHTMLProps<
 > & {
   isLoading?: boolean
   onInputClear?: () => void
-  showDropdown?: boolean
   /**
    * `children` is used to render menu content items,
    * it should be `FilterDropdownItem` components.
@@ -55,7 +55,6 @@ export const CosSearchBarFilter = (props: CosSearchBarFilterProps) => {
     ref: inputRef,
     isLoading,
     onInputClear,
-    showDropdown = true,
     value,
     onChange: onInputChange,
     className,
@@ -71,16 +70,14 @@ export const CosSearchBarFilter = (props: CosSearchBarFilterProps) => {
 
   const hasInputValue = value !== ''
 
+  const hasMenuItems = checkIsDropdownChildValid(children, FilterDropdownItem)
+
   useEffect(() => {
-    if (hasInputValue) {
-      setDropdownOpen(true)
-    } else {
-      setDropdownOpen(false)
-    }
+    setDropdownOpen(hasInputValue)
   }, [hasInputValue])
 
   const floatingProps = useFloating<HTMLDivElement, HTMLDivElement>({
-    isOpen: showDropdown && dropdownOpen,
+    isOpen: hasMenuItems && hasInputValue && dropdownOpen,
     placement: 'bottom-left',
     offsets: {
       y: 8,
@@ -141,6 +138,7 @@ export const CosSearchBarFilter = (props: CosSearchBarFilterProps) => {
           value={value}
           onChange={onInputChange}
           placeholder={placeholder}
+          autoComplete="off"
           className={twMerge(input({ hasInputValue }), className)}
         />
         {renderIcon()}

--- a/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/CosSearchBarGlobal.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/CosSearchBarGlobal.tsx
@@ -2,7 +2,7 @@ import { twMerge } from 'tailwind-merge'
 import { CosSearchBarSkeleton } from '../CosSearchBarSkeleton'
 import { CosSearchBarGlobalItem } from './CosSearchBarGlobalItem'
 import { GlobalSearchBarInput } from './GlobalSearchBarInput'
-import { GlobalSearchBarSorting } from './GlobalSearchBarSorting'
+import { GlobalSearchBarCategory } from './GlobalSearchBarCategory'
 import { CosSearchBarGlobalProps } from './cosSearchBarGlobalTypes'
 import { container } from './cosSearchBarGlobalStyles'
 import { omitNonInputProps } from './cosSearchBarGlobalUtils'
@@ -12,13 +12,13 @@ export const CosSearchBarGlobal = (props: CosSearchBarGlobalProps) => {
 
   if (isLoading) return <CosSearchBarSkeleton variant="global" />
 
-  const renderSortingDropdown = () => {
-    if (variant !== 'sorting') return null
+  const renderCategoryDropdown = () => {
+    if (variant !== 'category') return null
 
     const { categories, selectedCategory, onCategoryClick } = props
 
     return (
-      <GlobalSearchBarSorting
+      <GlobalSearchBarCategory
         categories={categories}
         selectedCategory={selectedCategory}
         onCategoryClick={onCategoryClick}
@@ -35,7 +35,7 @@ export const CosSearchBarGlobal = (props: CosSearchBarGlobalProps) => {
       >
         {children}
       </GlobalSearchBarInput>
-      {renderSortingDropdown()}
+      {renderCategoryDropdown()}
     </div>
   )
 }

--- a/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/GlobalSearchBarCategory.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/GlobalSearchBarCategory.tsx
@@ -2,45 +2,48 @@ import { Fragment, useCallback, useEffect, useState } from 'react'
 import { twMerge } from 'tailwind-merge'
 import ChevronDown from '../../CosIcon/monochrome/chevron_down.svg?react'
 import { useFloating } from '../../../internal/utils/floating/useFloating'
-import { sorting } from './cosSearchBarGlobalStyles'
+import { category } from './cosSearchBarGlobalStyles'
 import { createPortal } from 'react-dom'
 
-type GlobalSearchBarSortingProps = {
+type GlobalSearchBarCategoryProps = {
   categories: string[]
   selectedCategory: string | undefined
   onCategoryClick: (category: string) => void
 }
 
-export const GlobalSearchBarSorting = (props: GlobalSearchBarSortingProps) => {
+export const GlobalSearchBarCategory = (
+  props: GlobalSearchBarCategoryProps,
+) => {
   const {
     categories,
     selectedCategory,
     onCategoryClick: onCategoryClickProp,
   } = props
 
-  const [sortingDropdownOpen, setSortingDropdownOpen] = useState(false)
+  const [dropdownOpen, setDropdownOpen] = useState(false)
 
   const toggleDropdownOpen = () => {
-    setSortingDropdownOpen((prev) => !prev)
+    setDropdownOpen((prev) => !prev)
   }
 
   const onCategoryClick = (cate: string) => {
     onCategoryClickProp(cate)
-    setSortingDropdownOpen(false)
+    setDropdownOpen(false)
   }
 
-  const sortingDropdownFloatingProps = useFloating<
+  const categoryDropdownFloatingProps = useFloating<
     HTMLDivElement,
     HTMLDivElement
   >({
-    isOpen: sortingDropdownOpen,
+    isOpen: dropdownOpen,
     placement: 'bottom-right',
     offsets: {
       y: 8,
     },
   })
 
-  const { anchorRef, elementRef, resolvedStyles } = sortingDropdownFloatingProps
+  const { anchorRef, elementRef, resolvedStyles } =
+    categoryDropdownFloatingProps
 
   const handleClickOutside = useCallback(
     (event: MouseEvent) => {
@@ -50,10 +53,10 @@ export const GlobalSearchBarSorting = (props: GlobalSearchBarSortingProps) => {
       const isMenu = elementRef.current?.contains(target)
 
       if (!isTrigger && !isMenu) {
-        setSortingDropdownOpen(false)
+        setDropdownOpen(false)
       }
     },
-    [anchorRef, elementRef, setSortingDropdownOpen],
+    [anchorRef, elementRef, setDropdownOpen],
   )
 
   useEffect(() => {
@@ -63,22 +66,32 @@ export const GlobalSearchBarSorting = (props: GlobalSearchBarSortingProps) => {
     }
   }, [handleClickOutside])
 
+  const renderItems = () => {
+    const hasData = categories.length !== 0
+
+    if (!hasData)
+      return (
+        <div className={twMerge(category.item({ hasData }))}>No Category</div>
+      )
+    return categories.map((cate) => (
+      <div
+        key={cate}
+        className={twMerge(category.item({ hasData }))}
+        onClick={() => onCategoryClick(cate)}
+      >
+        {cate}
+      </div>
+    ))
+  }
+
   const renderMenu = () => {
     return createPortal(
       <div
         ref={elementRef}
-        className={twMerge(sorting.menu)}
+        className={twMerge(category.menu)}
         style={resolvedStyles?.floatingStyle}
       >
-        {categories.map((cate) => (
-          <div
-            key={cate}
-            className={twMerge(sorting.item)}
-            onClick={() => onCategoryClick(cate)}
-          >
-            {cate}
-          </div>
-        ))}
+        {renderItems()}
       </div>,
       document.body,
     )
@@ -88,13 +101,13 @@ export const GlobalSearchBarSorting = (props: GlobalSearchBarSortingProps) => {
     <Fragment>
       <div className="h-[20px] w-px border-l border-functional-border-divider" />
       <div ref={anchorRef}>
-        <div className={twMerge(sorting.trigger)} onClick={toggleDropdownOpen}>
+        <div className={twMerge(category.trigger)} onClick={toggleDropdownOpen}>
           <div className="primary-body2 max-w-[100px] truncate">
             {selectedCategory ?? 'Category'}
           </div>
           <ChevronDown
-            className={sorting.triggerIcon({
-              isOpen: sortingDropdownOpen,
+            className={category.triggerIcon({
+              isOpen: dropdownOpen,
             })}
           />
         </div>

--- a/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/GlobalSearchBarInput.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/GlobalSearchBarInput.tsx
@@ -1,4 +1,10 @@
-import { ComponentProps, useCallback, useEffect, useState } from 'react'
+import {
+  ComponentProps,
+  ReactElement,
+  useCallback,
+  useEffect,
+  useState,
+} from 'react'
 import { createPortal } from 'react-dom'
 import { twMerge } from 'tailwind-merge'
 import Search from '../../CosIcon/monochrome/search.svg?react'
@@ -6,11 +12,15 @@ import Clear from '../../CosIcon/monochrome/x_small.svg?react'
 import { useFloating } from '../../../internal/utils/floating/useFloating'
 import { keyword } from './cosSearchBarGlobalStyles'
 import { CosSearchBarGlobalVariant } from './cosSearchBarGlobalTypes'
+import { checkIsDropdownChildValid } from '../utils'
+import { CosSearchBarGlobalItem } from './CosSearchBarGlobalItem'
 
 type GlobalSearchBarInputProps = ComponentProps<'input'> & {
   variant: CosSearchBarGlobalVariant
   onInputClear: () => void
-  children?: React.ReactNode
+  children?:
+    | ReactElement<typeof CosSearchBarGlobalItem>[]
+    | ReactElement<typeof CosSearchBarGlobalItem>
 }
 
 export const GlobalSearchBarInput = (props: GlobalSearchBarInputProps) => {
@@ -30,19 +40,20 @@ export const GlobalSearchBarInput = (props: GlobalSearchBarInputProps) => {
 
   const hasInputValue = typeof value === 'string' && value.trim() !== ''
 
+  const hasMenuItems = checkIsDropdownChildValid(
+    children,
+    CosSearchBarGlobalItem,
+  )
+
   useEffect(() => {
-    if (hasInputValue) {
-      setKeywordDropdownOpen(true)
-    } else {
-      setKeywordDropdownOpen(false)
-    }
+    setKeywordDropdownOpen(hasInputValue)
   }, [hasInputValue, setKeywordDropdownOpen])
 
   const keywordDropdownFloatingProps = useFloating<
     HTMLDivElement,
     HTMLDivElement
   >({
-    isOpen: keywordDropdownOpen,
+    isOpen: hasMenuItems && hasInputValue && keywordDropdownOpen,
     placement: 'bottom-left',
     offsets: {
       y: 8,

--- a/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/cosSearchBarGlobalStyles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/cosSearchBarGlobalStyles.ts
@@ -15,7 +15,7 @@ export const keyword = {
       variants: {
         variant: {
           regular: 'rounded-full',
-          sorting: 'rounded-l-full',
+          category: 'rounded-l-full',
         },
         hasInputValue: {
           true: 'pr-[64px]',
@@ -41,7 +41,7 @@ export const keyword = {
   ),
 }
 
-export const sorting = {
+export const category = {
   trigger: [
     'flex h-[34px] cursor-pointer items-center justify-between gap-x-[6px] rounded-r-full',
     'primary-body2 shrink-0 px-5 py-[7px] text-functional-text',
@@ -56,5 +56,12 @@ export const sorting = {
     'z-10 min-w-[160px] overflow-y-auto rounded-[5px] border bg-white py-2',
     'shadow-[0_0_2px_0_rgba(0,0,0,0.2)]',
   ],
-  item: 'primary-body3 cursor-pointer px-6 py-[10px] text-functional-text hover:bg-functional-hover-secondary',
+  item: cva('primary-body3 px-6 py-[10px] text-functional-text', {
+    variants: {
+      hasData: {
+        true: 'cursor-pointer hover:bg-functional-hover-secondary',
+        false: '',
+      },
+    },
+  }),
 }

--- a/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/cosSearchBarGlobalTypes.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/cosSearchBarGlobalTypes.ts
@@ -6,7 +6,7 @@ export type CosSearchBarGlobalItemType = 'suggestion' | 'recentSuggestion'
 export type CosSearchBarGlobalVariant = CosSearchBarGlobalProps['variant']
 
 type BaseSearchBarGlobalProps = ComponentProps<'input'> & {
-  variant: 'regular' | 'sorting'
+  variant: 'regular' | 'category'
   /**
    * @default false
    */
@@ -25,8 +25,8 @@ type RegularSearchBarGlobalProp = BaseSearchBarGlobalProps & {
   variant: 'regular'
 }
 
-export type SortingSearchBarGlobalProps = BaseSearchBarGlobalProps & {
-  variant: 'sorting'
+export type CategorySearchBarGlobalProps = BaseSearchBarGlobalProps & {
+  variant: 'category'
   categories: string[]
   selectedCategory: string | undefined
   onCategoryClick: (category: string) => void
@@ -34,4 +34,4 @@ export type SortingSearchBarGlobalProps = BaseSearchBarGlobalProps & {
 
 export type CosSearchBarGlobalProps =
   | RegularSearchBarGlobalProp
-  | SortingSearchBarGlobalProps
+  | CategorySearchBarGlobalProps

--- a/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/cosSearchBarGlobalUtils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosSearchBar/CosSearchBarGlobal/cosSearchBarGlobalUtils.ts
@@ -1,7 +1,7 @@
 import { ComponentProps } from 'react'
 import {
   CosSearchBarGlobalProps,
-  SortingSearchBarGlobalProps,
+  CategorySearchBarGlobalProps,
 } from './cosSearchBarGlobalTypes'
 
 export const omitNonInputProps = (
@@ -9,9 +9,9 @@ export const omitNonInputProps = (
 ): ComponentProps<'input'> => {
   const { variant, isLoading, children, onInputClear, ...restProps } = props
 
-  if (variant === 'sorting') {
+  if (variant === 'category') {
     const { categories, selectedCategory, onCategoryClick, ...inputProps } =
-      restProps as SortingSearchBarGlobalProps
+      restProps as CategorySearchBarGlobalProps
     return inputProps
   }
 

--- a/packages/cube-frontend-ui-library/src/components/CosSearchBar/utils.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosSearchBar/utils.ts
@@ -1,0 +1,22 @@
+import {
+  Children,
+  ComponentType,
+  isValidElement,
+  ReactElement,
+  ReactNode,
+} from 'react'
+
+export const checkIsDropdownChildValid = <P>(
+  children: ReactNode,
+  expectedType: ComponentType<P>,
+): children is ReactElement<P> | ReactElement<P>[] => {
+  if (!children) return false
+
+  const childArray = Children.toArray(children)
+
+  if (childArray.length === 0) return false
+
+  return childArray.every(
+    (child) => isValidElement(child) && child.type === expectedType,
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CosCheckbox.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CosCheckbox.stories.tsx
@@ -37,15 +37,25 @@ export const Gallery: StoryObj = {
       <StoryLayout title="Checkbox">
         <StoryLayout.Section title="Checkbox">
           <div className="flex flex-col gap-y-8">
+            <CheckboxGrid title="">
+              <div className="primary-body2">Label Size</div>
+              <div className="primary-body2">Checkbox</div>
+            </CheckboxGrid>
             <CheckboxGrid title="md">
+              <div className="primary-body2">14px (default)</div>
               <CosCheckbox label={checkboxText} />
             </CheckboxGrid>
             <CheckboxGrid title="sm">
-              <CosCheckbox label={checkboxText} size="sm" />
+              <div className="primary-body2">13px</div>
+              <CosCheckbox label={checkboxText} labelSize="sm" />
             </CheckboxGrid>
             <CheckboxGrid title="xs">
-              <CosCheckbox label={checkboxText} size="xs" />
+              <div className="primary-body2">12px</div>
+              <CosCheckbox label={checkboxText} labelSize="xs" />
             </CheckboxGrid>
+            <p className="primary-body2 text-grey-850">
+              The `sm` and `xs` sizes are used in the dropdown component.
+            </p>
           </div>
         </StoryLayout.Section>
         <StoryLayout.Section title="Variants">

--- a/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CosCheckbox.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosCheckbox/CosCheckbox.stories.tsx
@@ -36,9 +36,17 @@ export const Gallery: StoryObj = {
     return (
       <StoryLayout title="Checkbox">
         <StoryLayout.Section title="Checkbox">
-          <CheckboxGrid title="Master">
-            <CosCheckbox label={checkboxText} />
-          </CheckboxGrid>
+          <div className="flex flex-col gap-y-8">
+            <CheckboxGrid title="md">
+              <CosCheckbox label={checkboxText} />
+            </CheckboxGrid>
+            <CheckboxGrid title="sm">
+              <CosCheckbox label={checkboxText} size="sm" />
+            </CheckboxGrid>
+            <CheckboxGrid title="xs">
+              <CosCheckbox label={checkboxText} size="xs" />
+            </CheckboxGrid>
+          </div>
         </StoryLayout.Section>
         <StoryLayout.Section title="Variants">
           <div className="flex flex-col gap-y-8">

--- a/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/CheckboxDropdown.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/CheckboxDropdown.tsx
@@ -12,11 +12,13 @@ type CheckboxDropdownProps = {
   isLoading: boolean
   selected: boolean
   disabled: boolean
+  isNoData: boolean
   label?: string
 }
 
 export const CheckboxDropdown = (props: CheckboxDropdownProps) => {
-  const { size, variant, isLoading, selected, disabled, label } = props
+  const { size, variant, isLoading, selected, disabled, isNoData, label } =
+    props
 
   const [selectedItems, setSelectedItems] = useState<MockDataItem[]>(() =>
     selected ? [mockData[0]] : [],
@@ -63,16 +65,18 @@ export const CheckboxDropdown = (props: CheckboxDropdownProps) => {
             : undefined}
         </CosDropdown.Trigger>
         <CosDropdown.Menu>
-          {mockData.map((item) => (
-            <CosDropdown.Item
-              key={item.value}
-              item={item}
-              disabled={item.disabled}
-              onClick={() => onItemClick(item)}
-            >
-              {item.label}
-            </CosDropdown.Item>
-          ))}
+          {isNoData
+            ? null
+            : mockData.map((item) => (
+                <CosDropdown.Item
+                  key={item.value}
+                  item={item}
+                  disabled={item.disabled}
+                  onClick={() => onItemClick(item)}
+                >
+                  {item.label}
+                </CosDropdown.Item>
+              ))}
         </CosDropdown.Menu>
       </CosDropdown>
     )
@@ -95,16 +99,18 @@ export const CheckboxDropdown = (props: CheckboxDropdownProps) => {
           : undefined}
       </CosDropdown.Trigger>
       <CosDropdown.Menu>
-        {mockData.map((item) => (
-          <CosDropdown.Item
-            key={item.value}
-            item={item}
-            disabled={item.disabled}
-            onClick={() => onItemClick(item)}
-          >
-            {item.label}
-          </CosDropdown.Item>
-        ))}
+        {isNoData
+          ? null
+          : mockData.map((item) => (
+              <CosDropdown.Item
+                key={item.value}
+                item={item}
+                disabled={item.disabled}
+                onClick={() => onItemClick(item)}
+              >
+                {item.label}
+              </CosDropdown.Item>
+            ))}
       </CosDropdown.Menu>
     </CosDropdown>
   )

--- a/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/CosDropdown.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/CosDropdown.stories.tsx
@@ -29,6 +29,7 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={false}
               disabled={false}
+              isNoData={false}
             />
           </DropdownLayout>
           <DropdownLayout title="sm">
@@ -37,6 +38,7 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={false}
               disabled={false}
+              isNoData={false}
             />
           </DropdownLayout>
         </StoryLayout.Section>
@@ -50,6 +52,7 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={false}
               disabled={false}
+              isNoData={false}
             />
           </DropdownLayout>
           <DropdownLayout title="Unselected + Disabled">
@@ -58,6 +61,7 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={false}
               disabled={true}
+              isNoData={false}
             />
           </DropdownLayout>
           <DropdownLayout title="Selected">
@@ -66,6 +70,7 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={true}
               disabled={false}
+              isNoData={false}
             />
           </DropdownLayout>
           <DropdownLayout title="Selected  + Disabled">
@@ -74,6 +79,16 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={true}
               disabled={true}
+              isNoData={false}
+            />
+          </DropdownLayout>
+          <DropdownLayout title="No Data">
+            <DropdownRow
+              size="md"
+              isLoading={false}
+              selected={false}
+              disabled={false}
+              isNoData={true}
             />
           </DropdownLayout>
           <DropdownLayout title="Loading">
@@ -82,6 +97,7 @@ export const Default: StoryObj = {
               isLoading={true}
               selected={true}
               disabled={true}
+              isNoData={false}
             />
           </DropdownLayout>
         </StoryLayout.Section>
@@ -95,6 +111,7 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={false}
               disabled={false}
+              isNoData={false}
               label="Label"
             />
           </DropdownLayout>
@@ -104,6 +121,7 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={false}
               disabled={true}
+              isNoData={false}
               label="Label"
             />
           </DropdownLayout>
@@ -113,6 +131,7 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={true}
               disabled={false}
+              isNoData={false}
               label="Label"
             />
           </DropdownLayout>
@@ -122,6 +141,17 @@ export const Default: StoryObj = {
               isLoading={false}
               selected={true}
               disabled={true}
+              isNoData={false}
+              label="Label"
+            />
+          </DropdownLayout>
+          <DropdownLayout title="No Data">
+            <DropdownRow
+              size="md"
+              isLoading={false}
+              selected={false}
+              disabled={false}
+              isNoData={true}
               label="Label"
             />
           </DropdownLayout>
@@ -131,6 +161,7 @@ export const Default: StoryObj = {
               isLoading={true}
               selected={true}
               disabled={true}
+              isNoData={false}
               label="Label"
             />
           </DropdownLayout>

--- a/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/DropdownLayout.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/DropdownLayout.tsx
@@ -31,6 +31,7 @@ export const DropdownRow = (props: {
   isLoading: boolean
   selected: boolean
   disabled: boolean
+  isNoData: boolean
   label?: string
 }) => {
   return (

--- a/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/RadioDropdown.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosDropdown/RadioDropdown.tsx
@@ -12,11 +12,13 @@ type RadioDropdownProps = {
   isLoading: boolean
   selected: boolean
   disabled: boolean
+  isNoData: boolean
   label?: string
 }
 
 export const RadioDropdown = (props: RadioDropdownProps) => {
-  const { size, variant, isLoading, selected, disabled, label } = props
+  const { size, variant, isLoading, selected, disabled, isNoData, label } =
+    props
 
   const [selectedItems, setSelectedItems] = useState<MockDataItem[]>(() =>
     selected ? [mockData[0]] : [],
@@ -45,16 +47,18 @@ export const RadioDropdown = (props: RadioDropdownProps) => {
         {selectedItems.length > 0 ? selectedItems[0].label : undefined}
       </CosDropdown.Trigger>
       <CosDropdown.Menu>
-        {mockData.map((item) => (
-          <CosDropdown.Item
-            key={item.value}
-            item={item}
-            disabled={item.disabled}
-            onClick={() => onItemClick(item)}
-          >
-            {item.label}
-          </CosDropdown.Item>
-        ))}
+        {isNoData
+          ? null
+          : mockData.map((item) => (
+              <CosDropdown.Item
+                key={item.value}
+                item={item}
+                disabled={item.disabled}
+                onClick={() => onItemClick(item)}
+              >
+                {item.label}
+              </CosDropdown.Item>
+            ))}
       </CosDropdown.Menu>
     </CosDropdown>
   )

--- a/packages/cube-frontend-ui-library/src/stories/components/CosSearchBar/CosSearchBarFilter.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosSearchBar/CosSearchBarFilter.stories.tsx
@@ -1,85 +1,32 @@
-import { ChangeEventHandler, useState } from 'react'
 import { Meta, StoryObj } from '@storybook/react'
-import { fn } from '@storybook/test'
 import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
-import {
-  CosSearchBarFilter,
-  CosSearchBarFilterProps,
-} from '../../../components/CosSearchBar/CosSearchBarFilter/CosSearchBarFilter'
+import { CosSearchBarFilter } from '../../../components/CosSearchBar/CosSearchBarFilter/CosSearchBarFilter'
 import { SearchBarGrid } from './SearchBarGrid'
-import { mockOptions } from './mockData'
+import { SearchBarFilter } from './SearchBarFilter'
 
 const meta = {
   title: 'Molecules/SearchBar/Filter',
   component: CosSearchBarFilter,
-  args: {
-    onChange: fn(),
-  },
 } satisfies Meta<typeof CosSearchBarFilter>
 
 export default meta
 
 export const Gallery: StoryObj = {
   args: {},
-  render: function Render(args: CosSearchBarFilterProps) {
-    const { onChange } = args
-
-    const [text1, setText1] = useState<string>('')
-
-    const [text2, setText2] = useState<string>('')
-
-    const handleText1Change: ChangeEventHandler<HTMLInputElement> = (e) => {
-      setText1(e.target.value)
-      if (onChange) onChange(e)
-    }
-
-    const handleText2Change: ChangeEventHandler<HTMLInputElement> = (e) => {
-      setText2(e.target.value)
-      if (onChange) onChange(e)
-    }
-
-    const handelText1Clear = () => {
-      setText1('')
-    }
-
-    const handelText2Clear = () => {
-      setText2('')
-    }
-
+  render: function Render() {
     return (
       <StoryLayout title="SearchBar - Filter">
         <StoryLayout.Section title="SearchBar - Filter">
           <SearchBarGrid title="Master">
-            <CosSearchBarFilter
-              value={text1}
-              onChange={handleText1Change}
-              onInputClear={handelText1Clear}
-            >
-              {mockOptions.map((option) => (
-                <CosSearchBarFilter.Item key={option.label}>
-                  <div className="grid grid-cols-4 gap-2">
-                    <div className="col-span-2">{option.label}</div>
-                    <div className="col-span-1">{option.option}</div>
-                    <div className="col-span-1 font-medium text-primary">
-                      {option.description}
-                    </div>
-                  </div>
-                </CosSearchBarFilter.Item>
-              ))}
-            </CosSearchBarFilter>
+            <SearchBarFilter isLoading={false} isNoData={false} />
           </SearchBarGrid>
           <SearchBarGrid title="No dropdown">
-            <CosSearchBarFilter
-              value={text2}
-              onChange={handleText2Change}
-              onInputClear={handelText2Clear}
-              showDropdown={false}
-            />
+            <SearchBarFilter isLoading={false} isNoData={true} />
           </SearchBarGrid>
         </StoryLayout.Section>
         <StoryLayout.Section title="Skeleton">
           <SearchBarGrid title="Master">
-            <CosSearchBarFilter isLoading={true} />
+            <SearchBarFilter isLoading={true} isNoData={true} />
           </SearchBarGrid>
         </StoryLayout.Section>
       </StoryLayout>

--- a/packages/cube-frontend-ui-library/src/stories/components/CosSearchBar/CosSearchBarGlobal.stories.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosSearchBar/CosSearchBarGlobal.stories.tsx
@@ -1,147 +1,50 @@
-import { ChangeEventHandler, Fragment, useState } from 'react'
 import { Meta, StoryObj } from '@storybook/react'
 import { StoryLayout } from '../../../internal/components/StoryLayout/StoryLayout'
 import { CosSearchBarGlobal } from '../../../components/CosSearchBar/CosSearchBarGlobal/CosSearchBarGlobal'
 import { SearchBarGrid } from './SearchBarGrid'
-import {
-  mockCategories,
-  mockSuggestions,
-  mockRecentSuggestions,
-} from './mockData'
+import { SearchBarGlobal } from './SearchBarGlobal'
 
 const meta = {
   title: 'Molecules/SearchBar/Global Search',
   component: CosSearchBarGlobal,
-  args: {},
 } satisfies Meta<typeof CosSearchBarGlobal>
 
 export default meta
 
 export const Gallery: StoryObj = {
   render: function Render() {
-    const [text1, setText1] = useState<string>('')
-
-    const [text2, setText2] = useState<string>('')
-
-    const [category, setCategory] = useState<string>()
-
-    const handleText1Change: ChangeEventHandler<HTMLInputElement> = (e) => {
-      setText1(e.target.value)
-    }
-
-    const handleText2Change: ChangeEventHandler<HTMLInputElement> = (e) => {
-      setText2(e.target.value)
-    }
-
-    const handelText1Clear = () => setText1('')
-
-    const handelText2Clear = () => setText2('')
-
-    const handleCategoryClick = (category: string) => setCategory(category)
-
-    const action = (action: string) => window.alert(action)
-
     return (
       <StoryLayout title="SearchBar - Global Search">
         <StoryLayout.Section title="SearchBar - Global Search">
           <SearchBarGrid title="Master">
-            <CosSearchBarGlobal
+            <SearchBarGlobal
+              isLoading={false}
               variant="regular"
-              value={text1}
-              onChange={handleText1Change}
-              onInputClear={handelText1Clear}
-            >
-              <Fragment>
-                {mockSuggestions.map((suggestion) => (
-                  <CosSearchBarGlobal.Item
-                    key={suggestion.value}
-                    type="suggestion"
-                    onClick={() => action('Suggestion selected!')}
-                  >
-                    {suggestion.value}
-                  </CosSearchBarGlobal.Item>
-                ))}
-                {mockRecentSuggestions.map((recentSuggestion) => (
-                  <CosSearchBarGlobal.Item
-                    key={recentSuggestion.value}
-                    type="recentSuggestion"
-                    onClick={() => action('Suggestion selected!')}
-                    onSuggestionClear={() => action('Suggestion cleared!')}
-                  >
-                    {recentSuggestion.value}
-                  </CosSearchBarGlobal.Item>
-                ))}
-              </Fragment>
-            </CosSearchBarGlobal>
+              isNoData={false}
+            />
           </SearchBarGrid>
-          <SearchBarGrid title="w/Sorting">
-            <CosSearchBarGlobal
-              variant="sorting"
-              value={text2}
-              categories={mockCategories}
-              selectedCategory={category}
-              onChange={handleText2Change}
-              onInputClear={handelText2Clear}
-              onCategoryClick={handleCategoryClick}
-            >
-              <Fragment>
-                {mockSuggestions.map((suggestion) => (
-                  <CosSearchBarGlobal.Item
-                    key={suggestion.value}
-                    type="suggestion"
-                    onClick={() => action('Suggestion selected!')}
-                  >
-                    {suggestion.value}
-                  </CosSearchBarGlobal.Item>
-                ))}
-                {mockRecentSuggestions.map((recentSuggestion) => (
-                  <CosSearchBarGlobal.Item
-                    key={recentSuggestion.value}
-                    type="recentSuggestion"
-                    onClick={() => action('Suggestion selected!')}
-                    onSuggestionClear={() => action('Suggestion cleared!')}
-                  >
-                    {recentSuggestion.value}
-                  </CosSearchBarGlobal.Item>
-                ))}
-              </Fragment>
-            </CosSearchBarGlobal>
+          <SearchBarGrid title="w/Category">
+            <SearchBarGlobal
+              isLoading={false}
+              variant="category"
+              isNoData={false}
+            />
+          </SearchBarGrid>
+          <SearchBarGrid title="No Dropdown/Category">
+            <SearchBarGlobal
+              isLoading={false}
+              variant="category"
+              isNoData={true}
+            />
           </SearchBarGrid>
         </StoryLayout.Section>
         <StoryLayout.Section title="Skeleton">
           <SearchBarGrid title="Master">
-            <CosSearchBarGlobal
+            <SearchBarGlobal
               isLoading={true}
-              variant="sorting"
-              value={text2}
-              categories={mockCategories}
-              selectedCategory={category}
-              onChange={handleText2Change}
-              onInputClear={handelText2Clear}
-              onCategoryClick={handleCategoryClick}
-            >
-              <Fragment>
-                {mockSuggestions.map((suggestion) => (
-                  <CosSearchBarGlobal.Item
-                    key={suggestion.value}
-                    type="suggestion"
-                    onClick={() => action('Suggestion selected!')}
-                  >
-                    {suggestion.value}
-                  </CosSearchBarGlobal.Item>
-                ))}
-                {mockRecentSuggestions.map((recentSuggestion) => (
-                  <CosSearchBarGlobal.Item
-                    key={recentSuggestion.value}
-                    type="recentSuggestion"
-                    onClick={() => action('Suggestion selected!')}
-                    onSuggestionClear={() => action('Suggestion cleared!')}
-                  >
-                    {recentSuggestion.value}
-                  </CosSearchBarGlobal.Item>
-                ))}
-              </Fragment>
-            </CosSearchBarGlobal>
+              variant="regular"
+              isNoData={true}
+            />
           </SearchBarGrid>
         </StoryLayout.Section>
       </StoryLayout>

--- a/packages/cube-frontend-ui-library/src/stories/components/CosSearchBar/SearchBarFilter.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosSearchBar/SearchBarFilter.tsx
@@ -1,0 +1,50 @@
+import { ChangeEventHandler, useState } from 'react'
+import { CosSearchBarFilter } from '../../../components/CosSearchBar/CosSearchBarFilter/CosSearchBarFilter'
+import { mockOptions } from './mockData'
+
+type SearchBarFilterProps = { isLoading: boolean; isNoData: boolean }
+
+export const SearchBarFilter = (props: SearchBarFilterProps) => {
+  const { isLoading, isNoData } = props
+
+  const [searchValue, setSearchValue] = useState('')
+
+  const handleSearchValueChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setSearchValue(e.target.value)
+  }
+
+  const handleSearchValueClear = () => {
+    setSearchValue('')
+  }
+
+  const renderOptions = () => {
+    if (isNoData) return []
+
+    return mockOptions
+      .filter((option) =>
+        option.label.toLowerCase().includes(searchValue.toLowerCase()),
+      )
+      .map(({ label, option, description }) => (
+        <CosSearchBarFilter.Item key={label}>
+          <div className="grid grid-cols-4 gap-2">
+            <div className="col-span-2">{label}</div>
+            <div className="col-span-1">{option}</div>
+            <div className="col-span-1 font-medium text-primary">
+              {description}
+            </div>
+          </div>
+        </CosSearchBarFilter.Item>
+      ))
+  }
+
+  return (
+    <CosSearchBarFilter
+      value={searchValue}
+      onChange={handleSearchValueChange}
+      onInputClear={handleSearchValueClear}
+      isLoading={isLoading}
+    >
+      {renderOptions()}
+    </CosSearchBarFilter>
+  )
+}

--- a/packages/cube-frontend-ui-library/src/stories/components/CosSearchBar/SearchBarGlobal.tsx
+++ b/packages/cube-frontend-ui-library/src/stories/components/CosSearchBar/SearchBarGlobal.tsx
@@ -1,0 +1,97 @@
+import { ChangeEventHandler, useState } from 'react'
+import { CosSearchBarGlobal } from '../../../components/CosSearchBar/CosSearchBarGlobal/CosSearchBarGlobal'
+import { CosSearchBarGlobalVariant } from '../../../components/CosSearchBar/CosSearchBarGlobal/cosSearchBarGlobalTypes'
+import {
+  mockCategories,
+  mockSuggestions,
+  mockRecentSuggestions,
+} from './mockData'
+
+type SearchBarGlobalProps = {
+  isLoading: boolean
+  variant: CosSearchBarGlobalVariant
+  isNoData: boolean
+}
+
+export const SearchBarGlobal = (props: SearchBarGlobalProps) => {
+  const { isLoading, variant, isNoData } = props
+
+  const [searchValue, setSearchValue] = useState('')
+
+  const [selectedCategory, setSelectedCategory] = useState<string>()
+
+  const handleSearchValueChange: ChangeEventHandler<HTMLInputElement> = (e) => {
+    setSearchValue(e.target.value)
+  }
+
+  const handleSearchValueClear = () => {
+    setSearchValue('')
+  }
+
+  const handleCategoryClick = (category: string) =>
+    setSelectedCategory(category)
+
+  const showAlert = (action: string) => window.alert(action)
+
+  const renderOptions = () => {
+    if (isNoData) return []
+
+    return [
+      ...mockSuggestions
+        .filter((suggestion) =>
+          suggestion.value.toLowerCase().includes(searchValue.toLowerCase()),
+        )
+        .map((suggestion) => (
+          <CosSearchBarGlobal.Item
+            key={suggestion.value}
+            type="suggestion"
+            onClick={() => showAlert('Suggestion selected!')}
+          >
+            {suggestion.value}
+          </CosSearchBarGlobal.Item>
+        )),
+      ...mockRecentSuggestions
+        .filter((suggestion) =>
+          suggestion.value.toLowerCase().includes(searchValue.toLowerCase()),
+        )
+        .map((recentSuggestion) => (
+          <CosSearchBarGlobal.Item
+            key={recentSuggestion.value}
+            type="recentSuggestion"
+            onClick={() => showAlert('Suggestion selected!')}
+            onSuggestionClear={() => showAlert('Suggestion cleared!')}
+          >
+            {recentSuggestion.value}
+          </CosSearchBarGlobal.Item>
+        )),
+    ]
+  }
+
+  if (variant === 'regular')
+    return (
+      <CosSearchBarGlobal
+        isLoading={isLoading}
+        variant="regular"
+        value={searchValue}
+        onChange={handleSearchValueChange}
+        onInputClear={handleSearchValueClear}
+      >
+        {renderOptions()}
+      </CosSearchBarGlobal>
+    )
+
+  return (
+    <CosSearchBarGlobal
+      isLoading={isLoading}
+      variant="category"
+      value={searchValue}
+      categories={isNoData ? [] : mockCategories}
+      selectedCategory={selectedCategory}
+      onChange={handleSearchValueChange}
+      onInputClear={handleSearchValueClear}
+      onCategoryClick={handleCategoryClick}
+    >
+      {renderOptions()}
+    </CosSearchBarGlobal>
+  )
+}

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectHosts/HostFilter.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectHosts/HostFilter.tsx
@@ -39,7 +39,6 @@ export const HostFilter = (props: HostFilterProps) => {
       <div className="w-[288px]">
         <CosSearchBarFilter
           value={keyword}
-          showDropdown={false}
           onChange={onKeywordChange}
           onInputClear={onKeywordClear}
         />

--- a/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/TuningSpecTableSection.tsx
+++ b/packages/cube-frontend-web-app/src/components/UpsertTunings/_components/SelectKeyValue/TuningSpecTableSection.tsx
@@ -32,7 +32,6 @@ export const TuningSpecTableSection = (props: TuningSpecTableSectionProps) => {
           placeholder="Search key or description"
           value={filter.keyword}
           isLoading={isLoading}
-          showDropdown={false}
           onChange={onKeywordChange}
           onInputClear={onKeywordClear}
         />

--- a/packages/cube-frontend-web-app/src/pages/events/index/_components/EventsTableFilter.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/index/_components/EventsTableFilter.tsx
@@ -138,7 +138,6 @@ export const EventsTableFilter = (props: EventsTableFilterProps) => {
             value={keyword}
             onChange={(e) => onKeywordChange(e.target.value)}
             onInputClear={() => onKeywordChange('')}
-            showDropdown={false}
           />
         </div>
         {eventsFilter &&

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/HardwareSerialNumberModal/LicenseAttachmentFilters.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseActions/HardwareSerialNumberModal/LicenseAttachmentFilters.tsx
@@ -56,7 +56,6 @@ export const LicenseAttachmentFilters = (
           value={searchKeyword}
           onChange={(e) => handleSearchKeywordChange(e.target.value)}
           onInputClear={handleSearchKeywordClear}
-          showDropdown={false}
         />
         <RoleFilter
           selectedRoles={selectedRoles}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseFilters/LicenseFilters.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/license/_components/LicenseFilters/LicenseFilters.tsx
@@ -67,7 +67,6 @@ export const LicenseFilters = (props: LicenseFiltersProps) => {
           value={searchKeyword}
           onChange={(e) => handleSearchKeywordChange(e.target.value)}
           onInputClear={handleSearchKeywordClear}
-          showDropdown={false}
         />
         <ProductFilter
           selectedProducts={selectedProducts}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/SupportFilesFilters.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/supportFiles/_components/SupportFilesFilters.tsx
@@ -79,7 +79,6 @@ export const SupportFilesFilters = (props: SupportFilesFiltersProps) => {
           value={keyword}
           onChange={(e) => handleSearchKeywordChange(e.target.value)}
           onInputClear={handleSearchKeywordClear}
-          showDropdown={false}
         />
         <RoleFilter
           selectedRoles={roles}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/tunings/TuningsFilter.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/tunings/TuningsFilter.tsx
@@ -30,7 +30,6 @@ export const TuningsFilter = (props: TuningsFilterProps) => {
     <div className="flex items-center gap-x-2">
       <CosSearchBarFilter
         value={query.keyword}
-        showDropdown={false}
         onChange={onKeywordChange}
         onInputClear={onKeywordClear}
       />

--- a/packages/cube-frontend-web-app/src/pages/node/_components/NodeFilters.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/_components/NodeFilters.tsx
@@ -35,7 +35,6 @@ export const NodeFilters = (props: NodeFiltersProps) => {
           value={keyword}
           onChange={(e) => handleKeywordChange(e.target.value)}
           onInputClear={handleKeywordClear}
-          showDropdown={false}
         />
         <RoleFilter
           selectedRoles={roles}


### PR DESCRIPTION
#### What type of PR is this?

- Enhancement

#### What this PR does / why we need it

##### 1. CosDropdown
- 1). When there is no data, display `No Data` in the menu ([77cc97f](https://github.com/bigstack-oss/cube-cos-ui/pull/632/commits/77cc97fa062883b57cf64851454d7420df853973))
- 2). Update the size of checkboxes in the dropdown to match the design guideline ([3ebea97](https://github.com/bigstack-oss/cube-cos-ui/pull/632/commits/3ebea976aea0b692d172598ce3cf4b7ba246cc99))


https://github.com/user-attachments/assets/4b24ac6c-5c65-4250-a18a-6837b932356a

<img width="1190" height="459" alt="Screenshot 2025-08-20 at 5 30 52 PM" src="https://github.com/user-attachments/assets/e0026c26-a4ad-4478-9310-369275afcb66" />

| <img width="1148" height="531" alt="Screenshot 2025-08-20 at 5 32 00 PM" src="https://github.com/user-attachments/assets/9f1f4398-aa5d-45d2-adc5-0cf74216337b" /> |  <img width="1114" height="530" alt="Screenshot 2025-08-20 at 5 31 26 PM" src="https://github.com/user-attachments/assets/5fa7ca93-1e44-4816-b8c7-8a60003d2d9e" />
|---------------------------|---------------------------|

##### 2. CosSearchBarFilter
- When there is no data, the menu should not open ([05e6408](https://github.com/bigstack-oss/cube-cos-ui/pull/632/commits/05e6408a59e9f9913393ef743bdd556ebf9bfa80))

https://github.com/user-attachments/assets/b5ae4b0e-c25d-4b75-9925-6521132c690f

##### 3. CosSearchBarGlobal
- 1). When there is no data, the menu should not open ([5373e00](https://github.com/bigstack-oss/cube-cos-ui/pull/632/commits/5373e007b1d20ffadca1c7a03a42e3a2b5003e27))
- 2). When there is no data, display `No Data` in the `Category` menu

https://github.com/user-attachments/assets/87d00ad1-1eb8-45df-b784-c6879782ee3a

#### Which issue(s) this PR fixes

Fixes #592 

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```

