### PR TITLE
Fix: Display Verify Script Message Correctly

### DIFF
--- a/packages/cube-frontend-web-app/src/components/UpsertTriggers/_components/SetResponse/PersonalizedScriptModal/useUploadScript.ts
+++ b/packages/cube-frontend-web-app/src/components/UpsertTriggers/_components/SetResponse/PersonalizedScriptModal/useUploadScript.ts
@@ -1,4 +1,6 @@
 import { useContext, useEffect, useState } from 'react'
+import { isAxiosError } from 'axios'
+import { upperFirst } from 'lodash'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { fileToBase64 } from '@cube-frontend/web-app/utils/file'
 import { triggersApi } from '@cube-frontend/web-app/api/cosApi'
@@ -107,17 +109,31 @@ export const useUploadScript = (
         verifyMaterialScriptRequest: { script: scriptInfo.content },
       })
 
-      const formattedResult = `Script:\n${testResult.data.data}\n\nResult:\n${testResult.data.msg}`
+      const formattedResult =
+        `Script:\n` +
+        `${testResult.data.data}\n\n` +
+        `Result:\n${upperFirst(testResult.data.msg)}`
 
       setShowScriptTestResult({
         status: 'testSucceeded',
         message: formattedResult,
       })
     } catch (error) {
-      setShowScriptTestResult({
-        status: 'testFailed',
-        message: 'Error occurred when verifying script: ' + error,
-      })
+      if (isAxiosError(error)) {
+        setShowScriptTestResult({
+          status: 'testFailed',
+          message:
+            `${upperFirst(error?.response?.data.status)}\n\n` +
+            `${upperFirst(error?.response?.data.msg)}`,
+        })
+      } else {
+        setShowScriptTestResult({
+          status: 'testFailed',
+          message:
+            `Error occurred when verifying script:\n\n` +
+            (error || 'Unknown error'),
+        })
+      }
     }
   }
 


### PR DESCRIPTION
#### What type of PR is this?

- fix

#### What this PR does / why we need it

- When verifying a personalised script during trigger creation or editing, if the verification fails, display the corresponding status and message from the response.

### Before

https://github.com/user-attachments/assets/bf2ba26a-d47f-44ed-aba3-b3ae3c27221b

### After

https://github.com/user-attachments/assets/69bbfea5-afd7-449b-acfe-6547e8e38d3c



#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

> Note

#### Additional documentation

```docs

```
