### PR TITLE
fix: mint GPU instance console link on demand

### DIFF
--- a/packages/cube-frontend-api/sdk/api.ts
+++ b/packages/cube-frontend-api/sdk/api.ts
@@ -3776,6 +3776,75 @@ export type GetFixpackUpdateProgressResponseDataProgressesInnerStatusCurrentEnum
 /**
  * 
  * @export
+ * @interface GetGpuInstanceConsole200Response
+ */
+export interface GetGpuInstanceConsole200Response {
+    /**
+     * 
+     * @type {number}
+     * @memberof GetGpuInstanceConsole200Response
+     */
+    'code': number;
+    /**
+     * 
+     * @type {GetGpuInstanceConsole200ResponseData}
+     * @memberof GetGpuInstanceConsole200Response
+     */
+    'data': GetGpuInstanceConsole200ResponseData;
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGpuInstanceConsole200Response
+     */
+    'msg': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGpuInstanceConsole200Response
+     */
+    'status': string;
+}
+/**
+ * 
+ * @export
+ * @interface GetGpuInstanceConsole200ResponseData
+ */
+export interface GetGpuInstanceConsole200ResponseData {
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGpuInstanceConsole200ResponseData
+     */
+    'console': string;
+}
+/**
+ * 
+ * @export
+ * @interface GetGpuInstanceConsole500Response
+ */
+export interface GetGpuInstanceConsole500Response {
+    /**
+     * 
+     * @type {number}
+     * @memberof GetGpuInstanceConsole500Response
+     */
+    'code'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGpuInstanceConsole500Response
+     */
+    'msg'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGpuInstanceConsole500Response
+     */
+    'status'?: string;
+}
+/**
+ * 
+ * @export
  * @interface GetGrafanaDashboardLinkResponse
  */
 export interface GetGrafanaDashboardLinkResponse {
@@ -9795,6 +9864,12 @@ export interface ListNodeGPUCardsResponseDataInner {
      * @memberof ListNodeGPUCardsResponseDataInner
      */
     'status': ListNodeGPUCardsResponseDataInnerStatus;
+    /**
+     * True when NVML runtime enrichment that this card should have had (stats, attached instances) could not be obtained, so its reported capacity is not trustworthy. Consumers such as schedulers should not allocate off a degraded card.
+     * @type {boolean}
+     * @memberof ListNodeGPUCardsResponseDataInner
+     */
+    'degraded': boolean;
 }
 
 
@@ -9872,12 +9947,6 @@ export interface ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerLinks {
      * @memberof ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerLinks
      */
     'grafana': string;
-    /**
-     * 
-     * @type {string}
-     * @memberof ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerLinks
-     */
-    'console': string;
 }
 /**
  * 
@@ -14076,6 +14145,31 @@ export interface UpdateNodeDeviceResponse {
 /**
  * 
  * @export
+ * @interface UpdateNodeGPUCard400Response
+ */
+export interface UpdateNodeGPUCard400Response {
+    /**
+     * 
+     * @type {number}
+     * @memberof UpdateNodeGPUCard400Response
+     */
+    'code'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof UpdateNodeGPUCard400Response
+     */
+    'msg'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof UpdateNodeGPUCard400Response
+     */
+    'status'?: string;
+}
+/**
+ * 
+ * @export
  * @interface UpdateNodeGPUCard409Response
  */
 export interface UpdateNodeGPUCard409Response {
@@ -14152,10 +14246,10 @@ export interface UpdateNodeGPUCardPutRequest {
 export interface UpdateNodeGPUCardPutRequestProfilesInner {
     /**
      * 
-     * @type {string}
+     * @type {number}
      * @memberof UpdateNodeGPUCardPutRequestProfilesInner
      */
-    'id': string;
+    'id': number;
     /**
      * 
      * @type {number}
@@ -20604,7 +20698,7 @@ export interface HealthApiGetHealthHistoryRequest {
 
     /**
      * The name of the module to retrieve health history. use GET /api/v1/datacenters/{dataCenter}/services/{serviceType} to get the module list.
-     * @type {'link' | 'clock' | 'dns' | 'bootstrap' | 'license' | 'etcd' | 'nodelist' | 'hacluster' | 'rabbitmq' | 'mysql' | 'mongodb' | 'vip' | 'haproxy_ha' | 'ceph' | 'ceph_mon' | 'ceph_osd' | 'ceph_rgw' | 'ceph_mds' | 'ceph_mgr' | 'rbd_target' | 'haproxy' | 'httpd' | 'skyline' | 'api' | 'memcache' | 'k3s' | 'keycloak' | 'neutron' | 'nova' | 'cyborg' | 'ironic' | 'glance' | 'cinder' | 'manila' | 'swift' | 'heat' | 'octavia' | 'designate' | 'rancher' | 'masakari' | 'zookeeper' | 'kafka' | 'monasca' | 'telegraf' | 'grafana' | 'filebeat' | 'auditbeat' | 'logstash' | 'opensearch' | 'opensearch-dashboards' | 'influxdb' | 'kapacitor'}
+     * @type {'link' | 'clock' | 'dns' | 'bootstrap' | 'license' | 'etcd' | 'nodelist' | 'hacluster' | 'rabbitmq' | 'mysql' | 'mongodb' | 'vip' | 'haproxy_ha' | 'ceph' | 'ceph_mon' | 'ceph_osd' | 'ceph_rgw' | 'ceph_mds' | 'ceph_mgr' | 'rbd_target' | 'fc_link' | 'haproxy' | 'httpd' | 'skyline' | 'api' | 'memcache' | 'k3s' | 'keycloak' | 'neutron' | 'nova' | 'cyborg' | 'ironic' | 'glance' | 'cinder' | 'manila' | 'swift' | 'heat' | 'octavia' | 'designate' | 'rancher' | 'masakari' | 'zookeeper' | 'kafka' | 'monasca' | 'telegraf' | 'grafana' | 'filebeat' | 'auditbeat' | 'logstash' | 'opensearch' | 'opensearch-dashboards' | 'influxdb' | 'kapacitor'}
      * @memberof HealthApiGetHealthHistory
      */
     readonly moduleType: GetHealthHistoryModuleTypeEnum
@@ -20758,7 +20852,7 @@ export interface HealthApiRepairModuleHealthRequest {
 
     /**
      * The name of the module to repair. use GET /api/v1/datacenters/{dataCenter}/services/{serviceType} to get the module list.
-     * @type {'link' | 'clock' | 'dns' | 'bootstrap' | 'license' | 'etcd' | 'nodelist' | 'hacluster' | 'rabbitmq' | 'mysql' | 'mongodb' | 'vip' | 'haproxy_ha' | 'ceph' | 'ceph_mon' | 'ceph_osd' | 'ceph_rgw' | 'ceph_mds' | 'ceph_mgr' | 'rbd_target' | 'haproxy' | 'httpd' | 'skyline' | 'api' | 'memcache' | 'k3s' | 'keycloak' | 'neutron' | 'nova' | 'cyborg' | 'ironic' | 'glance' | 'cinder' | 'manila' | 'swift' | 'heat' | 'octavia' | 'designate' | 'rancher' | 'masakari' | 'zookeeper' | 'kafka' | 'monasca' | 'telegraf' | 'grafana' | 'filebeat' | 'auditbeat' | 'logstash' | 'opensearch' | 'opensearch-dashboards' | 'influxdb' | 'kapacitor'}
+     * @type {'link' | 'clock' | 'dns' | 'bootstrap' | 'license' | 'etcd' | 'nodelist' | 'hacluster' | 'rabbitmq' | 'mysql' | 'mongodb' | 'vip' | 'haproxy_ha' | 'ceph' | 'ceph_mon' | 'ceph_osd' | 'ceph_rgw' | 'ceph_mds' | 'ceph_mgr' | 'rbd_target' | 'fc_link' | 'haproxy' | 'httpd' | 'skyline' | 'api' | 'memcache' | 'k3s' | 'keycloak' | 'neutron' | 'nova' | 'cyborg' | 'ironic' | 'glance' | 'cinder' | 'manila' | 'swift' | 'heat' | 'octavia' | 'designate' | 'rancher' | 'masakari' | 'zookeeper' | 'kafka' | 'monasca' | 'telegraf' | 'grafana' | 'filebeat' | 'auditbeat' | 'logstash' | 'opensearch' | 'opensearch-dashboards' | 'influxdb' | 'kapacitor'}
      * @memberof HealthApiRepairModuleHealth
      */
     readonly moduleType: RepairModuleHealthModuleTypeEnum
@@ -20889,6 +20983,7 @@ export const GetHealthHistoryModuleTypeEnum = {
     CephMds: 'ceph_mds',
     CephMgr: 'ceph_mgr',
     RbdTarget: 'rbd_target',
+    FcLink: 'fc_link',
     Haproxy: 'haproxy',
     Httpd: 'httpd',
     Skyline: 'skyline',
@@ -21046,6 +21141,7 @@ export const RepairModuleHealthModuleTypeEnum = {
     CephMds: 'ceph_mds',
     CephMgr: 'ceph_mgr',
     RbdTarget: 'rbd_target',
+    FcLink: 'fc_link',
     Haproxy: 'haproxy',
     Httpd: 'httpd',
     Skyline: 'skyline',
@@ -24805,6 +24901,52 @@ export const NodesApiAxiosParamCreator = function (configuration?: Configuration
             };
         },
         /**
+         * Mints a Nova noVNC console link for a single attached instance on demand. The GPU cards listing does not include console links, so that polling the listing does not create a console token per instance on every request; clients call this endpoint when a user opens a console.
+         * @summary Retrieve the console link for a GPU-attached instance
+         * @param {string} dataCenter The name of the data center to operate
+         * @param {string} nodeName The name of the node
+         * @param {string} instanceId The id of the GPU-attached instance (VM).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getGpuInstanceConsole: async (dataCenter: string, nodeName: string, instanceId: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'dataCenter' is not null or undefined
+            assertParamExists('getGpuInstanceConsole', 'dataCenter', dataCenter)
+            // verify required parameter 'nodeName' is not null or undefined
+            assertParamExists('getGpuInstanceConsole', 'nodeName', nodeName)
+            // verify required parameter 'instanceId' is not null or undefined
+            assertParamExists('getGpuInstanceConsole', 'instanceId', instanceId)
+            const localVarPath = `/api/v1/datacenters/{dataCenter}/nodes/{nodeName}/gpuCards/instances/{instanceId}/console`
+                .replace(`{${"dataCenter"}}`, encodeURIComponent(String(dataCenter)))
+                .replace(`{${"nodeName"}}`, encodeURIComponent(String(nodeName)))
+                .replace(`{${"instanceId"}}`, encodeURIComponent(String(instanceId)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
          * 
          * @summary Retrieve the node details
          * @param {string} dataCenter The name of the data center to operate
@@ -25500,6 +25642,21 @@ export const NodesApiFp = function(configuration?: Configuration) {
             return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
         },
         /**
+         * Mints a Nova noVNC console link for a single attached instance on demand. The GPU cards listing does not include console links, so that polling the listing does not create a console token per instance on every request; clients call this endpoint when a user opens a console.
+         * @summary Retrieve the console link for a GPU-attached instance
+         * @param {string} dataCenter The name of the data center to operate
+         * @param {string} nodeName The name of the node
+         * @param {string} instanceId The id of the GPU-attached instance (VM).
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getGpuInstanceConsole(dataCenter: string, nodeName: string, instanceId: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetGpuInstanceConsole200Response>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getGpuInstanceConsole(dataCenter, nodeName, instanceId, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['NodesApi.getGpuInstanceConsole']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
          * 
          * @summary Retrieve the node details
          * @param {string} dataCenter The name of the data center to operate
@@ -25741,6 +25898,16 @@ export const NodesApiFactory = function (configuration?: Configuration, basePath
             return localVarFp.disconnectNodeIpmi(requestParameters.dataCenter, requestParameters.nodeName, options).then((request) => request(axios, basePath));
         },
         /**
+         * Mints a Nova noVNC console link for a single attached instance on demand. The GPU cards listing does not include console links, so that polling the listing does not create a console token per instance on every request; clients call this endpoint when a user opens a console.
+         * @summary Retrieve the console link for a GPU-attached instance
+         * @param {NodesApiGetGpuInstanceConsoleRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getGpuInstanceConsole(requestParameters: NodesApiGetGpuInstanceConsoleRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetGpuInstanceConsole200Response> {
+            return localVarFp.getGpuInstanceConsole(requestParameters.dataCenter, requestParameters.nodeName, requestParameters.instanceId, options).then((request) => request(axios, basePath));
+        },
+        /**
          * 
          * @summary Retrieve the node details
          * @param {NodesApiGetNodeRequest} requestParameters Request parameters.
@@ -25948,6 +26115,34 @@ export interface NodesApiDisconnectNodeIpmiRequest {
      * @memberof NodesApiDisconnectNodeIpmi
      */
     readonly nodeName: string
+}
+
+/**
+ * Request parameters for getGpuInstanceConsole operation in NodesApi.
+ * @export
+ * @interface NodesApiGetGpuInstanceConsoleRequest
+ */
+export interface NodesApiGetGpuInstanceConsoleRequest {
+    /**
+     * The name of the data center to operate
+     * @type {string}
+     * @memberof NodesApiGetGpuInstanceConsole
+     */
+    readonly dataCenter: string
+
+    /**
+     * The name of the node
+     * @type {string}
+     * @memberof NodesApiGetGpuInstanceConsole
+     */
+    readonly nodeName: string
+
+    /**
+     * The id of the GPU-attached instance (VM).
+     * @type {string}
+     * @memberof NodesApiGetGpuInstanceConsole
+     */
+    readonly instanceId: string
 }
 
 /**
@@ -26397,6 +26592,18 @@ export class NodesApi extends BaseAPI {
      */
     public disconnectNodeIpmi(requestParameters: NodesApiDisconnectNodeIpmiRequest, options?: RawAxiosRequestConfig) {
         return NodesApiFp(this.configuration).disconnectNodeIpmi(requestParameters.dataCenter, requestParameters.nodeName, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * Mints a Nova noVNC console link for a single attached instance on demand. The GPU cards listing does not include console links, so that polling the listing does not create a console token per instance on every request; clients call this endpoint when a user opens a console.
+     * @summary Retrieve the console link for a GPU-attached instance
+     * @param {NodesApiGetGpuInstanceConsoleRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof NodesApi
+     */
+    public getGpuInstanceConsole(requestParameters: NodesApiGetGpuInstanceConsoleRequest, options?: RawAxiosRequestConfig) {
+        return NodesApiFp(this.configuration).getGpuInstanceConsole(requestParameters.dataCenter, requestParameters.nodeName, requestParameters.instanceId, options).then((request) => request(this.axios, this.basePath));
     }
 
     /**

--- a/packages/cube-frontend-web-app/src/mocks/gpu.ts
+++ b/packages/cube-frontend-web-app/src/mocks/gpu.ts
@@ -1,5 +1,6 @@
 import { delay, http, HttpResponse } from 'msw'
 import {
+  GetGpuInstanceConsole200Response,
   ListNodeGPUCardsResponse,
   UpdateNodeGPUCardPutRequest,
   UpdateNodeGPUCardResponse,
@@ -15,6 +16,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // MIG-backed vGPU + InUse
   {
     id: 'gpu-001',
+    degraded: false,
     name: 'NVIDIA A100 80GB',
     resourceType: GPUResourceType.MigBackedVgpu,
     pciAddress: '0000:01:00.0',
@@ -94,7 +96,6 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
         },
         links: {
           grafana: 'https://example.grafana/vm-99',
-          console: 'https://example.console/vm-99',
         },
       },
     ],
@@ -102,6 +103,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // MIG-backed vGPU + Idle
   {
     id: 'gpu-002',
+    degraded: false,
     name: 'NVIDIA A100 40GB',
     resourceType: GPUResourceType.MigBackedVgpu,
     pciAddress: '0000:02:00.0',
@@ -174,6 +176,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // Unassigned
   {
     id: 'gpu-003',
+    degraded: false,
     name: 'NVIDIA A100 80GB',
     resourceType: GPUResourceType.Unset,
     pciAddress: '0000:03:00.0',
@@ -208,6 +211,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // SR-IOV vGPU + InUse
   {
     id: 'gpu-004',
+    degraded: false,
     name: 'Intel Data Center GPU Flex 170',
     resourceType: GPUResourceType.SriovVgpu,
     pciAddress: '0000:04:00.0',
@@ -258,7 +262,6 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
         },
         links: {
           grafana: 'https://example.grafana/vm-201',
-          console: 'https://example.console/vm-201',
         },
       },
       {
@@ -272,7 +275,6 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
         },
         links: {
           grafana: 'https://example.grafana/vm-202',
-          console: 'https://example.console/vm-202',
         },
       },
       {
@@ -286,7 +288,6 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
         },
         links: {
           grafana: 'https://example.grafana/vm-203',
-          console: 'https://example.console/vm-203',
         },
       },
     ],
@@ -294,6 +295,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // SR-IOV vGPU + Idle
   {
     id: 'gpu-005',
+    degraded: false,
     name: 'Intel Data Center GPU Flex 140',
     resourceType: GPUResourceType.SriovVgpu,
     pciAddress: '0000:05:00.0',
@@ -337,6 +339,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // Unassigned
   {
     id: 'gpu-006',
+    degraded: false,
     name: 'Intel Data Center GPU Flex 170',
     resourceType: GPUResourceType.Unset,
     pciAddress: '0000:06:00.0',
@@ -367,6 +370,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // Passthrough + InUse
   {
     id: 'gpu-007',
+    degraded: false,
     name: 'NVIDIA RTX 4090',
     resourceType: GPUResourceType.Pgpu,
     pciAddress: '0000:07:00.0',
@@ -401,7 +405,6 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
         },
         links: {
           grafana: 'https://example.grafana/vm-301',
-          console: 'https://example.console/vm-301',
         },
       },
     ],
@@ -409,6 +412,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // Passthrough + Idle
   {
     id: 'gpu-008',
+    degraded: false,
     name: 'NVIDIA RTX 4080',
     resourceType: GPUResourceType.Pgpu,
     pciAddress: '0000:08:00.0',
@@ -436,6 +440,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // Unassigned
   {
     id: 'gpu-009',
+    degraded: false,
     name: 'NVIDIA T4',
     resourceType: GPUResourceType.Unset,
     pciAddress: '0000:09:00.0',
@@ -463,6 +468,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // Passthrough + InUse (H100)
   {
     id: 'gpu-010',
+    degraded: false,
     name: 'NVIDIA H100 80GB',
     resourceType: GPUResourceType.Pgpu,
     pciAddress: '0000:0a:00.0',
@@ -501,7 +507,6 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
         },
         links: {
           grafana: 'https://example.grafana/vm-401',
-          console: 'https://example.console/vm-401',
         },
       },
     ],
@@ -509,6 +514,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // SR-IOV vGPU + Idle (L40)
   {
     id: 'gpu-011',
+    degraded: false,
     name: 'NVIDIA L40',
     resourceType: GPUResourceType.SriovVgpu,
     pciAddress: '0000:0b:00.0',
@@ -552,6 +558,7 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
   // Unset + Unassigned
   {
     id: 'gpu-012',
+    degraded: false,
     name: 'NVIDIA A30',
     resourceType: GPUResourceType.Unset,
     pciAddress: '0000:0c:00.0',
@@ -608,6 +615,27 @@ export const mockUpdateNodeGpuCard = http.put<
     const res: UpdateNodeGPUCardResponse = {
       code: 200,
       msg: 'Success',
+      status: 'ok',
+    }
+
+    return HttpResponse.json(res)
+  },
+)
+
+export const mockGetGpuInstanceConsole = http.get<{
+  dataCenter: string
+  nodeName: string
+  instanceId: string
+}>(
+  '/api/v1/datacenters/:dataCenter/nodes/:nodeName/gpuCards/instances/:instanceId/console',
+  async ({ params }) => {
+    await delay(1000)
+    const res: GetGpuInstanceConsole200Response = {
+      code: 200,
+      data: {
+        console: `https://example.console/${params.instanceId}`,
+      },
+      msg: 'gpu instance console link retrieved successfully',
       status: 'ok',
     }
 

--- a/packages/cube-frontend-web-app/src/mocks/handlers.ts
+++ b/packages/cube-frontend-web-app/src/mocks/handlers.ts
@@ -1,3 +1,3 @@
-import { mockUpdateNodeGpuCard } from './gpu'
+import { mockGetGpuInstanceConsole, mockUpdateNodeGpuCard } from './gpu'
 
-export const handlers = [mockUpdateNodeGpuCard]
+export const handlers = [mockUpdateNodeGpuCard, mockGetGpuInstanceConsole]

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/EditGPUResourceModal/editGPUResourceUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/EditGPUResourceModal/editGPUResourceUtils.ts
@@ -184,7 +184,7 @@ export const getPayload = (
     selectedResourceType === 'pgpu'
       ? undefined
       : (confirmTableData.editedProfiles.map((p) => ({
-          id: p.id,
+          id: Number(p.id),
           count: p.count,
         })) satisfies UpdateNodeGPUCardPutRequestProfilesInner[])
 

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuConsoleLink.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuConsoleLink.tsx
@@ -1,0 +1,54 @@
+import { useContext } from 'react'
+import { useTranslation } from 'react-i18next'
+import { CosHyperlink } from '@cube-frontend/ui-library'
+import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
+import { nodesApi } from '@cube-frontend/web-app/api/cosApi'
+import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
+import { useShowErrorToast } from '@cube-frontend/web-app/hooks/useShowErrorToast/useShowErrorToast'
+
+export type GpuConsoleLinkProps = {
+  nodeName: string
+  instanceId: string
+}
+
+/**
+ * Console links are minted on demand rather than embedded in the GPU cards
+ * listing (so polling the listing does not create a Nova console token per
+ * instance on every request). Fetch the link on click and open it in a new tab.
+ */
+export const GpuConsoleLink = (props: GpuConsoleLinkProps) => {
+  const { nodeName, instanceId } = props
+
+  const { t } = useTranslation()
+
+  const { dataCenter } = useContext(DataCenterContext)
+
+  const showErrorToast = useShowErrorToast()
+
+  const { isLoading, mutateResource: getGpuInstanceConsole } =
+    useCosMutationRequest(nodesApi.getGpuInstanceConsole)
+
+  const onConsoleClick = async () => {
+    try {
+      const { console: consoleUrl } = await getGpuInstanceConsole({
+        dataCenter: dataCenter!.name,
+        nodeName,
+        instanceId,
+      })
+      window.open(consoleUrl, '_blank', 'noopener,noreferrer')
+    } catch (error) {
+      showErrorToast(error)
+    }
+  }
+
+  return (
+    <CosHyperlink
+      size="sm"
+      variant="text-inline"
+      disabled={isLoading}
+      onClick={onConsoleClick}
+    >
+      {t('nodes.details.attachedInstancesList.console')}
+    </CosHyperlink>
+  )
+}

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuConsoleLink.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuConsoleLink.tsx
@@ -1,9 +1,9 @@
-import { useContext } from 'react'
+import { useContext, useState } from 'react'
 import { useTranslation } from 'react-i18next'
 import { CosHyperlink } from '@cube-frontend/ui-library'
 import { DataCenterContext } from '@cube-frontend/web-app/context/DataCenterContext'
 import { nodesApi } from '@cube-frontend/web-app/api/cosApi'
-import { useCosMutationRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosMutationRequest'
+import { useCosGetRequest } from '@cube-frontend/web-app/hooks/useCosRequest/useCosGetRequest'
 import { useShowErrorToast } from '@cube-frontend/web-app/hooks/useShowErrorToast/useShowErrorToast'
 
 export type GpuConsoleLinkProps = {
@@ -25,19 +25,27 @@ export const GpuConsoleLink = (props: GpuConsoleLinkProps) => {
 
   const showErrorToast = useShowErrorToast()
 
-  const { isLoading, mutateResource: getGpuInstanceConsole } =
-    useCosMutationRequest(nodesApi.getGpuInstanceConsole)
+  const { getResource: getGpuInstanceConsole } = useCosGetRequest(
+    nodesApi.getGpuInstanceConsole,
+    () => ({
+      dataCenter: dataCenter!.name,
+      nodeName,
+      instanceId,
+    }),
+    { fetchOnMount: false, fetchOnParamChanges: false },
+  )
+
+  const [isOpeningConsole, setIsOpeningConsole] = useState(false)
 
   const onConsoleClick = async () => {
+    setIsOpeningConsole(true)
     try {
-      const { console: consoleUrl } = await getGpuInstanceConsole({
-        dataCenter: dataCenter!.name,
-        nodeName,
-        instanceId,
-      })
+      const { console: consoleUrl } = await getGpuInstanceConsole()
       window.open(consoleUrl, '_blank', 'noopener,noreferrer')
     } catch (error) {
       showErrorToast(error)
+    } finally {
+      setIsOpeningConsole(false)
     }
   }
 
@@ -45,7 +53,7 @@ export const GpuConsoleLink = (props: GpuConsoleLinkProps) => {
     <CosHyperlink
       size="sm"
       variant="text-inline"
-      disabled={isLoading}
+      disabled={isOpeningConsole}
       onClick={onConsoleClick}
     >
       {t('nodes.details.attachedInstancesList.console')}

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetails.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetails.tsx
@@ -12,6 +12,7 @@ import {
   GPUProfileRow,
   getProfilesByResourceType,
 } from './utils'
+import { GpuConsoleLink } from './GpuConsoleLink'
 
 const GpuProfilesInfoTable = GetInfoTable<GPUProfileRow>()
 
@@ -19,11 +20,12 @@ const GpuAttachedInstanceInfoTable =
   GetInfoTable<ListNodeGPUCardsResponseDataInnerAttachedInstancesInner>()
 
 export type GpuDetailsProps = {
+  nodeName: string
   row: GpuResourceRow
 }
 
 const GpuDetails = (props: GpuDetailsProps) => {
-  const { row } = props
+  const { nodeName, row } = props
 
   const { t } = useTranslation()
 
@@ -51,14 +53,7 @@ const GpuDetails = (props: GpuDetailsProps) => {
   ) => {
     return (
       <div className="flex w-full flex-row gap-x-4">
-        <CosHyperlink
-          size="sm"
-          variant="text-inline"
-          href={row.links.console}
-          target="_blank"
-        >
-          {t('nodes.details.attachedInstancesList.console')}
-        </CosHyperlink>
+        <GpuConsoleLink nodeName={nodeName} instanceId={row.id} />
         <CosHyperlink
           size="sm"
           variant="text-inline"

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetailsFullViewModal/FullViewInstanceTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetailsFullViewModal/FullViewInstanceTable.tsx
@@ -1,7 +1,4 @@
-import {
-  ListNodeGPUCardsResponseDataInnerAttachedInstancesInner,
-  ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerLinks,
-} from '@cube-frontend/api'
+import { ListNodeGPUCardsResponseDataInnerAttachedInstancesInner } from '@cube-frontend/api'
 import {
   GetCosBasicTable,
   CosTableRow,
@@ -14,6 +11,7 @@ import { toReadableUsedSize } from '@cube-frontend/web-app/utils/byte'
 import { useMemo, useState } from 'react'
 import { getItemsInView } from './utils'
 import { useTranslation } from 'react-i18next'
+import { GpuConsoleLink } from '../GpuConsoleLink'
 
 type InstanceTableRow = CosTableRow &
   ListNodeGPUCardsResponseDataInnerAttachedInstancesInner
@@ -22,11 +20,12 @@ const InstanceTable = GetCosBasicTable<InstanceTableRow>()
 
 type FullViewInstanceTableProps = {
   title: string
+  nodeName: string
   instances: ListNodeGPUCardsResponseDataInnerAttachedInstancesInner[]
 }
 
 export const FullViewInstanceTable = (props: FullViewInstanceTableProps) => {
-  const { title, instances } = props
+  const { title, nodeName, instances } = props
 
   const { t } = useTranslation()
 
@@ -59,23 +58,14 @@ export const FullViewInstanceTable = (props: FullViewInstanceTableProps) => {
     return `${used} ${sizeUnit} / ${total} ${sizeUnit}`
   }
 
-  const renderActions = (
-    links: ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerLinks,
-  ) => {
+  const renderActions = (row: InstanceTableRow) => {
     return (
       <div className="flex w-full flex-row gap-x-4">
+        <GpuConsoleLink nodeName={nodeName} instanceId={row.id} />
         <CosHyperlink
           size="sm"
           variant="text-inline"
-          href={links.console}
-          target="_blank"
-        >
-          {t('nodes.details.attachedInstancesList.console')}
-        </CosHyperlink>
-        <CosHyperlink
-          size="sm"
-          variant="text-inline"
-          href={links.grafana}
+          href={row.links.grafana}
           target="_blank"
         >
           Grafana
@@ -115,7 +105,7 @@ export const FullViewInstanceTable = (props: FullViewInstanceTableProps) => {
           property="links"
           label={t('nodes.details.attachedInstancesList.action')}
         >
-          {(links) => renderActions(links)}
+          {(_, row) => renderActions(row)}
         </InstanceTable.Column>
       </InstanceTable>
       <CosPagination

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetailsFullViewModal/GpuDetailsFullViewModal.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetailsFullViewModal/GpuDetailsFullViewModal.tsx
@@ -10,6 +10,7 @@ type FullViewTab = 'profiles' | 'instances'
 
 export type GpuDetailsFullViewModalProps = {
   isModalOpen: boolean
+  nodeName: string
   resource: GpuResourceRow | undefined
   onClose: () => void
 }
@@ -17,7 +18,7 @@ export type GpuDetailsFullViewModalProps = {
 export const GpuDetailsFullViewModal = (
   props: GpuDetailsFullViewModalProps,
 ) => {
-  const { isModalOpen, resource, onClose } = props
+  const { isModalOpen, nodeName, resource, onClose } = props
 
   const { t } = useTranslation()
 
@@ -52,6 +53,7 @@ export const GpuDetailsFullViewModal = (
     instances: () => (
       <FullViewInstanceTable
         title={tabTitleMap['instances']}
+        nodeName={nodeName}
         instances={resource?.attachedInstances ?? []}
       />
     ),

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/NodeGpuResources.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/NodeGpuResources.tsx
@@ -207,7 +207,7 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
 
     return (
       <div className="flex w-full justify-between gap-x-4">
-        <GpuDetails row={row} />
+        <GpuDetails nodeName={node?.hostname ?? ''} row={row} />
         <CosTooltip
           hoverContent={{ message: t('nodes.details.fullViewModal.tooltip') }}
           placement="top-left"
@@ -297,6 +297,7 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
       {fullViewTarget && (
         <GpuDetailsFullViewModal
           isModalOpen={!!fullViewTarget}
+          nodeName={node?.hostname ?? ''}
           resource={fullViewTarget}
           onClose={closeResourceFullView}
         />


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

GPU-attached instance console links are no longer embedded in the `listNodeGPUCards` response. They are now minted on demand per instance via the new `getGpuInstanceConsole` endpoint, opened in a new tab on click; any failure surfaces as an error toast. List `links` now carry only the Grafana deep-link. This avoids minting a Nova console token per instance on every listing poll.

- Bump `cube-cos-openapi` submodule to `develop` and regenerate the SDK (console endpoint, `degraded` flag, `links` without `console`, profile-id type fix).
- New `GpuConsoleLink` component: click → `getGpuInstanceConsole` → `window.open`; disabled while loading; error toast. Dedupes the two identical console render spots.
- `GpuDetails` / `FullViewInstanceTable`: swap the console hyperlink for `GpuConsoleLink`; Grafana unchanged. `nodeName` threaded down from `NodeGpuResources`.
- `editGPUResourceUtils`: update-payload profile `id` now `Number(...)` to match the SDK type flip (string → number).
- Mocks: drop `console` from mock links, add `degraded: false` to cards, add + register `mockGetGpuInstanceConsole`.

Out of scope: rendering the new `degraded` card flag in the UI.

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

> The submodule points at `cube-cos-openapi` **develop**. Land that spec change before merging so the SDK diff matches a pinned ref.

Verification: `pnpm tsc` clean, `pnpm web-app:test` 98 passed, `pnpm lint` clean.

#### Additional documentation

```docs
Handbook: kb/cubecos/architecture/gpu-card-apis.md — list / update / console endpoint contract.
```
