### PR TITLE
fix: 733 button text context switcher incorrect styles

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosButton/cosButtonStyles.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosButton/cosButtonStyles.tsx
@@ -3,7 +3,7 @@ import { CosButtonUsage } from './CosButton'
 import { ClassValue } from 'class-variance-authority/types'
 
 export const button = cva(
-  'flex shrink-0 items-center justify-center gap-x-2 rounded-[5px] font-urbanist font-semibold transition-colors',
+  'flex shrink-0 items-center justify-center gap-x-2 whitespace-nowrap rounded-[5px] font-urbanist font-semibold transition-colors',
   {
     variants: {
       type: {

--- a/packages/cube-frontend-ui-library/src/components/CosContentSwitcher/CosContentSwitcherItem.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosContentSwitcher/CosContentSwitcherItem.tsx
@@ -15,7 +15,8 @@ const contentSwitcherItem = {
   default: cva(
     [
       'flex items-center justify-center',
-      'border-y border-primary-200 bg-grey-0 font-medium text-functional-text-light transition-colors',
+      'border-y border-primary-200 bg-grey-0',
+      'whitespace-nowrap font-medium text-functional-text-light transition-colors',
       'first-of-type:rounded-l-[5px] first-of-type:border-l',
       'last-of-type:rounded-r-[5px] last-of-type:border-r',
     ],

--- a/packages/cube-frontend-ui-library/src/components/CosIconText/CosIconText.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosIconText/CosIconText.tsx
@@ -18,7 +18,7 @@ export type CosIconTextType =
   | 'primary-outline'
 
 const iconText = cva(
-  'secondary-body4 rounded px-1 py-0.5 text-center font-semibold text-grey-0',
+  'secondary-body4 whitespace-nowrap rounded px-1 py-0.5 text-center font-semibold text-grey-0',
   {
     variants: {
       type: {

--- a/packages/cube-frontend-ui-library/src/components/CosStatusReaction/CosStatusReaction.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosStatusReaction/CosStatusReaction.tsx
@@ -19,15 +19,18 @@ export type CosStatusReactionProps = {
   message?: string
 }
 
-const statusReaction = cva([baseClass, 'secondary-body3 font-semibold'], {
-  variants: {
-    type: {
-      neutral: 'text-status-neutral',
-      success: 'text-status-positive',
-      warning: 'text-status-negative',
-    } satisfies Record<StatusType, ClassValue>,
+const statusReaction = cva(
+  [baseClass, 'secondary-body3 whitespace-nowrap font-semibold'],
+  {
+    variants: {
+      type: {
+        neutral: 'text-status-neutral',
+        success: 'text-status-positive',
+        warning: 'text-status-negative',
+      } satisfies Record<StatusType, ClassValue>,
+    },
   },
-})
+)
 
 const iconMap: Record<StatusType, SvgComponent> = {
   neutral: CheckmarkBold,

--- a/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/StatusWithIcon.tsx
+++ b/packages/cube-frontend-web-app/src/pages/maintenance/update/_components/StatusWithIcon.tsx
@@ -14,7 +14,9 @@ export const StatusWithIcon = (props: StatusWithIconProps) => {
   return (
     <div className={twMerge('flex items-center gap-x-2', color)}>
       <Icon className="icon-md-sm" />
-      <span className="secondary-body3 font-semibold">{text}</span>
+      <span className="secondary-body3 whitespace-nowrap font-semibold">
+        {text}
+      </span>
     </div>
   )
 }


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it

fix: 733 button text context switcher incorrect styles


<img width="1511" height="599" alt="截圖 2025-12-18 下午3 00 16" src="https://github.com/user-attachments/assets/537f5eb1-8f33-4cd4-a7d3-3cdbbc297ed3" />

<img width="1674" height="657" alt="截圖 2025-12-18 下午3 00 01" src="https://github.com/user-attachments/assets/4196b838-4122-422c-b713-6f1244391c5e" />

<img width="630" height="951" alt="截圖 2025-12-18 下午2 57 33" src="https://github.com/user-attachments/assets/42e34ea6-daac-4ed6-a96a-214aa9449725" />

<img width="1914" height="455" alt="截圖 2025-12-19 晚上7 22 45" src="https://github.com/user-attachments/assets/f0baaa5a-6c4e-4683-b5ef-8090a827ade9" />

#### Which issue(s) this PR fixes

Fixes #733