### PR TITLE
chore: unregister the GPU MSW mock handlers

### DIFF
--- a/packages/cube-frontend-web-app/src/mocks/handlers.ts
+++ b/packages/cube-frontend-web-app/src/mocks/handlers.ts
@@ -1,3 +1,6 @@
-import { mockGetGpuInstanceConsole, mockUpdateNodeGpuCard } from './gpu'
+import type { RequestHandler } from 'msw'
 
-export const handlers = [mockUpdateNodeGpuCard, mockGetGpuInstanceConsole]
+// No handler is registered, so every request goes to the real API.
+// The GPU mocks in `./gpu` stay available. Add them back here when you need
+// them.
+export const handlers: RequestHandler[] = []


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it

The GPU feature is ready on the API side, so the dev UI no longer needs mocked GPU responses.

- `src/mocks/handlers.ts` now exports an empty handler list. MSW starts with `onUnhandledRequest: 'bypass'`, so every request goes to the real API through the Vite `/api` proxy.
- `src/mocks/gpu.ts` stays in the tree. Import the mocks back into `handlers` when you need them again.

**QA view**

Depends on `cube-cos-api` for the GPU card endpoints. Nothing changes in a production build — MSW only runs in dev mode.

Check list (dev mode, `pnpm run web-app:dev`, `.env.local` pointed at a data center with a GPU node):

1. Open the node detail page of a node with `labels.isGpuEnabled = true`.
2. The GPU Resources table shows the cards the API returns, not the mock cards (`NVIDIA A100`, `NVIDIA H100`, …).
3. The browser Network tab shows a real `GET /api/v1/datacenters/{dc}/nodes/{node}/gpuCards` request, with a 200 from the appliance.
4. The browser console has no error.
5. Edit GPU Resource and the GPU console link hit the appliance too — no mocked delay, and a failure now surfaces the API error.

**Developer view**

| File | Change |
| --- | --- |
| `packages/cube-frontend-web-app/src/mocks/handlers.ts` | `handlers` is now `RequestHandler[] = []` |
| `packages/cube-frontend-web-app/src/mocks/gpu.ts` | unchanged, kept for future use |

`enableMocking()` in `src/main.tsx`, `src/mocks/browser.js`, `public/mockServiceWorker.js`, and the `msw` devDependency all stay. An empty worker plus `bypass` is a no-op on the network.

#### Which issue(s) this PR fixes

Fixes #

#### Special notes for your reviewer

> Note

Verified against a live appliance (`sky150`). `GET .../nodes/sky150/gpuCards` returned one `NVIDIA RTX A2000`, and the GPU Resources table rendered that card (`Unset`, `0.21 GiB / 5.99 GiB`, `0%`, `00000000:86:00.0`, `Unassigned`) with zero console errors.

`pnpm tsc`, `eslint`, and `prettier --check` are clean.

#### Additional documentation

The handbook Topic that describes this feature is updated in the same breath, so nobody reads "dev-time GPU data comes from MSW" after this lands: [bigstack-handbook#283](https://github.com/bigstack-oss/bigstack-handbook/pull/283).

It records why a stale handler is silent — MSW runs inside the page and wins over the Vite `/api` proxy, and `onUnhandledRequest: 'bypass'` only quiets requests **no** handler matched — plus the curl recipe that proves which side answered a request.

```docs
https://github.com/bigstack-oss/bigstack-handbook/pull/283
kb/cubecos/architecture/gpu-resource-listing.md
```
