### PR TITLE
867 Build custom table for GPU listing page

### DIFF
--- a/packages/cube-frontend-web-app/src/components/InfoTable/InfoTable.tsx
+++ b/packages/cube-frontend-web-app/src/components/InfoTable/InfoTable.tsx
@@ -1,0 +1,192 @@
+import {
+  Children,
+  ComponentProps,
+  ComponentType,
+  PropsWithChildren,
+  ReactElement,
+  ReactNode,
+  useMemo,
+} from 'react'
+import { twMerge } from 'tailwind-merge'
+import { CosLoadingSpinner } from '@cube-frontend/ui-library'
+import { InfoTableRow, isInfoTableColumn } from './_components/infoTableUtils'
+import {
+  CreateInfoTableColumn,
+  InfoTableColumnProps,
+} from './_components/InfoTableColumn'
+
+type InfoTableProps<Row extends InfoTableRow> = PropsWithChildren<{
+  scrollBehavior: 'horizontal' | 'vertical'
+  /**
+   * @default false
+   */
+  isLoading?: boolean
+  rows: Row[]
+  /**
+   * @default 5
+   */
+  maxRows?: number
+  title: string
+  className?: string
+}>
+
+const InfoTable = <Row extends InfoTableRow>(props: InfoTableProps<Row>) => {
+  const {
+    children,
+    scrollBehavior,
+    isLoading = false,
+    rows,
+    maxRows = 5,
+    title,
+    className,
+  } = props
+  const isVertical = scrollBehavior === 'vertical'
+
+  const renderTitle = () => {
+    return (
+      <div className="primary-body4 font-semibold text-functional-text-light">
+        {title}
+      </div>
+    )
+  }
+
+  const renderLoadingSpinner = () => {
+    return (
+      <div className="w-fit border border-functional-border-divider bg-primary-0 p-4">
+        <div className="flex min-w-[400px] items-center justify-center">
+          <CosLoadingSpinner variant="dot120" className="size-4" />
+        </div>
+      </div>
+    )
+  }
+
+  const columns = useMemo(() => {
+    return Children.toArray(children).filter(
+      (
+        child,
+      ): child is ReactElement<InfoTableColumnProps<Row, keyof Row | never>> =>
+        isInfoTableColumn<Row>(child),
+    )
+  }, [children])
+
+  const renderCell = (
+    row: Row,
+    rowIndex: number,
+    column: InfoTableColumnProps<Row, keyof Row | never>,
+  ): ReactNode => {
+    const { children: columnChildren, property } = column
+    const propertyValue = property ? row[property] : undefined
+
+    if (typeof columnChildren === 'function') {
+      return columnChildren(
+        propertyValue as typeof property extends keyof Row
+          ? Row[keyof Row]
+          : undefined,
+        row,
+        rowIndex,
+      )
+    }
+
+    if (columnChildren !== undefined) return columnChildren
+
+    return propertyValue?.toString()
+  }
+
+  const renderTable = (rows: Row[]) => {
+    return (
+      <table className="border-separate border-spacing-4">
+        <thead>
+          <tr>
+            {columns.map((column, columnIndex) => (
+              <th
+                key={columnIndex}
+                className="primary-body5 p-0 text-left font-semibold text-functional-text-light"
+              >
+                {column.props.label}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody>
+          {rows.map((row, rowIndex) => (
+            <tr key={rowIndex}>
+              {columns.map((column, columnIndex) => (
+                <td
+                  key={columnIndex}
+                  className={twMerge(
+                    'primary-body5 p-0 text-left text-functional-text-light',
+                    columnIndex === 0 && 'text-functional-text',
+                  )}
+                >
+                  {renderCell(row, rowIndex, column.props)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    )
+  }
+
+  const renderVerticalScrollTable = () => {
+    return (
+      <div className="flex w-fit flex-col gap-y-2">
+        {renderTitle()}
+        {isLoading ? (
+          renderLoadingSpinner()
+        ) : (
+          <div
+            className={twMerge(
+              'border border-functional-border-divider bg-primary-0 p-4',
+              className,
+            )}
+          >
+            {renderTable(rows)}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  const renderHorizontalScrollTable = () => {
+    const chunks: Row[][] = []
+    for (let i = 0; i < rows.length; i += maxRows) {
+      chunks.push(rows.slice(i, i + maxRows))
+    }
+
+    return (
+      <div className="flex w-full flex-col gap-y-2">
+        {renderTitle()}
+        {isLoading ? (
+          renderLoadingSpinner()
+        ) : (
+          <div className="flex w-full gap-x-4 overflow-x-scroll border border-functional-border-divider bg-primary-0 p-4">
+            {chunks.map((chunk, chunkIndex) => (
+              <div key={chunkIndex} className="min-w-[491px] shrink-0">
+                {renderTable(chunk)}
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    )
+  }
+
+  return isVertical
+    ? renderVerticalScrollTable()
+    : renderHorizontalScrollTable()
+}
+
+InfoTable.Column = CreateInfoTableColumn<InfoTableRow>()
+
+type InfoTableWithColumn<Row extends InfoTableRow> = ComponentType<
+  ComponentProps<typeof InfoTable<Row>>
+> & {
+  Column: ReturnType<typeof CreateInfoTableColumn<Row>>
+}
+
+export const GetInfoTable = <
+  Row extends InfoTableRow,
+>(): InfoTableWithColumn<Row> => {
+  return InfoTable as unknown as InfoTableWithColumn<Row>
+}

--- a/packages/cube-frontend-web-app/src/components/InfoTable/_components/InfoTableColumn.tsx
+++ b/packages/cube-frontend-web-app/src/components/InfoTable/_components/InfoTableColumn.tsx
@@ -1,0 +1,34 @@
+import { ReactNode } from 'react'
+import { INFO_TABLE_COLUMN_SYMBOL, InfoTableRow } from './infoTableUtils'
+
+export type InfoTableColumnProps<
+  Row extends InfoTableRow,
+  Property extends keyof Row | never,
+> = {
+  label?: ReactNode
+  property?: Property
+  children?:
+    | ReactNode
+    | ((
+        propertyValue: Property extends keyof Row ? Row[Property] : undefined,
+        row: Row,
+        rowIndex: number,
+      ) => ReactNode)
+}
+
+export const CreateInfoTableColumn = <Row extends InfoTableRow>() => {
+  type ColumnProps<Property extends keyof Row | never> = InfoTableColumnProps<
+    Row,
+    Property
+  >
+
+  const InfoTableColumn = <Property extends keyof Row | never = never>(
+    _props: ColumnProps<Property>,
+  ) => {
+    return undefined
+  }
+
+  InfoTableColumn[INFO_TABLE_COLUMN_SYMBOL] = true
+
+  return InfoTableColumn
+}

--- a/packages/cube-frontend-web-app/src/components/InfoTable/_components/infoTableUtils.ts
+++ b/packages/cube-frontend-web-app/src/components/InfoTable/_components/infoTableUtils.ts
@@ -1,0 +1,22 @@
+import { isValidElement, ReactElement, ReactNode } from 'react'
+import { InfoTableColumnProps } from './InfoTableColumn'
+
+export type InfoTableRow = {
+  id: string
+}
+
+// Internal marker for compound-component parsing.
+// We tag `InfoTable.Column` with this symbol so `InfoTableBase` can safely
+// identify and extract only column definition children.
+export const INFO_TABLE_COLUMN_SYMBOL = Symbol('InfoTableColumn')
+
+export const isInfoTableColumn = <Row extends InfoTableRow>(
+  node: ReactNode,
+): node is ReactElement<InfoTableColumnProps<Row, keyof Row | never>> => {
+  if (!isValidElement(node)) {
+    return false
+  }
+  return (
+    typeof node.type === 'function' && INFO_TABLE_COLUMN_SYMBOL in node.type
+  )
+}


### PR DESCRIPTION
#### What type of PR is this?

Feat

#### What this PR does / why we need it

## 1. Horizontal Scroll Table / Max Row: 5 (default)

https://github.com/user-attachments/assets/c11ad826-0db1-4d9e-bf99-8d549fba813b

## 2. Horizontal Scroll Table / Max Row: 3

<img width="1245" height="281" alt="Screenshot 2026-05-08 at 2 28 25 PM" src="https://github.com/user-attachments/assets/78bc8f24-7032-4e9c-a4db-b56eb71e45ab" />

## 3. Horizontal Scroll Table / No Scroll

<img width="1240" height="360" alt="Screenshot 2026-05-08 at 2 28 05 PM" src="https://github.com/user-attachments/assets/512143cf-edda-4613-a8ac-02587a72b26a" />

## 4. Vertical Scroll Table

https://github.com/user-attachments/assets/3501e0a3-a103-4f84-96a7-91cb3dd9e172

## 5. Loading State

<img width="484" height="105" alt="Screenshot 2026-05-08 at 2 28 38 PM" src="https://github.com/user-attachments/assets/03c7d639-5cab-4965-b554-78b222d83666" />


#### Which issue(s) this PR fixes

Fixes https://github.com/bigstack-oss/cubecos/issues/867

#### Special notes for your reviewer

Reference -

1. Horizontal scroll mockup: https://www.figma.com/design/Z4v1zkTLGVts3tsDTc7AMH/-COS--COS-3.2-GPU-Productization?node-id=113-15668&t=AAQVGzZOlJOXD4Zl-4

2. Vertical scroll mockup: https://www.figma.com/design/Z4v1zkTLGVts3tsDTc7AMH/-COS--COS-3.2-GPU-Productization?node-id=203-2576&t=AAQVGzZOlJOXD4Zl-4
