### PR TITLE
feat(web-app): maintenance update page upload firmware

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/MaintenanceUpdateFirmwarePage.tsx
@@ -7,12 +7,14 @@ import {
 import Trash from '@cube-frontend/ui-library/icons/monochrome/delete.svg?react'
 import InformationCircle from '@cube-frontend/ui-library/icons/monochrome/information_circle.svg?react'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { useOpenState } from '@cube-frontend/web-app/hooks/useOpenState/useOpenState'
 import dayjs from 'dayjs'
 import { useContext } from 'react'
 import { MaintenanceUpdateLayout } from '../_components/MaintenanceUpdateLayout'
 import { ReleaseNotePanel } from '../_components/ReleaseNotePanel'
 import { useReleaseNotePanel } from '../_components/useReleaseNotePanel'
 import { FirmwareRow } from './listFirmwaresUtils'
+import { UploadFirmwareModal } from './UploadFirmwareModal'
 import { useListFirmwares } from './useListFirmwares'
 import { useListFirmwaresQuery } from './useListFirmwaresQuery'
 
@@ -23,7 +25,14 @@ export const MaintenanceUpdateFirmwarePage = () => {
 
   const { query, onPageChange, onItemsPerPageChange } = useListFirmwaresQuery()
 
-  const { showLoading, rows, totalItemCount } = useListFirmwares(query)
+  const { showLoading, rows, totalItemCount, listFirmwares } =
+    useListFirmwares(query)
+
+  const {
+    isOpen: isUploadModalOpen,
+    open: openUploadModal,
+    close: closeUploadModal,
+  } = useOpenState()
 
   const { rowForReleaseNote, showReleaseNoteFor, releaseNotePanel } =
     useReleaseNotePanel<FirmwareRow>()
@@ -46,7 +55,9 @@ export const MaintenanceUpdateFirmwarePage = () => {
         <CosCollapsiblePanelLayout.LeftPanel
           topic="Firmware List"
           rightSlot={
-            <CosButton disabled={showLoading}>Upload Firmware</CosButton>
+            <CosButton disabled={showLoading} onClick={openUploadModal}>
+              Upload Firmware
+            </CosButton>
           }
           customToggleButton={
             <button
@@ -120,6 +131,11 @@ export const MaintenanceUpdateFirmwarePage = () => {
           <ReleaseNotePanel releaseNote={rowForReleaseNote?.releaseNotes} />
         </CosCollapsiblePanelLayout.RightPanel>
       </CosCollapsiblePanelLayout>
+      <UploadFirmwareModal
+        isOpen={isUploadModalOpen}
+        onClose={closeUploadModal}
+        onMd5Verified={listFirmwares}
+      />
     </MaintenanceUpdateLayout>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/UploadFirmwareModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/UploadFirmwareModal.tsx
@@ -7,6 +7,7 @@ import { Md5Verification } from '../_components/Md5Verification'
 import { PkgAndChecksumInfo } from '../_components/md5VerificationUtils'
 import { useFileUpload } from '../_components/useFileUpload'
 import { useScrollToMd5Verification } from '../_components/useScrollToMd5Verification'
+import { checksumFileExtensions } from '../maintenanceUpdateUtils'
 import { useFirmwareMd5Verification } from './useFirmwareMd5Verification'
 
 type UploadFirmwareModalProps = {
@@ -215,7 +216,7 @@ export const UploadFirmwareModal = (props: UploadFirmwareModalProps) => {
             className="w-full"
             buttonText="Choose checksum"
             inputId={checksumInputId}
-            accept=".md5,.md5sum,.txt,.cksum"
+            accept={checksumFileExtensions}
             isUploading={checksumFileUpload.isUploading}
             disabled={isMd5Verifying || isMd5ChecksumVerified}
             onFileChange={checksumFileUpload.start}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/UploadFirmwareModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/UploadFirmwareModal.tsx
@@ -1,5 +1,5 @@
 import { CosModal, CosStroke, CosUpload } from '@cube-frontend/ui-library'
-import { fixpacksApi } from '@cube-frontend/web-app/api/cosApi'
+import { firmwaresApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { HttpStatusCode, isAxiosError } from 'axios'
 import { useContext, useEffect, useId, useMemo } from 'react'
@@ -7,15 +7,15 @@ import { Md5Verification } from '../_components/Md5Verification'
 import { PkgAndChecksumInfo } from '../_components/md5VerificationUtils'
 import { useFileUpload } from '../_components/useFileUpload'
 import { useScrollToMd5Verification } from '../_components/useScrollToMd5Verification'
-import { useFixpackMd5Verification } from './useFixpackMd5Verification'
+import { useFirmwareMd5Verification } from './useFirmwareMd5Verification'
 
-type UploadFixpackModalProps = {
+type UploadFirmwareModalProps = {
   isOpen: boolean
   onClose: () => void
   onMd5Verified: () => Promise<unknown>
 }
 
-export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
+export const UploadFirmwareModal = (props: UploadFirmwareModalProps) => {
   const { isOpen, onClose, onMd5Verified } = props
 
   const { dataCenter } = useContext(DataCenterContext)
@@ -25,7 +25,7 @@ export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
 
   const pkgFileUpload = useFileUpload({
     request: async (file, config) => {
-      await fixpacksApi.uploadFixpack(
+      await firmwaresApi.uploadFirmware(
         {
           dataCenter: dataCenter!.name,
           file: file.name,
@@ -39,7 +39,7 @@ export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
 
       if (isAxiosError(error) && error.status == HttpStatusCode.Conflict) {
         // TODO: show error message based on business error code in error API response when it's implemented.
-        return 'A duplicate Fixpack ID was found, or an MD5 checksum is being verified.'
+        return 'A duplicate Firmware ID was found, or an MD5 checksum is being verified.'
       }
 
       return 'Unknown error occurred, please try again.'
@@ -48,7 +48,7 @@ export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
 
   const checksumFileUpload = useFileUpload({
     request: async (file, config) => {
-      await fixpacksApi.uploadFixpackMd5Sum(
+      await firmwaresApi.uploadFirmwareMd5Sum(
         {
           dataCenter: dataCenter!.name,
           body: file,
@@ -61,7 +61,7 @@ export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
 
       if (isAxiosError(error) && error.status == HttpStatusCode.Conflict) {
         // TODO: show error message based on business error code in error API response when it's implemented.
-        return 'An MD5 checksum is being verified, or a fixpack upload is in progress.'
+        return 'An MD5 checksum is being verified, or a firmware upload is in progress.'
       }
 
       return 'Unknown error occurred, please try again.'
@@ -74,7 +74,7 @@ export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
     md5ChecksumPair,
     verifyMd5,
     resetMd5,
-  } = useFixpackMd5Verification({
+  } = useFirmwareMd5Verification({
     pkgFileName: pkgFileUpload.fileName,
     checksumFileName: checksumFileUpload.fileName,
     onVerified: onMd5Verified,
@@ -173,13 +173,13 @@ export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
       <>
         <div className="flex flex-col items-start gap-y-3">
           <label htmlFor={pkgInputId} className="primary-body4 font-semibold">
-            Upload Fixpack
+            Upload Firmware
           </label>
           <CosUpload
             className="w-full"
             buttonText="Upload from computer"
             inputId={pkgInputId}
-            accept=".fixpack"
+            accept=".pkg"
             isUploading={pkgFileUpload.isUploading}
             disabled={isMd5Verifying || isMd5ChecksumVerified}
             onFileChange={pkgFileUpload.start}
@@ -246,7 +246,7 @@ export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
 
   return (
     <CosModal
-      title="Upload Fixpack"
+      title="Upload Firmware"
       isOpen={isOpen}
       actionText="Done"
       actionButtonProps={{

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useFirmwareMd5Verification.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useFirmwareMd5Verification.ts
@@ -1,0 +1,71 @@
+import { VerifyFirmwareMd5Sum400ResponseData } from '@cube-frontend/api'
+import { firmwaresApi } from '@cube-frontend/web-app/api/cosApi'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import {
+  isCosApiResponse,
+  isCosRequestError,
+} from '@cube-frontend/web-app/hooks/useCosRequest/cosRequestUtils'
+import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
+import { isAxiosError } from 'axios'
+import { useContext } from 'react'
+import { Md5ChecksumPair } from '../_components/md5VerificationUtils'
+import {
+  UseMd5Verification,
+  useMd5Verification,
+  UseMd5VerificationArgs,
+} from '../_components/useMd5Verification'
+
+type UseFirmwareMd5VerificationArgs = Pick<
+  UseMd5VerificationArgs,
+  'pkgFileName' | 'checksumFileName' | 'onVerified'
+>
+
+export const useFirmwareMd5Verification = (
+  args: UseFirmwareMd5VerificationArgs,
+): UseMd5Verification => {
+  const { dataCenter } = useContext(DataCenterContext)
+
+  const { mutateResource: callVerifyApi } = useCosMutationRequest(
+    firmwaresApi.verifyFirmwareMd5Sum,
+  )
+
+  const verify = async (): Promise<Md5ChecksumPair> => {
+    const { firmwareMd5, expectedMd5 } = await callVerifyApi({
+      dataCenter: dataCenter!.name,
+    })
+
+    return {
+      pkgMd5Checksum: firmwareMd5!,
+      expectedMd5Checksum: expectedMd5,
+    }
+  }
+
+  const errorToPair = (error: unknown) => {
+    if (!isCosRequestError(error)) {
+      return undefined
+    }
+
+    const nativeError = error.native
+
+    if (!isAxiosError(nativeError) || !isCosApiResponse(nativeError.response)) {
+      return undefined
+    }
+
+    const errorData = nativeError.response.data.data as
+      | VerifyFirmwareMd5Sum400ResponseData
+      | undefined
+
+    return {
+      pkgMd5Checksum: errorData?.firmwareMd5 ?? '',
+      expectedMd5Checksum: errorData?.expectedMd5 ?? '',
+    }
+  }
+
+  const md5Verification = useMd5Verification({
+    verify,
+    errorToPair,
+    ...args,
+  })
+
+  return md5Verification
+}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useFirmwareMd5Verification.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useFirmwareMd5Verification.ts
@@ -35,7 +35,7 @@ export const useFirmwareMd5Verification = (
     })
 
     return {
-      pkgMd5Checksum: firmwareMd5!,
+      pkgMd5Checksum: firmwareMd5,
       expectedMd5Checksum: expectedMd5,
     }
   }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useListFirmwares.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/firmware/useListFirmwares.ts
@@ -1,4 +1,7 @@
-import { FirmwaresApiListFirmwaresRequest } from '@cube-frontend/api'
+import {
+  FirmwaresApiListFirmwaresRequest,
+  ListFirmwaresResponseData,
+} from '@cube-frontend/api'
 import { firmwaresApi } from '@cube-frontend/web-app/api/cosApi'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
@@ -15,6 +18,7 @@ type UseListFirmwares = {
   showLoading: boolean
   rows: FirmwareRow[]
   totalItemCount: number
+  listFirmwares: () => Promise<ListFirmwaresResponseData>
 }
 
 const POLLING_INTERVAL = 5 * 1000
@@ -55,5 +59,6 @@ export const useListFirmwares = (
     rows,
     totalItemCount: pagedFirmwares?.page.totalItemCount ?? 0,
     showLoading,
+    listFirmwares,
   }
 }

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/fixpack/UploadFixpackModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/fixpack/UploadFixpackModal.tsx
@@ -7,6 +7,7 @@ import { Md5Verification } from '../_components/Md5Verification'
 import { PkgAndChecksumInfo } from '../_components/md5VerificationUtils'
 import { useFileUpload } from '../_components/useFileUpload'
 import { useScrollToMd5Verification } from '../_components/useScrollToMd5Verification'
+import { checksumFileExtensions } from '../maintenanceUpdateUtils'
 import { useFixpackMd5Verification } from './useFixpackMd5Verification'
 
 type UploadFixpackModalProps = {
@@ -215,7 +216,7 @@ export const UploadFixpackModal = (props: UploadFixpackModalProps) => {
             className="w-full"
             buttonText="Choose checksum"
             inputId={checksumInputId}
-            accept=".md5,.md5sum,.txt,.cksum"
+            accept={checksumFileExtensions}
             isUploading={checksumFileUpload.isUploading}
             disabled={isMd5Verifying || isMd5ChecksumVerified}
             onFileChange={checksumFileUpload.start}

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/maintenanceUpdateUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/maintenanceUpdateUtils.ts
@@ -1,0 +1,1 @@
+export const checksumFileExtensions = '.md5,.md5sum,.txt,.cksum'


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

Implement the upload firmware feature on the Maintenance Update page.

#### Which issue(s) this PR fixes

Fixes #619

#### Special notes for your reviewer

- Most of the code in this PR was copied from the fixpack upload with a few components/hooks renaming.
- ⚠️ Local uploads will fail if they take longer than 300 seconds, and this seems to be an issue with the Vite dev server (I haven't looked into it deeply yet):
   - The upload either stops without any error between the 300-340 second mark, or
   - The upload completes to 100%, but then you get a 400 Bad Request error with an empty response body.
      - However, according to the backend developer, the backend logs indicate that the frontend is the one disconnecting the connection, not the backend rejecting the request.
   - The code has been deployed to 45.10 for manual testing. You can upload files there if you have limited internet bandwidth.

#### Additional documentation

- [Firmwares for manual testing](https://drive.google.com/file/d/11Dd8pvvcvTaYhHdb9XuTbEe-rfRGVXYJ/view?usp=sharing)
- Upload and MD5 verification

   https://github.com/user-attachments/assets/847d8702-4e5a-4a1d-aa06-8a622c10f885
