### PR TITLE
feat(health): add FC Link label for the fc_link health module

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/home/health/homeHealthPageUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/home/health/homeHealthPageUtils.ts
@@ -72,6 +72,7 @@ const moduleNameLabelMap: Record<string, string> = {
   ceph_osd: 'Ceph OSD',
   ceph_rgw: 'Ceph RGW',
   rbd_target: 'RBD Target',
+  fc_link: 'FC Link',
   neutron: 'Neutron',
   nova: 'Nova',
   cyborg: 'Cyborg',


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

Adds the `FC Link` display label for the new `fc_link` health module in the home health view (`homeHealthPageUtils.ts` `moduleNameLabelMap`). Without it the module renders as its raw key. Pairs with the cubecos `cluster check` fc_link detector and the cos-api registry entry.

#### Which issue(s) this PR fixes

Refs bigstack-oss/cubecos#1056

#### Special notes for your reviewer

> One-line label-map addition; the health view is otherwise data-driven from the API.
