### PR TITLE
fix: 765 storage edit page missing upload translations

### DIFF
--- a/packages/cube-frontend-i18n/src/resources/web-app/en-US.json
+++ b/packages/cube-frontend-i18n/src/resources/web-app/en-US.json
@@ -380,6 +380,8 @@
   "integrations.storages.upsert.volumeTypeSettings": "Volume Type Settings",
   "integrations.storages.upsert.extraSettings": "Extra Settings",
   "integrations.storages.upsert.extraConfigFiles": "Extra Config Files",
+  "integrations.storages.upsert.extraConfigFiles.fileSizeOverLimit": "File is too large. Maximum allowed size is {{size}}.",
+  "integrations.storages.upsert.uploadExtraConfigFile": "Upload {{name}}",
   "integrations.storages.upsert.editConfirmModal.title": "Update the storage details\n",
   "integrations.storages.upsert.editConfirmModal.message": "Please confirm you have re-uploaded the extra config file.\nFor security reasons, previously uploaded files are not retained when editing.",
   "integrations.storages.upsert.editConfirmModal.yesUpdate": "Yes, update",

--- a/packages/cube-frontend-i18n/src/resources/web-app/zh-TW.json
+++ b/packages/cube-frontend-i18n/src/resources/web-app/zh-TW.json
@@ -380,6 +380,8 @@
   "integrations.storages.upsert.volumeTypeSettings": "磁碟類型設定",
   "integrations.storages.upsert.extraSettings": "額外設定",
   "integrations.storages.upsert.extraConfigFiles": "額外設定檔",
+  "integrations.storages.upsert.extraConfigFiles.fileSizeOverLimit": "檔案過大。大小上限為 {{size}}。",
+  "integrations.storages.upsert.uploadExtraConfigFile": "上傳 {{name}}",
   "integrations.storages.upsert.editConfirmModal.title": "更新儲存裝置設定",
   "integrations.storages.upsert.editConfirmModal.message": "請確認您已重新上傳額外設定檔。\n出於安全性考量，在編輯時先前上傳的檔案不會被保留。",
   "integrations.storages.upsert.editConfirmModal.yesUpdate": "是，更新",

--- a/packages/cube-frontend-web-app/src/pages/integrations/storages/_components/upsert/Form/CommonSection.tsx
+++ b/packages/cube-frontend-web-app/src/pages/integrations/storages/_components/upsert/Form/CommonSection.tsx
@@ -127,11 +127,8 @@ export const CommonSection = (props: CommonSectionProps) => {
         isLoading={formState.isInputLoading}
         disabled={formState.isInputDisabled || formState.isEdit}
       >
-        <CosDropdown.Trigger
-          placeholder="Select an Item"
-          className="max-w-full"
-        >
-          {selectedModelName || 'Select a model'}
+        <CosDropdown.Trigger className="max-w-full">
+          {selectedModelName}
         </CosDropdown.Trigger>
         <CosDropdown.Menu className="max-w-full">
           {modelOptions.map((item) => (

--- a/packages/cube-frontend-web-app/src/pages/integrations/storages/_components/upsert/Form/ModelBasedSection/ConfigFileUpload.tsx
+++ b/packages/cube-frontend-web-app/src/pages/integrations/storages/_components/upsert/Form/ModelBasedSection/ConfigFileUpload.tsx
@@ -1,6 +1,7 @@
 import { CosUpload } from '@cube-frontend/ui-library'
 import { fileToBase64 } from '@cube-frontend/web-app/utils/file'
 import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
 
 const EXTRA_CONFIG_FILE_SIZE_LIMIT_MB = 10
 const EXTRA_CONFIG_FILE_SIZE_LIMIT =
@@ -17,6 +18,8 @@ export type ConfigFileUploadProps = {
 export const ConfigFileUpload = (props: ConfigFileUploadProps) => {
   const { buttonText, fileName, disabled, onFileChange, onCancel } = props
 
+  const { t } = useTranslation()
+
   const [errorMessage, setErrorMessage] = useState<string | undefined>(
     undefined,
   )
@@ -26,7 +29,9 @@ export const ConfigFileUpload = (props: ConfigFileUploadProps) => {
 
     if (file.size > EXTRA_CONFIG_FILE_SIZE_LIMIT) {
       setErrorMessage(
-        `File size exceeds ${EXTRA_CONFIG_FILE_SIZE_LIMIT_MB} MB limit.`,
+        t('integrations.storages.upsert.extraConfigFiles.fileSizeOverLimit', {
+          size: `${EXTRA_CONFIG_FILE_SIZE_LIMIT_MB} MB`,
+        }),
       )
       return
     }

--- a/packages/cube-frontend-web-app/src/pages/integrations/storages/_components/upsert/Form/ModelBasedSection/ExtraConfigFileSection.tsx
+++ b/packages/cube-frontend-web-app/src/pages/integrations/storages/_components/upsert/Form/ModelBasedSection/ExtraConfigFileSection.tsx
@@ -19,6 +19,8 @@ export type ExtraConfigFileSectionProps = {
 export const ExtraConfigFileSection = (props: ExtraConfigFileSectionProps) => {
   const { storage, setStorage, formState } = props
 
+  const { t } = useTranslation()
+
   const { extraConfigFiles } = storage.storage.service
 
   const renderField = (
@@ -52,15 +54,15 @@ export const ExtraConfigFileSection = (props: ExtraConfigFileSectionProps) => {
       <ConfigFileUpload
         key={`${index}-${extraConfigFile.name}`}
         disabled={formState.isInputDisabled}
-        buttonText={`Upload ${extraConfigFile.name}`}
+        buttonText={t('integrations.storages.upsert.uploadExtraConfigFile', {
+          name: extraConfigFile.name,
+        })}
         fileName={extraConfigFile.localFileName}
         onFileChange={handleFieldChange}
         onCancel={handleCancel}
       />
     )
   }
-
-  const { t } = useTranslation()
 
   return (
     <StorageFormSection


### PR DESCRIPTION
#### What type of PR is this?

fix

#### What this PR does / why we need it

- Add i18n keys for file size limit error and upload button label.
- Update ConfigFileUpload and ExtraConfigFileSection to use translated strings.

<img width="1571" height="950" alt="截圖 2026-01-19 下午3 15 12" src="https://github.com/user-attachments/assets/2dd71238-e8f8-40b6-8b3f-162399241357" />

#### Which issue(s) this PR fixes

Fixes #765
