### PR TITLE
chore: 808 upgrade typescript to v7 to improve VSCode and lint performance

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -47,6 +47,7 @@
     "svgr",
     "Svgs",
     "tseslint",
+    "tsgo",
     "unrollbackable",
     "vcpu",
     "Vgpu",
@@ -60,5 +61,6 @@
   ],
   "i18n-ally.keystyle": "nested",
   "i18n-ally.displayLanguage": "en-US",
-  "i18n-ally.enabledFrameworks": ["react-i18next", "i18next"]
+  "i18n-ally.enabledFrameworks": ["react-i18next", "i18next"],
+  "js/ts.tsdk.path": "node_modules/typescript/lib"
 }

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
     "pnpm": ">=10.33"
   },
   "scripts": {
-    "tsc": "pnpm -r tsc",
+    "tsc": "pnpm -r --no-bail tsc",
+    "tsgo": "pnpm -r --no-bail tsgo",
     "eslint": "eslint .",
-    "test": "pnpm -r test",
+    "test": "pnpm -r --no-bail test",
     "eslint:fix": "eslint . --fix",
     "eslint:inspect": "eslint --inspect-config .eslintrc.js",
     "keycloak-login:build": "pnpm --filter @cube-frontend/keycloak-login build",
@@ -40,6 +41,7 @@
     "@commitlint/config-conventional": "^20.5.0",
     "@eslint/js": "^9.17.0",
     "@typescript-eslint/parser": "^8.59.0",
+    "@typescript/native-preview": "7.0.0-dev.20260421.2",
     "eslint": "^9.17.0",
     "eslint-config-prettier": "^9.1.2",
     "eslint-import-resolver-typescript": "^4.4.4",

--- a/packages/cube-frontend-i18n/package.json
+++ b/packages/cube-frontend-i18n/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "tsc": "tsc -b",
+    "tsgo": "tsgo -b",
     "sync": "node scripts/syncI18n.ts"
   },
   "dependencies": {

--- a/packages/cube-frontend-keycloak-login/package.json
+++ b/packages/cube-frontend-keycloak-login/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "tsc": "tsc",
+    "tsgo": "tsgo -b",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "copy-output": "rm -rf ./keycloak/themes/cos-ui/login/resources && cp -r ./dist/resources ./keycloak/themes/cos-ui/login",

--- a/packages/cube-frontend-ui-library/package.json
+++ b/packages/cube-frontend-ui-library/package.json
@@ -10,6 +10,7 @@
   },
   "scripts": {
     "tsc": "tsc",
+    "tsgo": "tsgo",
     "storybook": "storybook dev -p 6006 --no-open",
     "build-storybook": "storybook build",
     "serve-storybook": "pnpm dlx http-server ./storybook-static"

--- a/packages/cube-frontend-ui-theme/package.json
+++ b/packages/cube-frontend-ui-theme/package.json
@@ -8,7 +8,8 @@
     "pnpm": ">=10.33"
   },
   "scripts": {
-    "tsc": "tsc"
+    "tsc": "tsc",
+    "tsgo": "tsgo"
   },
   "dependencies": {
     "@cube-frontend/utils": "workspace:^",

--- a/packages/cube-frontend-utils/package.json
+++ b/packages/cube-frontend-utils/package.json
@@ -7,6 +7,10 @@
     "node": ">=v24.15",
     "pnpm": ">=10.33"
   },
+  "scripts": {
+    "tsc": "tsc -b",
+    "tsgo": "tsgo -b"
+  },
   "dependencies": {
     "@types/pluralize": "catalog:",
     "dayjs": "catalog:",

--- a/packages/cube-frontend-web-app/package.json
+++ b/packages/cube-frontend-web-app/package.json
@@ -6,6 +6,7 @@
   "type": "module",
   "scripts": {
     "tsc": "tsc -b",
+    "tsgo": "tsgo -b",
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.59.0
         version: 8.59.0(eslint@9.39.4(jiti@2.4.2))(typescript@6.0.3)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260421.2
+        version: 7.0.0-dev.20260421.2
       eslint:
         specifier: ^9.17.0
         version: 9.39.4(jiti@2.4.2)
@@ -1748,6 +1751,45 @@ packages:
   '@typescript-eslint/visitor-keys@8.59.0':
     resolution: {integrity: sha512-/uejZt4dSere1bx12WLlPfv8GktzcaDtuJ7s42/HEZ5zGj9oxRaD4bj7qwSunXkf+pbAhFt2zjpHYUiT5lHf0Q==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-fHv1r3ZmVo6zxuAIFmuX3w9QxbcauoG0SsWhmDwm6VmRubLlOJIcmTtlmV3JAb9oOnq8LuzZljzT7Q39fSMQDw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-KWTR6xbW9t+JS7D5DQIzo75pqVXVWUxF9PMv/+S6xsnOjCVd6g0ixHcFpFMJMKSUQpGPr8Z5f7b8ks6LHW01jg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-VLMEuml3BhUb+jaL0TXQ4xvVODxJF+RhkI+tBWvlynsJI4khTXEiwWh+wPOJrsfBRYFRMXEu28Odl/HXkYze8w==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-BWLQO3nemLDSV5PoE5GPHe1dU9Dth77Kv8/cle9Ujcp4LhPo0KincdPqFH/qKeU/xvW25mgFueflZ1nc4rKuww==}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-qUrJWTB5/wv4wnRG0TRXElAxc2kykNiRNyEIEqBbLmzDlrcvAW7RRy8MXoY1ZyTiKGMu14itZ3x9oW6+blFpRw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-Rc6NsWlZmCs5YUKVzKgwoBOoRUGsPzct4BDMRX0csD1devLBBc4AbUXWKsJRbpwIAnqMO1ld4sNHEb+wXgfNHQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-GQv1+dya1t6EqF2Cpsb+xoozovdX10JUSf6Kl/8xNkTapzmlHd+uMr+8ku3jIASTxoRGn0Mklgjj3MDKrOTuLg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    resolution: {integrity: sha512-CmajHI25HpVWE9R1XFoxr+cphJPxoYD3eFioQtAvXYkMFKnLdICMS9pXre9Pybizb75ejRxjKD5/CVG055rEIg==}
+    hasBin: true
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -5676,6 +5718,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.59.0
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260421.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260421.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260421.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260421.2
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     optional: true


### PR DESCRIPTION
#### What type of PR is this?

chore

#### What this PR does / why we need it

Chore: 808 upgrade typescript to v7 to improve VSCode and lint performance

#### Which issue(s) this PR fixes

Fixes #808

#### Special notes for your reviewer

Please check out https://devblogs.microsoft.com/typescript/announcing-typescript-7-0-beta/

#### Additional documentation

Since it is in beta, VSCode should install https://marketplace.visualstudio.com/items?itemName=TypeScriptTeam.native-preview to use Typescript 7.


#### Performance Compare

<img width="928" height="599" alt="image" src="https://github.com/user-attachments/assets/30ad372d-d7b6-402a-90c5-34b36bb1101d" />


#### How to Test?

Run `pnpm run tsgo` in the root directory. 
