### PR TITLE
fix(login): build the keycloak image without XA transactions

### DIFF
--- a/packages/cube-frontend-keycloak-login/cube-cos-login.spec
+++ b/packages/cube-frontend-keycloak-login/cube-cos-login.spec
@@ -34,12 +34,23 @@ buildah run $ctr -- sed -i 's/owners="2"/owners="3"/g' /opt/keycloak/conf/cache-
 # Quarkus fixes these options when the server is augmented, so bake them in here. Left to
 # the runtime environment they make every pod re-augment while starting, and
 # http-relative-path cannot be changed at runtime at all.
+#
+# transaction-xa-enabled=false is what lets this image run against CubeCOS' database at
+# all once the cluster is HA: keycloak 18 defaults to XA transactions, and MariaDB
+# refuses them whenever wsrep is on -- "This version of MariaDB doesn't yet support 'XA
+# transactions with Galera replication'". That aborts the very first bootstrap midway,
+# after the default client scopes are committed but before MIGRATION_MODEL is stamped,
+# so every later start re-runs the initial migration and dies on a duplicate role_list
+# scope. A single-node install has no [galera] section and never sees it. The option is
+# build-time only -- keycloak 18 rejects it on `kc.sh start` and does not even list it in
+# --help-all -- so this build line is the only place it can be set.
 buildah run $ctr -- /opt/keycloak/bin/kc.sh build \
     --db=mariadb \
     --cache=ispn \
     --health-enabled=true \
     --metrics-enabled=true \
-    --http-relative-path=/auth
+    --http-relative-path=/auth \
+    --transaction-xa-enabled=false
 buildah commit $ctr localhost:5080/bigstack/keycloak:%{version}
 buildah rm $ctr
 cd -


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

The keycloak image this package builds cannot run against CubeCOS' database once the cluster is HA.

Keycloak 18 defaults to **XA transactions**, and MariaDB refuses XA whenever wsrep is on:

```
java.sql.SQLSyntaxErrorException: This version of MariaDB doesn't yet support 'XA transactions with Galera replication'
```

That kills the very first bootstrap midway — the default client scopes are committed, but `MIGRATION_MODEL` is never stamped — so every later start re-runs the initial migration and dies on a duplicate scope:

```
Duplicate entry '375fb96e-…-role_list' for key 'UK_CLI_SCOPE'
```

The pod ends up in a permanent `CrashLoopBackOff` (93+ restarts observed), the k3s ingress serves 503 for `/auth/realms/master/protocol/saml/descriptor`, and CubeCOS' first-time setup blocks forever on its SAML-metadata gate.

A single-node install writes no `[galera]` section, so it never sees this — which is why the 1cc/1ec topologies stayed green while every multi-node topology (2ec_1m, 3cc, 3c_3p_5s) hung.

`transaction-xa-enabled` is a **build-time** option: keycloak 18 rejects it on `kc.sh start` ("Unknown option"), does not list it in `--help-all`, and ignores both `KC_TRANSACTION_XA_ENABLED` and `QUARKUS_DATASOURCE_JDBC_TRANSACTIONS` at runtime. The augmentation in this spec is the only place it can be set, next to the db/cache/health/metrics/http-relative-path options already fixed there.

#### Which issue(s) this PR fixes

Fixes # <!-- no cube-cos-ui issue; found while closing out the CubeCOS side -->

Part of bigstack-oss/cubecos#614 — the wrap-up issue for the accept/prod pipeline runs closing out the yoga → antelope OpenStack migration epic for CubeCOS v3.1.10.

#### Special notes for your reviewer

> Note
> The healthy/broken split is visible directly in the database. A working single-node install carries the stamp; every broken HA node had none, with identical client scopes:

| node | `MIGRATION_MODEL` | keycloak pod |
|---|---|---|
| accept-1ec (single node) | `18.0.2` | `1/1 Running` |
| accept-2ec_1m / 3cc / 3c_3p_5s (HA) | *(empty)* | `CrashLoopBackOff` |

The poisoned state does not self-heal on an existing node: the keycloak database has to be dropped and recreated once the image carries the fix, because the duplicate scope rows survive a restart.

#### Additional documentation

```docs
Verified two ways.

1. The build line itself, run in the cubecos build jail exactly as this spec runs it:

     buildah run $ctr -- /opt/keycloak/bin/kc.sh build \
         --db=mariadb --cache=ispn --health-enabled=true \
         --metrics-enabled=true --http-relative-path=/auth \
         --transaction-xa-enabled=false

   kc.sh show-config on the resulting container:

     kc.cache               = ispn        (PersistedConfigSource)
     kc.db                  = mariadb     (PersistedConfigSource)
     kc.health-enabled      = true        (PersistedConfigSource)
     kc.http-relative-path  = /auth       (PersistedConfigSource)
     kc.metrics-enabled     = true        (PersistedConfigSource)
     kc.transaction-xa-enabled = false    (PersistedConfigSource)

   i.e. the new option persists and every existing one is untouched.

2. The same augmentation applied to the running pod on accept-2ec_1m, against a
   real galera cluster (wsrep_ready ON), with the poisoned keycloak database
   dropped and recreated first:

     pod              CrashLoopBackOff (93 restarts)  ->  1/1 Running (50s)
     XA errors        present                         ->  0
     MIGRATION_MODEL  (empty)                         ->  18.0.2
     SAML via VIP     503                             ->  200

   The blocked first-time setup then resumed on its own: /etc/keycloak/saml-metadata.xml
   and keystone_sp_metadata.xml were written and hex_config moved on to pacemaker.

NOT covered:
- The rebuilt RPM has not been through a full cubecos pipeline run yet; cubecos is being
  pointed at this branch temporarily so the next accept/prod run exercises it end to end.
- No 17 -> 18 upgrade path was exercised with this image; the verification above is a
  fresh HA install.
```