### PR TITLE
729 fix(web-app): node details chart ticks and mainenance update layout updated date format

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/MaintenanceUpdateLayout.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/MaintenanceUpdateLayout.tsx
@@ -19,7 +19,7 @@ export const MaintenanceUpdateLayout = (
   const location = useLocation()
   const navigate = useNavigate()
 
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   // TODO: Add support for custom elements (like the <Link> component from react-router) to `CosContentSwitcherItem`
   // for native hyperlink navigation.
@@ -31,7 +31,10 @@ export const MaintenanceUpdateLayout = (
 
   const formatLastUpdated = (): string => {
     if (!lastUpdated) return t('maintenance.update.never')
-    return dayjs.respectTzOffset(lastUpdated).format('YYYY/MM/DD HH:mm A')
+    return dayjs
+      .respectTzOffset(lastUpdated)
+      .locale(i18n.language)
+      .format('YYYY/MM/DD HH:mm A')
   }
 
   return (

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/CpuPerformanceChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/CpuPerformanceChart.tsx
@@ -15,6 +15,7 @@ import {
   getCpuChartOptions,
 } from './nodeChartsUtils'
 import { CosGeneralPanel } from '@cube-frontend/ui-library'
+import type { SupportedLanguage } from '@cube-frontend/web-app/i18n/utils'
 
 type CpuPerformanceChartProps = {
   node: Node | undefined
@@ -24,7 +25,7 @@ type CpuPerformanceChartProps = {
 export const CpuPerformanceChart = (props: CpuPerformanceChartProps) => {
   const { node } = props
 
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   const { dataCenter } = useContext(DataCenterContext)
 
@@ -60,8 +61,13 @@ export const CpuPerformanceChart = (props: CpuPerformanceChartProps) => {
   )
 
   const chartOptions = useMemo(
-    () => getCpuChartOptions(metricsData, t('nodes.details.consumedHostCpu')),
-    [metricsData, t],
+    () =>
+      getCpuChartOptions(
+        metricsData,
+        t('nodes.details.consumedHostCpu'),
+        i18n.language as SupportedLanguage,
+      ),
+    [metricsData, t, i18n],
   )
 
   return (

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/MemoryPerformanceChart.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/MemoryPerformanceChart.tsx
@@ -15,6 +15,7 @@ import {
   getMemoryChartOptions,
 } from './nodeChartsUtils'
 import { CosGeneralPanel } from '@cube-frontend/ui-library'
+import type { SupportedLanguage } from '@cube-frontend/web-app/i18n/utils'
 
 type MemoryPerformanceChartProps = {
   node: Node | undefined
@@ -23,7 +24,7 @@ type MemoryPerformanceChartProps = {
 export const MemoryPerformanceChart = (props: MemoryPerformanceChartProps) => {
   const { node } = props
 
-  const { t } = useTranslation()
+  const { t, i18n } = useTranslation()
 
   const { dataCenter } = useContext(DataCenterContext)
 
@@ -60,8 +61,12 @@ export const MemoryPerformanceChart = (props: MemoryPerformanceChartProps) => {
 
   const chartOptions = useMemo(
     () =>
-      getMemoryChartOptions(metricsData, t('nodes.details.consumedHostMemory')),
-    [metricsData, t],
+      getMemoryChartOptions(
+        metricsData,
+        t('nodes.details.consumedHostMemory'),
+        i18n.language as SupportedLanguage,
+      ),
+    [metricsData, t, i18n.language],
   )
 
   return (

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/nodeChartsUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/nodeChartsUtils.ts
@@ -4,6 +4,7 @@ import {
 } from '@cube-frontend/api'
 import { cubeTheme } from '@cube-frontend/ui-theme/src/cubeTheme'
 import { TimeRange } from '@cube-frontend/web-app/components/TimeRangeDropdown/timeRangeUtils'
+import type { SupportedLanguage } from '@cube-frontend/web-app/i18n/utils'
 import { convertSize, SizeUnit } from '@cube-frontend/web-app/utils/byte'
 import {
   chartFontFamily,
@@ -58,6 +59,7 @@ export const computeChartData = (
 export const getCpuChartOptions = (
   metricsData: HostMetricHistoryResponseData | undefined,
   yAxisText: string,
+  i18nLanguage: SupportedLanguage,
 ): ChartOptions<'line'> => {
   const { history = [], unit = '' } = metricsData ?? {}
   return {
@@ -77,7 +79,7 @@ export const getCpuChartOptions = (
         },
         ticks: getChartTicksOptions(),
         beforeFit: (axis) => {
-          transformTickLabelsBeforeFit(axis, history)
+          transformTickLabelsBeforeFit(axis, history, i18nLanguage)
         },
       },
       y: {
@@ -145,6 +147,7 @@ export const getCpuChartOptions = (
 export const getMemoryChartOptions = (
   metricsData: HostMetricHistoryResponseData | undefined,
   yAxisText: string,
+  i18nLanguage: SupportedLanguage,
 ): ChartOptions<'line'> => {
   const isLoading = !metricsData
   const history = metricsData?.history ?? []
@@ -168,7 +171,7 @@ export const getMemoryChartOptions = (
         },
         ticks: getChartTicksOptions(),
         beforeFit: (axis) => {
-          transformTickLabelsBeforeFit(axis, history)
+          transformTickLabelsBeforeFit(axis, history, i18nLanguage)
         },
       },
       y: {
@@ -260,6 +263,7 @@ type TickWithContext = Tick & {
 const transformTickLabelsBeforeFit = (
   axis: Scale,
   history: TimeValuePair[],
+  i18nLanguage: SupportedLanguage,
 ): void => {
   const { ticks } = axis
 
@@ -270,7 +274,9 @@ const transformTickLabelsBeforeFit = (
     const timeValuePair = history[castedTick.$context.index]
     if (!timeValuePair) return
 
-    const dateWithTz = dayjs.respectTzOffset(timeValuePair.time.toString())
+    const dateWithTz = dayjs
+      .respectTzOffset(timeValuePair.time.toString())
+      .locale(i18nLanguage)
     const dateString = dateWithTz.format('YYYY-MM-DD')
 
     if (prevDate !== dateString) {


### PR DESCRIPTION
#### What type of PR is this?

Fix

#### What this PR does / why we need it

Fix dayjs localized format issues.

#### Which issue(s) this PR fixes

Fixes #729

#### Special notes for your reviewer

The bug comes from using `dayjs(...).format(...)` without setting a locale via `dayjs(...).locale(...)`. It only happens when locale-dependent tokens are included in the template. For example, `MMMM` becomes `December` in `en-US` but `十二月` in `zh-TW`. Typical tokens such as `YYYY`, `MM`, `DD` can work without any problem.

#### Additional documentation

- Node details charts

   https://github.com/user-attachments/assets/6e60238d-d851-4494-a357-95deb6252cc2

- Maintenance update layout

   https://github.com/user-attachments/assets/4dc3ae1e-1bba-4f88-9b8d-5f4a727d68a1
