### PR TITLE
620 firmware removal and action button state

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/CosCheckbox.tsx
@@ -20,6 +20,7 @@ export type CosCheckboxProps = Omit<
   InputHTMLAttributes<HTMLInputElement>,
   'checked' | 'defaultChecked'
 > & {
+  containerClassName?: string
   /**
    * @default primary
    */
@@ -44,6 +45,7 @@ export type CosCheckboxProps = Omit<
 
 export const CosCheckbox = (props: CosCheckboxProps) => {
   const {
+    containerClassName,
     color = 'primary',
     label,
     labelSize = 'md',
@@ -103,7 +105,10 @@ export const CosCheckbox = (props: CosCheckboxProps) => {
   return (
     <label
       htmlFor={id}
-      className={twMerge(checkbox.container({ size: labelSize, disabled }))}
+      className={twMerge(
+        checkbox.container({ size: labelSize, disabled }),
+        containerClassName,
+      )}
     >
       <input
         {...restProps}

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/styles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/styles.ts
@@ -1,12 +1,12 @@
 import { cva } from 'class-variance-authority'
 
 export const checkbox = {
-  container: cva('inline-flex w-fit cursor-pointer gap-x-2', {
+  container: cva('inline-flex w-fit cursor-pointer items-center gap-x-2', {
     variants: {
       size: {
-        md: 'primary-body2 items-start',
-        sm: 'primary-body3 items-center',
-        xs: 'primary-body4 items-center',
+        md: 'primary-body2',
+        sm: 'primary-body3',
+        xs: 'primary-body4',
       },
       disabled: {
         true: 'cursor-default',

--- a/packages/cube-frontend-ui-library/src/components/CosCheckbox/styles.ts
+++ b/packages/cube-frontend-ui-library/src/components/CosCheckbox/styles.ts
@@ -1,12 +1,12 @@
 import { cva } from 'class-variance-authority'
 
 export const checkbox = {
-  container: cva('inline-flex w-fit cursor-pointer items-center gap-x-2', {
+  container: cva('inline-flex w-fit cursor-pointer gap-x-2', {
     variants: {
       size: {
-        md: 'primary-body2',
-        sm: 'primary-body3',
-        xs: 'primary-body4',
+        md: 'primary-body2 items-start',
+        sm: 'primary-body3 items-center',
+        xs: 'primary-body4 items-center',
       },
       disabled: {
         true: 'cursor-default',

--- a/packages/cube-frontend-ui-library/src/components/CosNagging/CosNagging.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosNagging/CosNagging.tsx
@@ -19,6 +19,7 @@ export type CosNaggingLink = Pick<CosHyperlinkProps, 'href' | 'onClick'> & {
 export type CosNaggingProps = PropsWithClassName & {
   type: CosNaggingType
   title: string
+  titleClassName?: string
   description?: string | string[]
   link?: CosNaggingLink
 } & (
@@ -57,7 +58,8 @@ const typeIcons: Record<CosNaggingType, SvgElement> = {
 }
 
 export const CosNagging = (props: CosNaggingProps) => {
-  const { className, type, variant, title, description, link } = props
+  const { className, type, variant, title, titleClassName, description, link } =
+    props
 
   const isVariantSidebar = variant === 'sidebar'
 
@@ -65,7 +67,12 @@ export const CosNagging = (props: CosNaggingProps) => {
 
   const renderTitle = () => {
     const titleElement = (
-      <div className="primary-body4 font-semibold text-functional-title">
+      <div
+        className={twMerge(
+          'primary-body4 font-semibold text-functional-title',
+          titleClassName,
+        )}
+      >
         {title}
       </div>
     )

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
@@ -92,10 +92,12 @@ export const MaintenanceUpdateFirmwarePage = () => {
             onClick={() => showUpdateFirmwareModal(version)}
           />
         )}
-        <DeleteAction
-          state={deleteActionState}
-          onClick={() => showDeleteFirmwareModal(version)}
-        />
+        {deleteActionState !== 'hidden' && (
+          <DeleteAction
+            state={deleteActionState}
+            onClick={() => showDeleteFirmwareModal(version)}
+          />
+        )}
       </div>
     )
   }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
@@ -86,18 +86,16 @@ export const MaintenanceUpdateFirmwarePage = () => {
 
     return (
       <div className="flex items-center">
-        {row.status.isUpdatable && (
+        {updateActionState !== 'hidden' && (
           <UpdateAction
             state={updateActionState}
             onClick={() => showUpdateFirmwareModal(version)}
           />
         )}
-        {row.status.isRemovable && (
-          <DeleteAction
-            state={deleteActionState}
-            onClick={() => showDeleteFirmwareModal(version)}
-          />
-        )}
+        <DeleteAction
+          state={deleteActionState}
+          onClick={() => showDeleteFirmwareModal(version)}
+        />
       </div>
     )
   }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
@@ -4,7 +4,6 @@ import {
   CosPagination,
   GetCosBasicTable,
 } from '@cube-frontend/ui-library'
-import Trash from '@cube-frontend/ui-library/icons/monochrome/delete.svg?react'
 import InformationCircle from '@cube-frontend/ui-library/icons/monochrome/information_circle.svg?react'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useOpenState } from '@cube-frontend/web-app/hooks/useOpenState/useOpenState'
@@ -12,7 +11,18 @@ import dayjs from 'dayjs'
 import { useContext } from 'react'
 import { MaintenanceUpdateLayout } from '../_components/MaintenanceUpdateLayout'
 import { ReleaseNotePanel } from '../_components/ReleaseNotePanel'
+import { useCephHealthStatus } from '../_components/useCephHealthStatus'
 import { useReleaseNotePanel } from '../_components/useReleaseNotePanel'
+import { DeleteAction } from './actions/delete/DeleteAction'
+import { DeleteFirmwareModal } from './actions/delete/DeleteFirmwareModal'
+import { useDeleteFirmwareModal } from './actions/delete/useDeleteFirmwareModal'
+import { UpdateAction } from './actions/update/UpdateAction'
+import { UpdateFirmwareModal } from './actions/update/UpdateFirmwareModal'
+import { useUpdateFirmwareModal } from './actions/update/useUpdateFirmwareModal'
+import {
+  computeFirmwareDeleteActionState,
+  computeFirmwareUpdateActionState,
+} from './computeFirmwaresActionState'
 import { FirmwareRow } from './listFirmwaresUtils'
 import { UploadFirmwareModal } from './UploadFirmwareModal'
 import { useListFirmwares } from './useListFirmwares'
@@ -37,9 +47,59 @@ export const MaintenanceUpdateFirmwarePage = () => {
   const { rowForReleaseNote, showReleaseNoteFor, releaseNotePanel } =
     useReleaseNotePanel<FirmwareRow>()
 
+  const cephHealthStatus = useCephHealthStatus()
+
+  const {
+    firmwareVersionToUpdate,
+    showUpdateFirmwareModal,
+    closeUpdateFirmwareModal,
+    updateModalTitle,
+    updateModalContent,
+    updateModalActionProps,
+  } = useUpdateFirmwareModal(listFirmwares)
+
+  const {
+    firmwareVersionToDelete,
+    showDeleteFirmwareModal,
+    closeDeleteFirmwareModal,
+  } = useDeleteFirmwareModal()
+
+  const onFirmwareDeleted = (): void => {
+    listFirmwares()
+    closeDeleteFirmwareModal()
+  }
+
   const formatUpdatedAt = (updatedAt: string): string => {
     if (!updatedAt) return ''
     return dayjs.respectTzOffset(updatedAt).format('YYYY/MM/DD')
+  }
+
+  const renderActions = (row: FirmwareRow) => {
+    const version = row.version
+
+    const updateActionState = computeFirmwareUpdateActionState(
+      row,
+      cephHealthStatus,
+    )
+
+    const deleteActionState = computeFirmwareDeleteActionState(row)
+
+    return (
+      <div className="flex items-center">
+        {row.status.isUpdatable && (
+          <UpdateAction
+            state={updateActionState}
+            onClick={() => showUpdateFirmwareModal(version)}
+          />
+        )}
+        {row.status.isRemovable && (
+          <DeleteAction
+            state={deleteActionState}
+            onClick={() => showDeleteFirmwareModal(version)}
+          />
+        )}
+      </div>
+    )
   }
 
   return (
@@ -97,22 +157,7 @@ export const MaintenanceUpdateFirmwarePage = () => {
                 fitContent={true}
                 skeletonVariant="icon-right"
               >
-                {() => (
-                  <div className="flex items-center">
-                    <CosButton
-                      type="ghost"
-                      onClick={(e) => e.stopPropagation()}
-                    >
-                      Update
-                    </CosButton>
-                    <CosButton
-                      type="ghost"
-                      usage="icon-only"
-                      Icon={Trash}
-                      onClick={(e) => e.stopPropagation()}
-                    />
-                  </div>
-                )}
+                {(_, row) => renderActions(row)}
               </FirmwareTable.Column>
             </FirmwareTable>
             <CosPagination
@@ -135,6 +180,18 @@ export const MaintenanceUpdateFirmwarePage = () => {
         isOpen={isUploadModalOpen}
         onClose={closeUploadModal}
         onMd5Verified={listFirmwares}
+      />
+      <UpdateFirmwareModal
+        version={firmwareVersionToUpdate}
+        title={updateModalTitle}
+        content={updateModalContent}
+        updateModalActionProps={updateModalActionProps}
+        onCloseClick={closeUpdateFirmwareModal}
+      />
+      <DeleteFirmwareModal
+        version={firmwareVersionToDelete}
+        onCloseClick={closeDeleteFirmwareModal}
+        onDeleted={onFirmwareDeleted}
       />
     </MaintenanceUpdateLayout>
   )

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteAction.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteAction.tsx
@@ -1,0 +1,54 @@
+import {
+  CosButton,
+  CosTooltip,
+  CosTooltipInformation,
+} from '@cube-frontend/ui-library'
+import Trash from '@cube-frontend/ui-library/icons/monochrome/delete.svg?react'
+import { MouseEvent } from 'react'
+import { DeleteActionState } from '../../computeFirmwaresActionState'
+
+type DeleteActionProps = {
+  state: DeleteActionState
+  onClick: () => void
+}
+
+export const DeleteAction = (props: DeleteActionProps) => {
+  const { state, onClick: onClickProp } = props
+
+  const getHoverTooltipContent = (): CosTooltipInformation | undefined => {
+    if (state === 'inProgress') {
+      return { message: 'Deletion is ongoing' }
+    }
+
+    if (state === 'blockedByUpdated') {
+      return { message: 'Deletion is blocked because the firmware is updated.' }
+    }
+
+    if (state === 'unavailable') {
+      return { message: 'Deletion is unavailable for this firmware.' }
+    }
+
+    return undefined
+  }
+
+  const onClick = (e: MouseEvent<HTMLButtonElement>): void => {
+    // Stop propagation because the table row is clickable.
+    e.stopPropagation()
+    onClickProp()
+  }
+
+  return (
+    <CosTooltip hoverContent={getHoverTooltipContent()}>
+      {/* Wrap the button with a <span> because the hover event doesn't work
+      when the button is disabled. */}
+      <span>
+        <CosButton
+          type="ghost"
+          usage="icon-only"
+          Icon={Trash}
+          onClick={onClick}
+        />
+      </span>
+    </CosTooltip>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteAction.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteAction.tsx
@@ -16,16 +16,15 @@ export const DeleteAction = (props: DeleteActionProps) => {
   const { state, onClick: onClickProp } = props
 
   const getHoverTooltipContent = (): CosTooltipInformation | undefined => {
-    if (state === 'inProgress') {
-      return { message: 'Deletion is ongoing' }
+    if (state === 'blockedByProcessing') {
+      return {
+        message:
+          'Deletion is blocked because the firmware is currently being updated.',
+      }
     }
 
     if (state === 'blockedByUpdated') {
       return { message: 'Deletion is blocked because the firmware is updated.' }
-    }
-
-    if (state === 'unavailable') {
-      return { message: 'Deletion is unavailable for this firmware.' }
     }
 
     return undefined

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteAction.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteAction.tsx
@@ -23,10 +23,6 @@ export const DeleteAction = (props: DeleteActionProps) => {
       }
     }
 
-    if (state === 'blockedByUpdated') {
-      return { message: 'Deletion is blocked because the firmware is updated.' }
-    }
-
     return undefined
   }
 

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteFirmwareModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteFirmwareModal.tsx
@@ -44,7 +44,8 @@ export const DeleteFirmwareModal = (props: DeleteFirmwareModalProps) => {
       onCloseClick={onCloseClick}
     >
       <div className="primary-body3 text-functional-text">
-        {`Are you sure you want to delete this firmware ${version}?`}
+        Are you sure you want to delete{' '}
+        <b className="font-semibold">{version}</b>?
       </div>
     </CosModal>
   )

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteFirmwareModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/DeleteFirmwareModal.tsx
@@ -1,0 +1,51 @@
+import { CosModal } from '@cube-frontend/ui-library'
+import { firmwaresApi } from '@cube-frontend/web-app/api/cosApi'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
+import { useContext } from 'react'
+
+type DeleteFirmwareModalProps = {
+  version: string | undefined
+  onCloseClick: () => void
+  onDeleted: () => void
+}
+
+export const DeleteFirmwareModal = (props: DeleteFirmwareModalProps) => {
+  const { version, onCloseClick, onDeleted } = props
+
+  const { dataCenter } = useContext(DataCenterContext)
+
+  const { isLoading, mutateResource: deleteFirmware } = useCosMutationRequest(
+    firmwaresApi.deleteFirmware,
+  )
+
+  const onDeleteClick = async (): Promise<void> => {
+    if (!version) return
+
+    try {
+      await deleteFirmware({
+        dataCenter: dataCenter!.name,
+        version,
+      })
+      onDeleted()
+    } catch (error) {
+      console.error('Delete firmware error: ', error)
+    }
+  }
+
+  return (
+    <CosModal
+      isOpen={!!version}
+      title="Delete Firmware"
+      size="sm"
+      actionText="Yes, delete"
+      actionButtonProps={{ loading: isLoading }}
+      onActionClick={onDeleteClick}
+      onCloseClick={onCloseClick}
+    >
+      <div className="primary-body3 text-functional-text">
+        {`Are you sure you want to delete this firmware ${version}?`}
+      </div>
+    </CosModal>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/useDeleteFirmwareModal.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/delete/useDeleteFirmwareModal.ts
@@ -1,0 +1,27 @@
+import { useState } from 'react'
+
+type UseDeleteFirmwareModal = {
+  firmwareVersionToDelete: string | undefined
+  showDeleteFirmwareModal: (version: string) => void
+  closeDeleteFirmwareModal: () => void
+}
+
+export const useDeleteFirmwareModal = (): UseDeleteFirmwareModal => {
+  const [firmwareVersionToDelete, setFirmwareVersionToDelete] = useState<
+    string | undefined
+  >(undefined)
+
+  const showDeleteFirmwareModal = (version: string): void => {
+    setFirmwareVersionToDelete(version)
+  }
+
+  const closeDeleteFirmwareModal = (): void => {
+    setFirmwareVersionToDelete(undefined)
+  }
+
+  return {
+    firmwareVersionToDelete,
+    showDeleteFirmwareModal,
+    closeDeleteFirmwareModal,
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/NodeUpdate.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/NodeUpdate.tsx
@@ -1,0 +1,80 @@
+import {
+  CosButton,
+  CosNagging,
+  GetCosBasicTable,
+} from '@cube-frontend/ui-library'
+import { upperFirst } from 'lodash'
+import { UpdateStatus } from './UpdateStatus'
+import { UpgradeProgressRow } from './updateActionUtils'
+
+type NodeUpdateProps = {
+  upgradeProgressRows: UpgradeProgressRow[]
+  isRolling: boolean
+}
+
+const UpgradeProgressTable = GetCosBasicTable<UpgradeProgressRow>()
+
+export const NodeUpdate = (props: NodeUpdateProps) => {
+  const { isRolling, upgradeProgressRows } = props
+
+  return (
+    <div className="flex flex-col gap-y-5">
+      <div className="primary-body2 text-functional-text">
+        Currently updating the following nodes...
+      </div>
+      <UpgradeProgressTable rows={upgradeProgressRows}>
+        <UpgradeProgressTable.Column label="Host" property="host" />
+        <UpgradeProgressTable.Column label="Status" property="status">
+          {(status) => <UpdateStatus status={status} />}
+        </UpgradeProgressTable.Column>
+        <UpgradeProgressTable.Column label="Phase" property="phase">
+          {(phase) => {
+            return phase ? (
+              <div className="font-semibold text-cosmos-primary">
+                {upperFirst(phase)}
+              </div>
+            ) : (
+              <div>-</div>
+            )
+          }}
+        </UpgradeProgressTable.Column>
+        <UpgradeProgressTable.Column label="Updating Details" property="status">
+          {(status) =>
+            status.description ? upperFirst(status.description) : '-'
+          }
+        </UpgradeProgressTable.Column>
+        <UpgradeProgressTable.Column property="status">
+          {(status) => {
+            if (status.current === 'failed')
+              return (
+                <div className="flex justify-end">
+                  <CosButton
+                    size="sm"
+                    type="warning"
+                    onClick={() => window.alert('click')}
+                  >
+                    Continue Anyway
+                  </CosButton>
+                </div>
+              )
+            return null
+          }}
+        </UpgradeProgressTable.Column>
+      </UpgradeProgressTable>
+      {isRolling && (
+        <div className="primary-body2 text-functional-text">
+          Each node will be updated one by one. Running VMs will be
+          automatically evacuated before update.
+        </div>
+      )}
+      <CosNagging
+        variant="top"
+        type="warning"
+        title="If a node fails to update, please resolve the issue manually to
+        continue."
+        className="w-full"
+        titleClassName="font-normal text-functional-text"
+      />
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdatableNodes.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdatableNodes.tsx
@@ -36,6 +36,7 @@ export const UpdatableNodes = (props: UpdatableNodesProps) => {
       </UpdatableNodeTable>
       <div className="flex items-start gap-x-2">
         <CosCheckbox
+          containerClassName="items-start"
           label="Rolling update — each node will be updated one by one. If any node is
           currently hosting running VMs, they will be automatically evacuated
           before the update to avoid service disruption."

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdatableNodes.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdatableNodes.tsx
@@ -1,0 +1,49 @@
+import { CosCheckbox, GetCosBasicTable } from '@cube-frontend/ui-library'
+import { UpdatableNodeRow } from './updateActionUtils'
+
+type UpdatableNodesProps = {
+  updatableNodeRows: UpdatableNodeRow[]
+  isRolling: boolean
+  onIsRollingCheck: () => void
+}
+
+const UpdatableNodeTable = GetCosBasicTable<UpdatableNodeRow>()
+
+export const UpdatableNodes = (props: UpdatableNodesProps) => {
+  const { updatableNodeRows, isRolling, onIsRollingCheck } = props
+
+  return (
+    <div className="flex flex-col gap-y-5">
+      <div className="primary-body2 text-functional-text">
+        Do you want to update these nodes:
+      </div>
+      <UpdatableNodeTable rows={updatableNodeRows}>
+        <UpdatableNodeTable.Column label="Host" property="name" />
+        <UpdatableNodeTable.Column
+          label="(Active) Firmware version"
+          property="firmware"
+          emphasize={true}
+        >
+          {(firmware) => firmware.active}
+        </UpdatableNodeTable.Column>
+        <UpdatableNodeTable.Column
+          label="(Inactive) Firmware version"
+          property="firmware"
+          emphasize={true}
+        >
+          {(firmware) => firmware.inactive}
+        </UpdatableNodeTable.Column>
+      </UpdatableNodeTable>
+      <div className="flex items-start gap-x-2">
+        <CosCheckbox
+          label="Rolling update — each node will be updated one by one. If any node is
+          currently hosting running VMs, they will be automatically evacuated
+          before the update to avoid service disruption."
+          labelClassName="max-w-none"
+          checked={isRolling}
+          onChange={onIsRollingCheck}
+        />
+      </div>
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateAction.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateAction.tsx
@@ -1,9 +1,9 @@
-import { MouseEvent } from 'react'
 import {
   CosButton,
   CosTooltip,
   CosTooltipInformation,
 } from '@cube-frontend/ui-library'
+import { MouseEvent } from 'react'
 import { UpdateActionState } from '../../computeFirmwaresActionState'
 
 type UpdateActionProps = {
@@ -25,10 +25,6 @@ export const UpdateAction = (props: UpdateActionProps) => {
 
     if (state === 'blockedByUnhealthyCeph') {
       return { message: 'Update is blocked because Ceph is unhealthy.' }
-    }
-
-    if (state === 'unavailable') {
-      return { message: 'Update is unavailable for this firmware.' }
     }
 
     return undefined

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateAction.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateAction.tsx
@@ -1,0 +1,54 @@
+import { MouseEvent } from 'react'
+import {
+  CosButton,
+  CosTooltip,
+  CosTooltipInformation,
+} from '@cube-frontend/ui-library'
+import { UpdateActionState } from '../../computeFirmwaresActionState'
+
+type UpdateActionProps = {
+  state: UpdateActionState
+  onClick: () => void
+}
+
+export const UpdateAction = (props: UpdateActionProps) => {
+  const { state, onClick: onClickProp } = props
+
+  const getHoverTooltipContent = (): CosTooltipInformation | undefined => {
+    if (state === 'inProgress') {
+      return { message: 'Update is ongoing' }
+    }
+
+    if (state === 'blockedByCheckingCephHealth') {
+      return { message: 'Update is blocked by checking Ceph health.' }
+    }
+
+    if (state === 'blockedByUnhealthyCeph') {
+      return { message: 'Update is blocked because Ceph is unhealthy.' }
+    }
+
+    if (state === 'unavailable') {
+      return { message: 'Update is unavailable for this firmware.' }
+    }
+
+    return undefined
+  }
+
+  const onClick = (e: MouseEvent<HTMLButtonElement>): void => {
+    // Stop propagation because the table row is clickable.
+    e.stopPropagation()
+    onClickProp()
+  }
+
+  return (
+    <CosTooltip hoverContent={getHoverTooltipContent()}>
+      {/* Wrap the button with a <span> because the hover event doesn't work
+      when the button is disabled. */}
+      <span>
+        <CosButton type="ghost" onClick={onClick}>
+          Update
+        </CosButton>
+      </span>
+    </CosTooltip>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateFirmwareModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateFirmwareModal.tsx
@@ -1,0 +1,29 @@
+import { CosModal, CosModalProps } from '@cube-frontend/ui-library'
+import { ReactNode } from 'react'
+
+type UpdateFirmwareModalProps = {
+  version: string | undefined
+  title: string
+  content: () => ReactNode
+  updateModalActionProps: Pick<
+    CosModalProps,
+    'actionText' | 'onActionClick' | 'actionButtonProps'
+  >
+  onCloseClick: () => void
+}
+
+export const UpdateFirmwareModal = (props: UpdateFirmwareModalProps) => {
+  const { version, title, content, updateModalActionProps, onCloseClick } =
+    props
+
+  return (
+    <CosModal
+      isOpen={!!version}
+      title={title}
+      {...updateModalActionProps}
+      onCloseClick={onCloseClick}
+    >
+      {content()}
+    </CosModal>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateStatus.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateStatus.tsx
@@ -1,0 +1,46 @@
+import CircleFill from '@cube-frontend/ui-library/icons/monochrome/circle_fill.svg?react'
+import CrossFill from '@cube-frontend/ui-library/icons/monochrome/cross_fill.svg?react'
+import { GetFirmwareUpgradeProgressResponseDataProgressesInnerStatus } from '@cube-frontend/api'
+import { upperFirst } from 'lodash'
+
+type UpdateStatusProps = {
+  status: GetFirmwareUpgradeProgressResponseDataProgressesInnerStatus
+}
+
+export const UpdateStatus = (props: UpdateStatusProps) => {
+  const { status } = props
+
+  const isOngoingStatus =
+    status.current === 'installing' || status.current === 'waitingReboot'
+
+  if (status.current === 'available')
+    return (
+      <div className="flex items-center gap-x-2 text-status-positive">
+        <CircleFill className="icon-md" />
+        <span>Succeeded</span>
+      </div>
+    )
+
+  if (status.current === 'failed')
+    return (
+      <div className="flex items-center gap-x-2 text-status-negative">
+        <CrossFill className="icon-md" />
+        <span>Failed</span>
+      </div>
+    )
+
+  if (status.current === 'resolved')
+    return (
+      <div className="flex items-center gap-x-2 text-status-neutral">
+        <div className="size-[14px] rounded-full bg-status-neutral" />
+        <span>Resolved</span>
+      </div>
+    )
+
+  return (
+    <div className="flex items-center gap-x-5">
+      <div>{upperFirst(status.current)}</div>
+      {isOngoingStatus && <div>{status.processPercent}%</div>}
+    </div>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateStatus.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/UpdateStatus.tsx
@@ -1,10 +1,10 @@
+import { GetFirmwareUpgradeProgressResponseDataProgressesInnerStatus as ProgressStatus } from '@cube-frontend/api'
 import CircleFill from '@cube-frontend/ui-library/icons/monochrome/circle_fill.svg?react'
 import CrossFill from '@cube-frontend/ui-library/icons/monochrome/cross_fill.svg?react'
-import { GetFirmwareUpgradeProgressResponseDataProgressesInnerStatus } from '@cube-frontend/api'
 import { upperFirst } from 'lodash'
 
 type UpdateStatusProps = {
-  status: GetFirmwareUpgradeProgressResponseDataProgressesInnerStatus
+  status: ProgressStatus
 }
 
 export const UpdateStatus = (props: UpdateStatusProps) => {

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/updateActionUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/updateActionUtils.ts
@@ -1,0 +1,17 @@
+import {
+  GetFirmwareUpgradeProgressResponseDataProgressesInner,
+  ListFirmwareUpdatableNodesResponseDataInner,
+} from '@cube-frontend/api'
+import { CosTableRow } from '@cube-frontend/ui-library'
+
+export type UpdatableNodeRow = ListFirmwareUpdatableNodesResponseDataInner &
+  CosTableRow
+
+export type UpgradeProgressRow =
+  GetFirmwareUpgradeProgressResponseDataProgressesInner & CosTableRow
+
+export type UpdateModalStep =
+  | 'updatableNodes'
+  | 'rollingUpdating'
+  | 'nonRollingUpdating'
+  | 'rebootCluster'

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/useUpdateFirmwareModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/useUpdateFirmwareModal.tsx
@@ -1,0 +1,144 @@
+import { ListFirmwaresResponseData } from '@cube-frontend/api'
+import { CosModalProps } from '@cube-frontend/ui-library'
+import { ReactNode, useMemo, useState } from 'react'
+import { mockUpdatableNodes, mockUpdateProgresses } from '../../mockFirmware'
+import { NodeUpdate } from './NodeUpdate'
+import { UpdatableNodes } from './UpdatableNodes'
+import { UpdateModalStep } from './updateActionUtils'
+
+const DONE_STATES = ['available', 'resolved']
+
+type UseUpdateFirmwareModal = {
+  firmwareVersionToUpdate: string | undefined
+  showUpdateFirmwareModal: (version: string) => void
+  closeUpdateFirmwareModal: () => void
+
+  updateModalTitle: string
+  updateModalContent: () => ReactNode
+  updateModalActionProps: Pick<
+    CosModalProps,
+    'actionText' | 'onActionClick' | 'actionButtonProps'
+  >
+}
+
+export const useUpdateFirmwareModal = (
+  listFirmwares: () => Promise<ListFirmwaresResponseData>,
+): UseUpdateFirmwareModal => {
+  const [firmwareVersionToUpdate, setFirmwareVersionToUpdate] = useState<
+    string | undefined
+  >(undefined)
+
+  const [currentStep, setCurrentStep] =
+    useState<UpdateModalStep>('updatableNodes')
+
+  const [isRolling, setIsRolling] = useState(false)
+
+  const updatableNodeRows = useMemo(() => {
+    return mockUpdatableNodes.map((node) => ({ ...node, id: node.name }))
+  }, [])
+
+  const upgradeProgressRows = useMemo(() => {
+    return mockUpdateProgresses.progresses.map((progress) => ({
+      ...progress,
+      id: progress.host,
+    }))
+  }, [])
+
+  const isFirmwareUpdateDone = useMemo((): boolean => {
+    if (!upgradeProgressRows.length) return false
+    return upgradeProgressRows.every(
+      (progress) =>
+        !progress.status.isProcessing &&
+        DONE_STATES.includes(progress.status.current),
+    )
+  }, [upgradeProgressRows])
+
+  const showUpdateFirmwareModal = (version: string): void => {
+    setFirmwareVersionToUpdate(version)
+  }
+
+  const closeUpdateFirmwareModal = (): void => {
+    setIsRolling(false)
+    setCurrentStep('updatableNodes')
+    setFirmwareVersionToUpdate(undefined)
+  }
+
+  const modalTitleMap: Record<UpdateModalStep, string> = {
+    updatableNodes: 'Firmware Update',
+    rollingUpdating: 'Firmware Updating (Rolling)',
+    nonRollingUpdating: 'Firmware Updating (Non-Rolling)',
+    rebootCluster: 'Reboot Cluster',
+  }
+
+  const modalContentMap: Record<UpdateModalStep, () => ReactNode> = {
+    updatableNodes: () => (
+      <UpdatableNodes
+        updatableNodeRows={updatableNodeRows}
+        isRolling={isRolling}
+        onIsRollingCheck={() => setIsRolling((prev) => !prev)}
+      />
+    ),
+    rollingUpdating: () => (
+      <NodeUpdate
+        isRolling={isRolling}
+        upgradeProgressRows={upgradeProgressRows}
+      />
+    ),
+    nonRollingUpdating: () => (
+      <NodeUpdate
+        isRolling={isRolling}
+        upgradeProgressRows={upgradeProgressRows}
+      />
+    ),
+    rebootCluster: () => (
+      <div className="primary-body3 text-functional-title">
+        Please be aware that selecting{' '}
+        <span className="font-semibold">Reboot</span> will make the system
+        unavailable for some time.
+      </div>
+    ),
+  }
+
+  const modalActionPropsMap: Record<
+    UpdateModalStep,
+    Pick<CosModalProps, 'actionText' | 'onActionClick' | 'actionButtonProps'>
+  > = {
+    updatableNodes: {
+      actionText: 'Yes, update',
+      onActionClick: () => {
+        setCurrentStep(isRolling ? 'rollingUpdating' : 'nonRollingUpdating')
+      },
+    },
+    rollingUpdating: {
+      actionText: 'Done',
+      onActionClick: () => {
+        listFirmwares()
+        closeUpdateFirmwareModal()
+      },
+      actionButtonProps: { disabled: !isFirmwareUpdateDone },
+    },
+    nonRollingUpdating: {
+      actionText: 'Reboot Cluster',
+      onActionClick: () => {
+        setCurrentStep('rebootCluster')
+      },
+      actionButtonProps: { disabled: !isFirmwareUpdateDone },
+    },
+    rebootCluster: {
+      actionText: 'Yes, reboot',
+      onActionClick: () => {
+        listFirmwares()
+        closeUpdateFirmwareModal()
+      },
+    },
+  }
+
+  return {
+    firmwareVersionToUpdate,
+    showUpdateFirmwareModal,
+    closeUpdateFirmwareModal,
+    updateModalTitle: modalTitleMap[currentStep],
+    updateModalContent: modalContentMap[currentStep],
+    updateModalActionProps: modalActionPropsMap[currentStep],
+  }
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/useUpdateFirmwareModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/actions/update/useUpdateFirmwareModal.tsx
@@ -1,4 +1,7 @@
-import { ListFirmwaresResponseData } from '@cube-frontend/api'
+import {
+  GetFirmwareUpgradeProgressResponseDataProgressesInnerStatusCurrentEnum as FirmwareStatus,
+  ListFirmwaresResponseData,
+} from '@cube-frontend/api'
 import { CosModalProps } from '@cube-frontend/ui-library'
 import { ReactNode, useMemo, useState } from 'react'
 import { mockUpdatableNodes, mockUpdateProgresses } from '../../mockFirmware'
@@ -6,7 +9,10 @@ import { NodeUpdate } from './NodeUpdate'
 import { UpdatableNodes } from './UpdatableNodes'
 import { UpdateModalStep } from './updateActionUtils'
 
-const DONE_STATES = ['available', 'resolved']
+const DONE_STATES: Set<FirmwareStatus> = new Set([
+  FirmwareStatus.Installed,
+  FirmwareStatus.Resolved,
+])
 
 type UseUpdateFirmwareModal = {
   firmwareVersionToUpdate: string | undefined
@@ -49,7 +55,7 @@ export const useUpdateFirmwareModal = (
     return upgradeProgressRows.every(
       (progress) =>
         !progress.status.isProcessing &&
-        DONE_STATES.includes(progress.status.current),
+        DONE_STATES.has(progress.status.current),
     )
   }, [upgradeProgressRows])
 

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/computeFirmwaresActionState.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/computeFirmwaresActionState.ts
@@ -1,48 +1,48 @@
-import { GetHealthsResponseDataOverallStatusCurrentEnum } from '@cube-frontend/api'
+import {
+  GetHealthsResponseDataOverallStatusCurrentEnum,
+  ListFirmwaresResponseDataFirmwaresInnerStatusCurrentEnum,
+} from '@cube-frontend/api'
 import { CephHealthStatus } from '../_components/useCephHealthStatus'
 import { FirmwareRow } from './listFirmwaresUtils'
 
 export type UpdateActionState =
   | 'available'
-  | 'unavailable'
   | 'inProgress'
   | 'blockedByCheckingCephHealth'
   | 'blockedByUnhealthyCeph'
+  | 'hidden'
 
 export type DeleteActionState =
   | 'available'
-  | 'unavailable'
-  | 'inProgress'
+  | 'blockedByProcessing'
   | 'blockedByUpdated'
 
 export const computeFirmwareUpdateActionState = (
   firmware: FirmwareRow,
   cephHealthStatus: CephHealthStatus,
 ): UpdateActionState => {
-  const isProcessing =
-    firmware.status.current === 'processing' || firmware.status.isProcessing
+  if (firmware.status.isProcessing) return 'inProgress'
 
-  if (isProcessing) return 'inProgress'
+  if (!firmware.status.isUpdatable) return 'hidden'
 
   if (cephHealthStatus === 'checking') return 'blockedByCheckingCephHealth'
 
   if (cephHealthStatus === GetHealthsResponseDataOverallStatusCurrentEnum.Ng)
     return 'blockedByUnhealthyCeph'
 
-  if (!firmware.status.isUpdatable) return 'unavailable'
-
   return 'available'
 }
 
-export const computeFirmwareDeleteActionState = (firmware: FirmwareRow) => {
-  const isProcessing =
-    firmware.status.current === 'processing' || firmware.status.isProcessing
+export const computeFirmwareDeleteActionState = (
+  firmware: FirmwareRow,
+): DeleteActionState => {
+  if (firmware.status.isProcessing) return 'blockedByProcessing'
 
-  if (isProcessing) return 'inProgress'
-
-  if (firmware.status.current === 'updated') return 'blockedByUpdated'
-
-  if (!firmware.status.isRemovable) return 'unavailable'
+  if (
+    firmware.status.current ===
+    ListFirmwaresResponseDataFirmwaresInnerStatusCurrentEnum.Updated
+  )
+    return 'blockedByUpdated'
 
   return 'available'
 }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/computeFirmwaresActionState.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/computeFirmwaresActionState.ts
@@ -12,10 +12,7 @@ export type UpdateActionState =
   | 'blockedByUnhealthyCeph'
   | 'hidden'
 
-export type DeleteActionState =
-  | 'available'
-  | 'blockedByProcessing'
-  | 'blockedByUpdated'
+export type DeleteActionState = 'available' | 'blockedByProcessing' | 'hidden'
 
 export const computeFirmwareUpdateActionState = (
   firmware: FirmwareRow,
@@ -36,13 +33,13 @@ export const computeFirmwareUpdateActionState = (
 export const computeFirmwareDeleteActionState = (
   firmware: FirmwareRow,
 ): DeleteActionState => {
-  if (firmware.status.isProcessing) return 'blockedByProcessing'
-
   if (
     firmware.status.current ===
     ListFirmwaresResponseDataFirmwaresInnerStatusCurrentEnum.Updated
   )
-    return 'blockedByUpdated'
+    return 'hidden'
+
+  if (firmware.status.isProcessing) return 'blockedByProcessing'
 
   return 'available'
 }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/computeFirmwaresActionState.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/computeFirmwaresActionState.ts
@@ -1,0 +1,48 @@
+import { GetHealthsResponseDataOverallStatusCurrentEnum } from '@cube-frontend/api'
+import { CephHealthStatus } from '../_components/useCephHealthStatus'
+import { FirmwareRow } from './listFirmwaresUtils'
+
+export type UpdateActionState =
+  | 'available'
+  | 'unavailable'
+  | 'inProgress'
+  | 'blockedByCheckingCephHealth'
+  | 'blockedByUnhealthyCeph'
+
+export type DeleteActionState =
+  | 'available'
+  | 'unavailable'
+  | 'inProgress'
+  | 'blockedByUpdated'
+
+export const computeFirmwareUpdateActionState = (
+  firmware: FirmwareRow,
+  cephHealthStatus: CephHealthStatus,
+): UpdateActionState => {
+  const isProcessing =
+    firmware.status.current === 'processing' || firmware.status.isProcessing
+
+  if (isProcessing) return 'inProgress'
+
+  if (cephHealthStatus === 'checking') return 'blockedByCheckingCephHealth'
+
+  if (cephHealthStatus === GetHealthsResponseDataOverallStatusCurrentEnum.Ng)
+    return 'blockedByUnhealthyCeph'
+
+  if (!firmware.status.isUpdatable) return 'unavailable'
+
+  return 'available'
+}
+
+export const computeFirmwareDeleteActionState = (firmware: FirmwareRow) => {
+  const isProcessing =
+    firmware.status.current === 'processing' || firmware.status.isProcessing
+
+  if (isProcessing) return 'inProgress'
+
+  if (firmware.status.current === 'updated') return 'blockedByUpdated'
+
+  if (!firmware.status.isRemovable) return 'unavailable'
+
+  return 'available'
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/mockFirmware.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/mockFirmware.ts
@@ -1,0 +1,81 @@
+import { GetFirmwareUpgradeProgressResponseData } from '@cube-frontend/api'
+
+export const mockUpdatableNodes = [
+  {
+    name: 'example-node-0',
+    firmware: {
+      active: 'Cube Appliance 3.1.0',
+      inactive: 'Cube Appliance 3.1.0',
+    },
+  },
+  {
+    name: 'example-node-1',
+    firmware: {
+      active: 'Cube Appliance 3.1.0',
+      inactive: 'Cube Appliance 3.1.0',
+    },
+  },
+  {
+    name: 'example-node-2',
+    firmware: {
+      active: 'Cube Appliance 3.1.0',
+      inactive: 'Cube Appliance 3.1.0',
+    },
+  },
+]
+
+export const mockUpdateProgresses: GetFirmwareUpgradeProgressResponseData = {
+  version: 'CUBE Appliance 3.1.0',
+  progresses: [
+    {
+      host: 'example-node-0',
+      phase: '',
+      status: {
+        current: 'available',
+        isProcessing: false,
+        processPercent: 0,
+        description: '',
+      },
+    },
+    {
+      host: 'example-node-1',
+      phase: '',
+      status: {
+        current: 'failed',
+        isProcessing: false,
+        processPercent: 0,
+        description: '',
+      },
+    },
+    {
+      host: 'example-node-2',
+      phase: '',
+      status: {
+        current: 'resolved',
+        isProcessing: false,
+        processPercent: 0,
+        description: '',
+      },
+    },
+    {
+      host: 'example-node-3',
+      phase: 'partitioning',
+      status: {
+        current: 'installing',
+        isProcessing: true,
+        processPercent: 75,
+        description: 'swapping partition for Cube Appliance 3.1.0',
+      },
+    },
+    {
+      host: 'example-node-4',
+      phase: '',
+      status: {
+        current: 'waitingReboot',
+        isProcessing: false,
+        processPercent: 0,
+        description: '',
+      },
+    },
+  ],
+}


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

- Implement the action button states of the firmware table rows on Maintenance Update page.
- Implement the remove firmware feature.
- Create a mock UI for the firmware update feature using mock data.

#### Which issue(s) this PR fixes

Fixes #620 

#### Special notes for your reviewer

- Most of the code this PR is authored by @lizzy-liang-bigstack, with a small refactor by me. Thank you so much for handling these features @lizzy-liang-bigstack! 🙏 
- The main goal of this PR is to implement the table action states and the remove firmware feature. We'll be refactoring the mock firmware UI in a future PR for #621, so we don't need to focus on it too much here.

#### Additional documentation

- Remove firmware

   https://github.com/user-attachments/assets/a141e5f6-d7ce-43a5-a24c-d307db8bd458

- Update firmware (mocked)

  https://github.com/user-attachments/assets/abf72ee5-0c79-45cb-a0a0-35b656c271ac
