### PR TITLE
feat: 687 events chart page i18n

### DIFF
--- a/packages/cube-frontend-web-app/src/components/EventsContentSwitcher/EventsContentSwitcher.tsx
+++ b/packages/cube-frontend-web-app/src/components/EventsContentSwitcher/EventsContentSwitcher.tsx
@@ -1,4 +1,4 @@
-import { upperFirst } from 'lodash'
+import { useTranslation } from 'react-i18next'
 import { GetEventsTypeEnum } from '@cube-frontend/api'
 import { CosContentSwitcher } from '@cube-frontend/ui-library'
 
@@ -10,6 +10,8 @@ type EventsContentSwitcherProps = {
 export const EventsContentSwitcher = (props: EventsContentSwitcherProps) => {
   const { activeTab, onEventsTypeChange: handleTabChange } = props
 
+  const { t } = useTranslation()
+
   return (
     <CosContentSwitcher variant="radius" className="rounded-full bg-white">
       {Object.values(GetEventsTypeEnum).map((tab) => (
@@ -18,7 +20,7 @@ export const EventsContentSwitcher = (props: EventsContentSwitcherProps) => {
           isActive={tab === activeTab}
           onClick={() => handleTabChange(tab)}
         >
-          {upperFirst(tab)}
+          {t(`events.${tab}`)}
         </CosContentSwitcher.Item>
       ))}
     </CosContentSwitcher>

--- a/packages/cube-frontend-web-app/src/pages/events/EventsLayout.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/EventsLayout.tsx
@@ -18,12 +18,12 @@ export const EventsLayout = () => {
         </Link>
         <Link to={links.triggers}>
           <CosTabs.Tab isActive={location.pathname === links.triggers}>
-            Triggers
+            {t('events.tabs.triggers')}
           </CosTabs.Tab>
         </Link>
         <Link to={links.chart}>
           <CosTabs.Tab isActive={location.pathname === links.chart}>
-            Chart
+            {t('events.tabs.chart')}
           </CosTabs.Tab>
         </Link>
       </CosTabs>

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/ChartEmpty.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/ChartEmpty.tsx
@@ -1,10 +1,14 @@
 import Chart from '@cube-frontend/ui-library/icons/monochrome/chart.svg?react'
+import { useTranslation } from 'react-i18next'
 
 export const ChartEmpty = () => {
+  const { t } = useTranslation()
   return (
     <div className="flex w-full flex-col items-center px-4 py-6">
       <Chart className="icon-xl m-2.5 text-functional-text" />
-      <p className="primary-body2 text-functional-text-light">No Data</p>
+      <p className="primary-body2 text-functional-text-light">
+        {t('events.chart.noData')}
+      </p>
     </div>
   )
 }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/BarChart/BarChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/BarChart/BarChart.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useRef, useState } from 'react'
 import { useNavigate } from 'react-router'
+import { useTranslation } from 'react-i18next'
 import {
   Chart as ChartJS,
   BarElement,
@@ -27,6 +28,8 @@ type BarChartProps = {
 
 export const BarChart = (props: BarChartProps) => {
   const { rankedEvents, isRankedEventsLoading, chartQuery } = props
+
+  const { t } = useTranslation()
 
   const hoveredEventIndexRef = useRef<number | null>(null)
 
@@ -79,6 +82,7 @@ export const BarChart = (props: BarChartProps) => {
         handleMouseEnter,
         handleMouseLeave,
         handleClick,
+        t,
       ),
     [
       chartData,
@@ -86,6 +90,7 @@ export const BarChart = (props: BarChartProps) => {
       handleClick,
       handleMouseEnter,
       handleMouseLeave,
+      t,
     ],
   )
 

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/BarChart/barChartUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/BarChart/barChartUtils.ts
@@ -8,6 +8,7 @@ import {
   getChartTooltipTitleFont,
   getChartYAxisTitleFont,
 } from '@cube-frontend/web-app/utils/chart'
+import { TFunction } from 'i18next'
 
 export type BarChartData = RankedEvent & {
   barColor: string
@@ -72,6 +73,7 @@ export const getChartOptions = (
   handleMouseEnter: (event: RankedEvent) => void,
   handleMouseLeave: () => void,
   handleClick: (event: RankedEvent) => void,
+  t: TFunction,
 ): ChartOptions<'bar'> => {
   if (!chartData) return {} as ChartOptions<'bar'>
 
@@ -105,7 +107,7 @@ export const getChartOptions = (
       y: {
         title: {
           display: true,
-          text: 'Number of occurrences',
+          text: t('events.chart.numberOfOccurences'),
           font: getChartYAxisTitleFont(),
           color: cubeTheme.colors.functional['text-light'],
         },
@@ -138,16 +140,19 @@ export const getChartOptions = (
               tooltipContents[tooltipItem.dataIndex]
 
             if (eventsType === 'host')
-              return [`Counting: ${number}`, `Host: ${host}`]
+              return [
+                `${t('events.chart.counting')}: ${number}`,
+                `${t('events.chart.host')}: ${host}`,
+              ]
 
             if (eventsType === 'instance')
               return [
-                `Counting: ${number}`,
-                `Instance Name: ${instanceName}`,
-                `Instance ID: ${instanceId}`,
+                `${t('events.chart.counting')}: ${number}`,
+                `${t('events.chart.instanceName')}: ${instanceName}`,
+                `${t('events.chart.instanceId')}: ${instanceId}`,
               ]
 
-            return `Counting: ${number}`
+            return `${t('events.chart.counting')}: ${number}`
           },
         },
       },

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/EventsChartComparison.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartComparison/EventsChartComparison.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import {
   GetEventFilterConditionResponseDataHost,
   GetEventFilterConditionResponseDataInstance,
@@ -11,11 +12,11 @@ import {
   ChartType,
   FilterKeysResponse,
   getFilterKeyByChartType,
-  getFilterLabel,
 } from '../utils'
 import { ChartEmpty } from '../ChartEmpty'
 import { FilterEmpty } from '../FilterEmpty'
 import { ChartQuery, FilterOptions } from '../useEventsChartQuery'
+import { useFilterLabel } from '../useFilterLabel'
 
 const chartType: ChartType = 'comparison'
 
@@ -46,6 +47,10 @@ export const EventsChartComparison = (props: EventsChartComparisonProps) => {
     onFieldChange,
     onFieldAllSelect,
   } = props
+
+  const { t } = useTranslation()
+
+  const { getFilterLabel } = useFilterLabel()
 
   const { isRankedEventsLoading, rankedEvents } = useRankedEvents(
     chartType,
@@ -95,7 +100,7 @@ export const EventsChartComparison = (props: EventsChartComparisonProps) => {
 
   return (
     <CosGeneralPanel
-      topic="Event ID Comparison (Top 24)"
+      topic={t('events.chart.eventIdComparison')}
       rightSlot={
         <div className="flex items-center gap-2">{renderFilters()}</div>
       }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/EventsChartProportion.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/EventsChartProportion.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next'
 import {
   GetEventFilterConditionResponseDataHost,
   GetEventFilterConditionResponseDataInstance,
@@ -12,10 +13,10 @@ import {
   ChartType,
   FilterKeysResponse,
   getFilterKeyByChartType,
-  getFilterLabel,
 } from '../utils'
 import { ChartEmpty } from '../ChartEmpty'
 import { ChartQuery, FilterOptions } from '../useEventsChartQuery'
+import { useFilterLabel } from '../useFilterLabel'
 
 const chartType: ChartType = 'proportion'
 
@@ -45,6 +46,10 @@ export const EventsChartProportion = (props: EventsChartProportionProps) => {
     onFieldChange,
     onFieldAllSelect,
   } = props
+
+  const { t } = useTranslation()
+
+  const { getFilterLabel } = useFilterLabel()
 
   const { isRankedEventsLoading, rankedEvents } = useRankedEvents(
     chartType,
@@ -92,7 +97,7 @@ export const EventsChartProportion = (props: EventsChartProportionProps) => {
 
   return (
     <CosGeneralPanel
-      topic="Event ID Proportion"
+      topic={t('events.chart.eventIdProportion')}
       rightSlot={
         <div className="flex items-center gap-2">{renderFilters()}</div>
       }

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/PieChart/PieChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/PieChart/PieChart.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useMemo, useState } from 'react'
 import { useNavigate } from 'react-router'
+import { useTranslation } from 'react-i18next'
 import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js'
 import { Pie } from 'react-chartjs-2'
 import { twMerge } from 'tailwind-merge'
@@ -21,6 +22,8 @@ type PieChartProps = {
 
 export const PieChart = (props: PieChartProps) => {
   const { isRankedEventsLoading, rankedEvents, chartQuery } = props
+
+  const { t } = useTranslation()
 
   const [targetEvent, setTargetEvent] = useState<RankedEvent | undefined>(
     undefined,
@@ -61,6 +64,7 @@ export const PieChart = (props: PieChartProps) => {
         handleMouseEnter,
         handleMouseLeave,
         handleClick,
+        t,
       ),
     [
       chartData,
@@ -68,6 +72,7 @@ export const PieChart = (props: PieChartProps) => {
       handleClick,
       handleMouseEnter,
       handleMouseLeave,
+      t,
     ],
   )
 

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/PieChart/pieChartUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/EventsChartProportion/PieChart/pieChartUtils.ts
@@ -7,6 +7,7 @@ import {
   getChartTooltipTitleFont,
 } from '@cube-frontend/web-app/utils/chart'
 import { hexToRGBA, getChartLabelByEventsType } from '../../utils'
+import { TFunction } from 'i18next'
 
 export const chartColors = [
   cubeTheme.colors.chart[1],
@@ -88,6 +89,7 @@ export const getChartOptions = (
   handleMouseEnter: (event: RankedEvent) => void,
   handleMouseLeave: () => void,
   handleClick: () => void,
+  t: TFunction,
 ): ChartOptions<'pie'> => {
   if (!chartData) return {} as ChartOptions<'pie'>
 
@@ -127,16 +129,19 @@ export const getChartOptions = (
               tooltipContents[tooltipItem.dataIndex]
 
             if (eventsType === 'host')
-              return [`Proportion: ${percent.toFixed(1)}%`, `Host: ${host}`]
+              return [
+                `${t('events.chart.proportion')}: ${percent.toFixed(1)}%`,
+                `${t('events.chart.host')}: ${host}`,
+              ]
 
             if (eventsType === 'instance')
               return [
-                `Proportion: ${percent.toFixed(1)}%`,
-                `Instance Name: ${instanceName}`,
-                `Instance ID: ${instanceId}`,
+                `${t('events.chart.proportion')}: ${percent.toFixed(1)}%`,
+                `${t('events.chart.instanceName')}: ${instanceName}`,
+                `${t('events.chart.instanceId')}: ${instanceId}`,
               ]
 
-            return `Proportion: ${percent.toFixed(1)}%`
+            return `${t('events.chart.proportion')}: ${percent.toFixed(1)}%`
           },
         },
       },

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/useFilterLabel.tsx
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/useFilterLabel.tsx
@@ -1,0 +1,19 @@
+import { useTranslation } from 'react-i18next'
+import { FilterKeysResponse } from './utils'
+
+export const useFilterLabel = () => {
+  const { t } = useTranslation()
+
+  const filterLabelMapping = {
+    categories: t('events.filter.categories'),
+    severities: t('events.filter.severities'),
+    names: t('events.filter.hosts'),
+    ids: t('events.filter.instances'),
+  } satisfies Record<FilterKeysResponse, string>
+
+  const getFilterLabel = (key: FilterKeysResponse): string => {
+    return filterLabelMapping[key]
+  }
+
+  return { getFilterLabel }
+}

--- a/packages/cube-frontend-web-app/src/pages/events/chart/_components/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/events/chart/_components/utils.ts
@@ -49,17 +49,6 @@ export const getFilterKeyByChartType = (
   return filterKeyMapping[key][chartType] || undefined
 }
 
-const filterLabelMapping: Record<FilterKeysResponse, string> = {
-  categories: 'Categories',
-  severities: 'Severities',
-  names: 'Hosts',
-  ids: 'Instances',
-}
-
-export const getFilterLabel = (key: FilterKeysResponse) => {
-  return filterLabelMapping[key] || ''
-}
-
 const getValidType = (type: string): GetEventsTypeEnum => {
   const defaultType = GetEventsTypeEnum.System
 


### PR DESCRIPTION
⚠️ This PR is based on https://github.com/bigstack-oss/cube-cos-ui/pull/709.

#### What type of PR is this?

feat

#### What this PR does / why we need it

feat: 687 events chart page i18n

#### Which issue(s) this PR fixes

Fixes #687 

#### screenshots

<img width="1670" height="850" alt="image" src="https://github.com/user-attachments/assets/d833ef05-c0c7-49b0-a952-1afb79304f4f" />

<img width="1643" height="595" alt="截圖 2025-10-30 下午5 32 26" src="https://github.com/user-attachments/assets/534538aa-ba6f-4516-8a4d-209b600c32ed" />

<img width="1644" height="618" alt="截圖 2025-10-30 下午5 32 41" src="https://github.com/user-attachments/assets/930cffa1-eaed-40c0-ab8c-678960d69fa8" />

<img width="1002" height="388" alt="截圖 2025-10-30 下午5 34 13" src="https://github.com/user-attachments/assets/d3287aee-3adf-49e2-8d62-160b118637b8" />

<img width="1136" height="494" alt="截圖 2025-10-30 下午5 34 27" src="https://github.com/user-attachments/assets/9ea32016-8d45-479a-9412-a23c34c235b6" />

