### PR TITLE
feat(nodes): 824 open the Grafana GPU history panels from a GPU row

### DIFF
--- a/packages/cube-frontend-api/sdk/api.ts
+++ b/packages/cube-frontend-api/sdk/api.ts
@@ -3895,6 +3895,56 @@ export interface GetGrafanaDashboardLinkResponseData {
 /**
  * 
  * @export
+ * @interface GetGrafanaDeviceGpuUtilization500Response
+ */
+export interface GetGrafanaDeviceGpuUtilization500Response {
+    /**
+     * 
+     * @type {number}
+     * @memberof GetGrafanaDeviceGpuUtilization500Response
+     */
+    'code'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGrafanaDeviceGpuUtilization500Response
+     */
+    'msg'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGrafanaDeviceGpuUtilization500Response
+     */
+    'status'?: string;
+}
+/**
+ * 
+ * @export
+ * @interface GetGrafanaDeviceGpuVram500Response
+ */
+export interface GetGrafanaDeviceGpuVram500Response {
+    /**
+     * 
+     * @type {number}
+     * @memberof GetGrafanaDeviceGpuVram500Response
+     */
+    'code'?: number;
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGrafanaDeviceGpuVram500Response
+     */
+    'msg'?: string;
+    /**
+     * 
+     * @type {string}
+     * @memberof GetGrafanaDeviceGpuVram500Response
+     */
+    'status'?: string;
+}
+/**
+ * 
+ * @export
  * @interface GetGrafanaHosts500Response
  */
 export interface GetGrafanaHosts500Response {
@@ -9860,6 +9910,12 @@ export interface ListNodeGPUCardsResponseDataInner {
     'attachedInstances': Array<ListNodeGPUCardsResponseDataInnerAttachedInstancesInner> | null;
     /**
      * 
+     * @type {ListNodeGPUCardsResponseDataInnerLinks}
+     * @memberof ListNodeGPUCardsResponseDataInner
+     */
+    'links': ListNodeGPUCardsResponseDataInnerLinks;
+    /**
+     * 
      * @type {ListNodeGPUCardsResponseDataInnerStatus}
      * @memberof ListNodeGPUCardsResponseDataInner
      */
@@ -9917,11 +9973,11 @@ export interface ListNodeGPUCardsResponseDataInnerAttachedInstancesInner {
      */
     'profileAlias': string | null;
     /**
-     * 
+     * Null when the value does not exist for this instance\'s GPU resource type: a MIG-backed vGPU reports no utilization, and a passed-through GPU is invisible to the host altogether.
      * @type {number}
      * @memberof ListNodeGPUCardsResponseDataInnerAttachedInstancesInner
      */
-    'utilizationPercent': number;
+    'utilizationPercent': number | null;
     /**
      * 
      * @type {ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerMemoryUsage}
@@ -9942,11 +9998,11 @@ export interface ListNodeGPUCardsResponseDataInnerAttachedInstancesInner {
  */
 export interface ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerLinks {
     /**
-     * 
+     * Null when the dashboard variables cannot be pinned: without the owning project the dashboard\'s tenant, hostname and instance variables all resolve on load and the page can label this VM\'s chart with another VM. A GPU passed through to a VM has no vGPU series to chart in the first place, so no link is the honest answer -- the same rule as the stats above, where a value that cannot be measured is null rather than 0.
      * @type {string}
      * @memberof ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerLinks
      */
-    'grafana': string;
+    'grafana': string | null;
 }
 /**
  * 
@@ -9959,13 +10015,13 @@ export interface ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerMemoryUs
      * @type {number}
      * @memberof ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerMemoryUsage
      */
-    'allocatedMiB': number;
+    'allocatedMiB': number | null;
     /**
      * 
      * @type {number}
      * @memberof ListNodeGPUCardsResponseDataInnerAttachedInstancesInnerMemoryUsage
      */
-    'totalMiB': number;
+    'totalMiB': number | null;
 }
 /**
  * 
@@ -9978,7 +10034,26 @@ export interface ListNodeGPUCardsResponseDataInnerGpu {
      * @type {number}
      * @memberof ListNodeGPUCardsResponseDataInnerGpu
      */
-    'utilizationPercent': number;
+    'utilizationPercent': number | null;
+}
+/**
+ * History charts for this one card. They are reported inline with the card because the UI offers them from its row: a link built per node would be identical on every row of the same node. Both are always present -- a card with no series (a passed-through GPU, or utilization on a MIG-enabled card) still has a chart, it is simply empty.
+ * @export
+ * @interface ListNodeGPUCardsResponseDataInnerLinks
+ */
+export interface ListNodeGPUCardsResponseDataInnerLinks {
+    /**
+     * 
+     * @type {string}
+     * @memberof ListNodeGPUCardsResponseDataInnerLinks
+     */
+    'workloadHistory': string;
+    /**
+     * 
+     * @type {string}
+     * @memberof ListNodeGPUCardsResponseDataInnerLinks
+     */
+    'vramHistory': string;
 }
 /**
  * 
@@ -10021,7 +10096,7 @@ export interface ListNodeGPUCardsResponseDataInnerStatus {
 
 
 /**
- * 
+ * A null field means the number does not exist for this card rather than being zero, and the card is not degraded by it. A GPU passed through to a VM (pgpu) is bound to vfio-pci and is invisible to the host, so it has no runtime stats at all; a card with MIG enabled reports its framebuffer but no utilization, because NVIDIA provides none once the card is partitioned.
  * @export
  * @interface ListNodeGPUCardsResponseDataInnerVram
  */
@@ -10031,19 +10106,19 @@ export interface ListNodeGPUCardsResponseDataInnerVram {
      * @type {number}
      * @memberof ListNodeGPUCardsResponseDataInnerVram
      */
-    'allocatedMiB': number;
+    'allocatedMiB': number | null;
     /**
      * 
      * @type {number}
      * @memberof ListNodeGPUCardsResponseDataInnerVram
      */
-    'totalMiB': number;
+    'totalMiB': number | null;
     /**
      * 
      * @type {number}
      * @memberof ListNodeGPUCardsResponseDataInnerVram
      */
-    'utilizationPercent': number;
+    'utilizationPercent': number | null;
 }
 /**
  * 
@@ -19587,6 +19662,90 @@ export const GrafanaApiAxiosParamCreator = function (configuration?: Configurati
     return {
         /**
          * 
+         * @summary Get Grafana device GPU utilization history dashboard link
+         * @param {string} dataCenter The name of the data center to operate
+         * @param {string} hostname The hostname of the host to operate
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getGrafanaDeviceGpuUtilization: async (dataCenter: string, hostname: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'dataCenter' is not null or undefined
+            assertParamExists('getGrafanaDeviceGpuUtilization', 'dataCenter', dataCenter)
+            // verify required parameter 'hostname' is not null or undefined
+            assertParamExists('getGrafanaDeviceGpuUtilization', 'hostname', hostname)
+            const localVarPath = `/api/v1/datacenters/{dataCenter}/grafana/devices/{hostname}/gpuUtilization`
+                .replace(`{${"dataCenter"}}`, encodeURIComponent(String(dataCenter)))
+                .replace(`{${"hostname"}}`, encodeURIComponent(String(hostname)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
+         * @summary Get Grafana device GPU VRAM usage history dashboard link
+         * @param {string} dataCenter The name of the data center to operate
+         * @param {string} hostname The hostname of the host to operate
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getGrafanaDeviceGpuVram: async (dataCenter: string, hostname: string, options: RawAxiosRequestConfig = {}): Promise<RequestArgs> => {
+            // verify required parameter 'dataCenter' is not null or undefined
+            assertParamExists('getGrafanaDeviceGpuVram', 'dataCenter', dataCenter)
+            // verify required parameter 'hostname' is not null or undefined
+            assertParamExists('getGrafanaDeviceGpuVram', 'hostname', hostname)
+            const localVarPath = `/api/v1/datacenters/{dataCenter}/grafana/devices/{hostname}/gpuVram`
+                .replace(`{${"dataCenter"}}`, encodeURIComponent(String(dataCenter)))
+                .replace(`{${"hostname"}}`, encodeURIComponent(String(hostname)));
+            // use dummy base URL string because the URL constructor only accepts absolute URLs.
+            const localVarUrlObj = new URL(localVarPath, DUMMY_BASE_URL);
+            let baseOptions;
+            if (configuration) {
+                baseOptions = configuration.baseOptions;
+            }
+
+            const localVarRequestOptions = { method: 'GET', ...baseOptions, ...options};
+            const localVarHeaderParameter = {} as any;
+            const localVarQueryParameter = {} as any;
+
+            // authentication BearerAuth required
+            // http bearer authentication required
+            await setBearerAuthToObject(localVarHeaderParameter, configuration)
+
+
+    
+            setSearchParams(localVarUrlObj, localVarQueryParameter);
+            let headersFromBaseOptions = baseOptions && baseOptions.headers ? baseOptions.headers : {};
+            localVarRequestOptions.headers = {...localVarHeaderParameter, ...headersFromBaseOptions, ...options.headers};
+
+            return {
+                url: toPathString(localVarUrlObj),
+                options: localVarRequestOptions,
+            };
+        },
+        /**
+         * 
          * @summary Get Grafana hosts dashboard
          * @param {string} dataCenter The name of the data center to operate
          * @param {string} hostname The hostname of the host to operate
@@ -19871,6 +20030,34 @@ export const GrafanaApiFp = function(configuration?: Configuration) {
     return {
         /**
          * 
+         * @summary Get Grafana device GPU utilization history dashboard link
+         * @param {string} dataCenter The name of the data center to operate
+         * @param {string} hostname The hostname of the host to operate
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getGrafanaDeviceGpuUtilization(dataCenter: string, hostname: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetGrafanaDashboardLinkResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getGrafanaDeviceGpuUtilization(dataCenter, hostname, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['GrafanaApi.getGrafanaDeviceGpuUtilization']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
+         * @summary Get Grafana device GPU VRAM usage history dashboard link
+         * @param {string} dataCenter The name of the data center to operate
+         * @param {string} hostname The hostname of the host to operate
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        async getGrafanaDeviceGpuVram(dataCenter: string, hostname: string, options?: RawAxiosRequestConfig): Promise<(axios?: AxiosInstance, basePath?: string) => AxiosPromise<GetGrafanaDashboardLinkResponse>> {
+            const localVarAxiosArgs = await localVarAxiosParamCreator.getGrafanaDeviceGpuVram(dataCenter, hostname, options);
+            const localVarOperationServerIndex = configuration?.serverIndex ?? 0;
+            const localVarOperationServerBasePath = operationServerMap['GrafanaApi.getGrafanaDeviceGpuVram']?.[localVarOperationServerIndex]?.url;
+            return (axios, basePath) => createRequestFunction(localVarAxiosArgs, globalAxios, BASE_PATH, configuration)(axios, localVarOperationServerBasePath || basePath);
+        },
+        /**
+         * 
          * @summary Get Grafana hosts dashboard
          * @param {string} dataCenter The name of the data center to operate
          * @param {string} hostname The hostname of the host to operate
@@ -19974,6 +20161,26 @@ export const GrafanaApiFactory = function (configuration?: Configuration, basePa
     return {
         /**
          * 
+         * @summary Get Grafana device GPU utilization history dashboard link
+         * @param {GrafanaApiGetGrafanaDeviceGpuUtilizationRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getGrafanaDeviceGpuUtilization(requestParameters: GrafanaApiGetGrafanaDeviceGpuUtilizationRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetGrafanaDashboardLinkResponse> {
+            return localVarFp.getGrafanaDeviceGpuUtilization(requestParameters.dataCenter, requestParameters.hostname, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
+         * @summary Get Grafana device GPU VRAM usage history dashboard link
+         * @param {GrafanaApiGetGrafanaDeviceGpuVramRequest} requestParameters Request parameters.
+         * @param {*} [options] Override http request option.
+         * @throws {RequiredError}
+         */
+        getGrafanaDeviceGpuVram(requestParameters: GrafanaApiGetGrafanaDeviceGpuVramRequest, options?: RawAxiosRequestConfig): AxiosPromise<GetGrafanaDashboardLinkResponse> {
+            return localVarFp.getGrafanaDeviceGpuVram(requestParameters.dataCenter, requestParameters.hostname, options).then((request) => request(axios, basePath));
+        },
+        /**
+         * 
          * @summary Get Grafana hosts dashboard
          * @param {GrafanaApiGetGrafanaHostsRequest} requestParameters Request parameters.
          * @param {*} [options] Override http request option.
@@ -20044,6 +20251,48 @@ export const GrafanaApiFactory = function (configuration?: Configuration, basePa
         },
     };
 };
+
+/**
+ * Request parameters for getGrafanaDeviceGpuUtilization operation in GrafanaApi.
+ * @export
+ * @interface GrafanaApiGetGrafanaDeviceGpuUtilizationRequest
+ */
+export interface GrafanaApiGetGrafanaDeviceGpuUtilizationRequest {
+    /**
+     * The name of the data center to operate
+     * @type {string}
+     * @memberof GrafanaApiGetGrafanaDeviceGpuUtilization
+     */
+    readonly dataCenter: string
+
+    /**
+     * The hostname of the host to operate
+     * @type {string}
+     * @memberof GrafanaApiGetGrafanaDeviceGpuUtilization
+     */
+    readonly hostname: string
+}
+
+/**
+ * Request parameters for getGrafanaDeviceGpuVram operation in GrafanaApi.
+ * @export
+ * @interface GrafanaApiGetGrafanaDeviceGpuVramRequest
+ */
+export interface GrafanaApiGetGrafanaDeviceGpuVramRequest {
+    /**
+     * The name of the data center to operate
+     * @type {string}
+     * @memberof GrafanaApiGetGrafanaDeviceGpuVram
+     */
+    readonly dataCenter: string
+
+    /**
+     * The hostname of the host to operate
+     * @type {string}
+     * @memberof GrafanaApiGetGrafanaDeviceGpuVram
+     */
+    readonly hostname: string
+}
 
 /**
  * Request parameters for getGrafanaHosts operation in GrafanaApi.
@@ -20164,6 +20413,30 @@ export interface GrafanaApiGetGrafanaTopInstancesRequest {
  * @extends {BaseAPI}
  */
 export class GrafanaApi extends BaseAPI {
+    /**
+     * 
+     * @summary Get Grafana device GPU utilization history dashboard link
+     * @param {GrafanaApiGetGrafanaDeviceGpuUtilizationRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof GrafanaApi
+     */
+    public getGrafanaDeviceGpuUtilization(requestParameters: GrafanaApiGetGrafanaDeviceGpuUtilizationRequest, options?: RawAxiosRequestConfig) {
+        return GrafanaApiFp(this.configuration).getGrafanaDeviceGpuUtilization(requestParameters.dataCenter, requestParameters.hostname, options).then((request) => request(this.axios, this.basePath));
+    }
+
+    /**
+     * 
+     * @summary Get Grafana device GPU VRAM usage history dashboard link
+     * @param {GrafanaApiGetGrafanaDeviceGpuVramRequest} requestParameters Request parameters.
+     * @param {*} [options] Override http request option.
+     * @throws {RequiredError}
+     * @memberof GrafanaApi
+     */
+    public getGrafanaDeviceGpuVram(requestParameters: GrafanaApiGetGrafanaDeviceGpuVramRequest, options?: RawAxiosRequestConfig) {
+        return GrafanaApiFp(this.configuration).getGrafanaDeviceGpuVram(requestParameters.dataCenter, requestParameters.hostname, options).then((request) => request(this.axios, this.basePath));
+    }
+
     /**
      * 
      * @summary Get Grafana hosts dashboard

--- a/packages/cube-frontend-i18n/src/resources/web-app/en-US.json
+++ b/packages/cube-frontend-i18n/src/resources/web-app/en-US.json
@@ -335,6 +335,8 @@
   "nodes.details.fullViewModal.details": "Details",
   "nodes.details.fullViewModal.actionText": "Close",
   "nodes.details.editGpuType": "Edit GPU Type",
+  "nodes.details.viewWorkloadHistory": "View Workload History",
+  "nodes.details.viewVramHistory": "View VRAM History",
   "nodes.details.editGpuType.next": "Next",
   "nodes.details.editGpuType.confirm": "Confirm",
   "nodes.details.editGpuType.gpuType": "GPU Type",

--- a/packages/cube-frontend-i18n/src/resources/web-app/zh-TW.json
+++ b/packages/cube-frontend-i18n/src/resources/web-app/zh-TW.json
@@ -335,6 +335,8 @@
   "nodes.details.fullViewModal.details": "詳情",
   "nodes.details.fullViewModal.actionText": "關閉",
   "nodes.details.editGpuType": "編輯 GPU 類型",
+  "nodes.details.viewWorkloadHistory": "查看工作負載歷史",
+  "nodes.details.viewVramHistory": "查看 VRAM 使用歷史",
   "nodes.details.editGpuType.next": "下一步",
   "nodes.details.editGpuType.confirm": "確認",
   "nodes.details.editGpuType.gpuType": "GPU 類型",

--- a/packages/cube-frontend-web-app/src/mocks/gpu.ts
+++ b/packages/cube-frontend-web-app/src/mocks/gpu.ts
@@ -12,7 +12,7 @@ import {
   ListNodeGPUCardsResponseDataInner,
 } from '@cube-frontend/api/sdk/api'
 
-export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
+const mockGpuCards: Omit<ListNodeGPUCardsResponseDataInner, 'links'>[] = [
   // MIG-backed vGPU + InUse
   {
     id: 'gpu-001',
@@ -588,6 +588,24 @@ export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] = [
     attachedInstances: [],
   },
 ]
+
+/**
+ * The API builds these per card, filtered to the card's PCI address. Mirror that
+ * shape so a row opens a link that names one card, not the whole node.
+ */
+const historyLink = (pciAddress: string, panelId: number): string =>
+  `https://example.grafana/grafana/d/i-device/device?orgId=1&var-GPU_HOST=example-node-0&var-GPU_PCIID=${encodeURIComponent(
+    pciAddress,
+  )}&from=now-3h&to=now&viewPanel=${panelId}`
+
+export const mockGpuResource: ListNodeGPUCardsResponseDataInner[] =
+  mockGpuCards.map((card) => ({
+    ...card,
+    links: {
+      workloadHistory: historyLink(card.pciAddress, 50),
+      vramHistory: historyLink(card.pciAddress, 51),
+    },
+  }))
 
 export const mockListNodeGpuCards = http.get(
   '/api/v1/datacenters/:dataCenter/nodes/:nodeName/gpuCards',

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/EditGPUResourceModal/editGPUResourceUtils.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/EditGPUResourceModal/editGPUResourceUtils.ts
@@ -84,7 +84,7 @@ export const getProfileLimits = (
   resource: ListNodeGPUCardsResponseDataInner,
 ): ProfileLimits => ({
   count: resource.sriovVgpuProfileCountLimit ?? Number.POSITIVE_INFINITY,
-  vramMiB: resource.vram.totalMiB,
+  vramMiB: resource.vram?.totalMiB ?? 0,
 })
 
 export type ProfileFormSummary = {

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetails.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetails.tsx
@@ -41,9 +41,13 @@ const GpuDetails = (props: GpuDetailsProps) => {
   const renderAttachedInstanceMemoryUsage = (
     memory: ListNodeGPUCardsResponseDataInnerAttachedInstancesInner['memoryUsage'],
   ) => {
+    const { allocatedMiB, totalMiB } = memory
+
+    if (allocatedMiB === null || totalMiB === null) return null
+
     const { total, used, sizeUnit } = toReadableUsedSize({
-      used: memory.allocatedMiB,
-      total: memory.totalMiB,
+      used: allocatedMiB,
+      total: totalMiB,
       originalSizeUnit: 'MiB',
     })
     return `${used} ${sizeUnit} / ${total} ${sizeUnit}`
@@ -55,14 +59,16 @@ const GpuDetails = (props: GpuDetailsProps) => {
     return (
       <div className="flex w-full flex-row gap-x-4">
         <GpuConsoleLink nodeName={nodeName} instanceId={row.id} />
-        <CosHyperlink
-          size="sm"
-          variant="text-inline"
-          href={row.links.grafana}
-          target="_blank"
-        >
-          Grafana
-        </CosHyperlink>
+        {row.links.grafana && (
+          <CosHyperlink
+            size="sm"
+            variant="text-inline"
+            href={row.links.grafana}
+            target="_blank"
+          >
+            Grafana
+          </CosHyperlink>
+        )}
       </div>
     )
   }

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetailsFullViewModal/FullViewInstanceTable.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetailsFullViewModal/FullViewInstanceTable.tsx
@@ -50,9 +50,13 @@ export const FullViewInstanceTable = (props: FullViewInstanceTableProps) => {
   const renderMemoryUsage = (
     memory: ListNodeGPUCardsResponseDataInnerAttachedInstancesInner['memoryUsage'],
   ) => {
+    const { allocatedMiB, totalMiB } = memory
+
+    if (allocatedMiB === null || totalMiB === null) return null
+
     const { total, used, sizeUnit } = toReadableUsedSize({
-      used: memory.allocatedMiB,
-      total: memory.totalMiB,
+      used: allocatedMiB,
+      total: totalMiB,
       originalSizeUnit: 'MiB',
     })
     return `${used} ${sizeUnit} / ${total} ${sizeUnit}`
@@ -62,14 +66,16 @@ export const FullViewInstanceTable = (props: FullViewInstanceTableProps) => {
     return (
       <div className="flex w-full flex-row gap-x-4">
         <GpuConsoleLink nodeName={nodeName} instanceId={row.id} />
-        <CosHyperlink
-          size="sm"
-          variant="text-inline"
-          href={row.links.grafana}
-          target="_blank"
-        >
-          Grafana
-        </CosHyperlink>
+        {row.links.grafana && (
+          <CosHyperlink
+            size="sm"
+            variant="text-inline"
+            href={row.links.grafana}
+            target="_blank"
+          >
+            Grafana
+          </CosHyperlink>
+        )}
       </div>
     )
   }

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/NodeGpuResources.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/NodeGpuResources.tsx
@@ -29,6 +29,8 @@ import {
   GpuResourceRow,
   GpuTypeLabelKeyMap,
   isGpuTypeEditDisabled,
+  isGpuUtilizationHistorySupported,
+  isGpuVramHistorySupported,
 } from './utils'
 import { useTranslation } from 'react-i18next'
 import { ParseKeys } from 'i18next'
@@ -121,11 +123,14 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
   }
 
   const renderVRamAllocation = (row: GpuResourceRow) => {
-    if (!row.vram) return null
+    const { allocatedMiB, totalMiB } = row.vram ?? {}
+
+    if (allocatedMiB === null || totalMiB === null) return null
+    if (allocatedMiB === undefined || totalMiB === undefined) return null
 
     const { total, used, sizeUnit } = toReadableUsedSize({
-      used: row.vram.allocatedMiB,
-      total: row.vram.totalMiB,
+      used: allocatedMiB,
+      total: totalMiB,
       originalSizeUnit: 'MiB',
     })
 
@@ -133,15 +138,23 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
   }
 
   const renderVramUtilization = (row: GpuResourceRow) => {
-    if (!row.vram) return null
+    const utilizationPercent = row.vram?.utilizationPercent
 
-    return `${row.vram.utilizationPercent}%`
+    if (utilizationPercent === null || utilizationPercent === undefined) {
+      return null
+    }
+
+    return `${utilizationPercent}%`
   }
 
   const renderGpuUtilization = (row: GpuResourceRow) => {
-    if (!row.gpu) return null
+    const utilizationPercent = row.gpu?.utilizationPercent
 
-    return `${row.gpu.utilizationPercent}%`
+    if (utilizationPercent === null || utilizationPercent === undefined) {
+      return null
+    }
+
+    return `${utilizationPercent}%`
   }
 
   const renderStatus = (status: GPUCardStatus) => {
@@ -170,6 +183,16 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
     return `${allocationSummary.current} / ${allocationSummary.total}`
   }
 
+  /**
+   * Each card reports its own history links, already filtered to that card's
+   * PCI address, so the row opens `row.links` instead of building a URL.
+   */
+  const openHistory = (link: string) => {
+    if (!link) return
+
+    window.open(link, '_blank', 'noopener,noreferrer')
+  }
+
   const renderAction = (row: GpuResourceRow) => {
     return (
       <CosOverflowMenu
@@ -182,6 +205,30 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
           type="plain"
           onClick={() => openResourceEditModal(row)}
           disabled={isGpuTypeEditDisabled(row.status)}
+        />
+        <CosOverflowMenu.Item
+          title={t('nodes.details.viewWorkloadHistory')}
+          type="plain"
+          onClick={() => openHistory(row.links.workloadHistory)}
+          disabled={!isGpuUtilizationHistorySupported(row.resourceType)}
+        />
+        <CosOverflowMenu.Item
+          title={t('nodes.details.viewVramHistory')}
+          type="plain"
+          onClick={() => openHistory(row.links.vramHistory)}
+          disabled={!isGpuVramHistorySupported(row.resourceType)}
+        />
+        <CosOverflowMenu.Item
+          title={t('nodes.details.viewWorkloadHistory')}
+          type="plain"
+          onClick={() => openHistory(row.links.workloadHistory)}
+          disabled={!isGpuUtilizationHistorySupported(row.resourceType)}
+        />
+        <CosOverflowMenu.Item
+          title={t('nodes.details.viewVramHistory')}
+          type="plain"
+          onClick={() => openHistory(row.links.vramHistory)}
+          disabled={!isGpuVramHistorySupported(row.resourceType)}
         />
       </CosOverflowMenu>
     )

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/utils.test.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/utils.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from 'vitest'
 import { GPUCardStatus, GPUResourceType } from '@cube-frontend/api'
-import { isGpuTypeEditDisabled, isProfileRemainingSupported } from './utils'
+import {
+  isGpuTypeEditDisabled,
+  isGpuUtilizationHistorySupported,
+  isGpuVramHistorySupported,
+  isProfileRemainingSupported,
+} from './utils'
 
 describe('isProfileRemainingSupported', () => {
   test('returns true for MIG-backed vGPU, which limits instances per profile', () => {
@@ -57,5 +62,36 @@ describe('isGpuTypeEditDisabled', () => {
         isProcessing: false,
       }),
     ).toBe(false)
+  })
+})
+
+describe('isGpuUtilizationHistorySupported', () => {
+  test('returns true for the resource types the host still reads util_* from', () => {
+    expect(isGpuUtilizationHistorySupported(GPUResourceType.Unset)).toBe(true)
+    expect(isGpuUtilizationHistorySupported(GPUResourceType.SriovVgpu)).toBe(
+      true,
+    )
+  })
+
+  test('returns false for MIG-backed vGPU, which reports no device-level utilization', () => {
+    expect(
+      isGpuUtilizationHistorySupported(GPUResourceType.MigBackedVgpu),
+    ).toBe(false)
+  })
+
+  test('returns false for passthrough GPU, which the host cannot see', () => {
+    expect(isGpuUtilizationHistorySupported(GPUResourceType.Pgpu)).toBe(false)
+  })
+})
+
+describe('isGpuVramHistorySupported', () => {
+  test('returns true for every resource type the host still samples memory of', () => {
+    expect(isGpuVramHistorySupported(GPUResourceType.Unset)).toBe(true)
+    expect(isGpuVramHistorySupported(GPUResourceType.SriovVgpu)).toBe(true)
+    expect(isGpuVramHistorySupported(GPUResourceType.MigBackedVgpu)).toBe(true)
+  })
+
+  test('returns false for passthrough GPU, which the host cannot see', () => {
+    expect(isGpuVramHistorySupported(GPUResourceType.Pgpu)).toBe(false)
   })
 })

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/utils.ts
@@ -51,6 +51,26 @@ export const isGpuTypeEditDisabled = (
   status: ListNodeGPUCardsResponseDataInnerStatus,
 ): boolean => status.current === GPUCardStatus.InUse || status.isProcessing
 
+/**
+ * The Grafana GPU Utilization panel plots `util_gpu` from the `gpu.host`
+ * measurement. NVIDIA stops reporting device-level utilization once MIG is
+ * enabled, and a passthrough card is bound to vfio-pci and handed to a VM, so
+ * neither type ever draws a line.
+ */
+export const isGpuUtilizationHistorySupported = (
+  resourceType: GPUResourceType,
+): boolean =>
+  resourceType === GPUResourceType.Unset ||
+  resourceType === GPUResourceType.SriovVgpu
+
+/**
+ * The collector samples `mem_*` at device level, so VRAM survives MIG. Only a
+ * passthrough card is invisible to the host.
+ */
+export const isGpuVramHistorySupported = (
+  resourceType: GPUResourceType,
+): boolean => resourceType !== GPUResourceType.Pgpu
+
 export const GpuTypeLabelKeyMap: Record<GPUResourceType, ParseKeys> = {
   [GPUResourceType.Unset]: 'nodes.details.gpuList.resourceType.unset',
   [GPUResourceType.Pgpu]: 'nodes.details.gpuList.resourceType.pgpu',


### PR DESCRIPTION
#### What type of PR is this?

/kind feature

#### What this PR does / why we need it

An operator can now jump from a physical GPU card to that card's history in
Grafana. The row overflow menu in **Nodes > \<node\> > GPU Resources** carries two
new entries:

| Menu entry | Opens | Ticket |
| --- | --- | --- |
| View Workload History | GPU Utilization over time, for that card | #824 |
| View VRAM History | VRAM usage over time, for that card | #825 |

The links arrive **inline with the GPU card listing** — `links.workloadHistory`
and `links.vramHistory` on every card — so a row action costs no extra request,
and each URL already carries the card's PCI address (`var-GPU_PCIID`). The UI
opens `link` verbatim in a new tab; it never builds a URL, so panel ids stay
inside `cube-cos-api`.

An entry is disabled when the card's resource type has no series to draw:

| Resource type | Workload | VRAM | Why |
| --- | --- | --- | --- |
| unset, sriovVgpu | enabled | enabled | the host reads both |
| migBackedVgpu | disabled | enabled | NVIDIA reports no device-level utilization once MIG is on |
| pgpu | disabled | disabled | the card is bound to vfio-pci, so the host sees nothing |

The API returns a link for those cards too — correctly, since the API should not
decide UX. The UI still greys the entry out, because that chart can never fill,
and the same row already shows `-` for the matching live stat.

This is the last track of #824 and #825. Infra (panels + hidden `$GPU_HOST` /
`$GPU_PCIID`), the collector, and the backend are handled in their own repos.

##### Screenshots

All three shots come from one node with the MSW GPU mocks, which cover every
resource type.

**1. Unset row — both history entries enabled**

<img width="2880" height="1490" alt="1-unset-both-enabled" src="https://github.com/user-attachments/assets/81f15cee-7d75-4892-91df-b9caed78ec7e" />

**2. MIG-backed vGPU row, in use — Workload History greyed out, VRAM History still live**

<img width="2880" height="1490" alt="2-mig-backed-vgpu-workload-disabled" src="https://github.com/user-attachments/assets/5e78de7e-fa82-4005-bcf6-756d8f142acf" />

**3. Passthrough row, idle — both history entries greyed out, Edit GPU Type still live**

<img width="2880" height="1490" alt="3-passthrough-both-disabled" src="https://github.com/user-attachments/assets/41913905-e9ce-448b-8ac7-98e61d0969a5" />

#### Which issue(s) this PR fixes

Fixes #824

##### Related PRs

Every dependency is merged. The UI only reads what these produced.

| Repo | PR | What it gives this PR |
| --- | --- | --- |
| cube-cos-openapi | [#108](https://github.com/bigstack-oss/cube-cos-openapi/pull/108) | `links.workloadHistory` / `links.vramHistory` on each GPU card |
| cube-cos-openapi | [#107](https://github.com/bigstack-oss/cube-cos-openapi/pull/107) | the nullable GPU stats that come with the same submodule bump |
| cube-cos-openapi | [#109](https://github.com/bigstack-oss/cube-cos-openapi/pull/109) | a nullable Grafana link on an attached instance |
| cube-cos-api | [#636](https://github.com/bigstack-oss/cube-cos-api/pull/636) | builds both per-card links, filtered by `var-GPU_PCIID` |
| cube-cos-api | [#635](https://github.com/bigstack-oss/cube-cos-api/pull/635) | reports unmeasurable stats as `null` instead of `0` |
| cubecos | [#1019](https://github.com/bigstack-oss/cubecos/pull/1019) | panels `50` / `51` and the hidden `$GPU_HOST` in `device.json` |
| cubecos | [#1228](https://github.com/bigstack-oss/cubecos/pull/1228) | the collector fix that lets those panels hold data at all |

Follow-up in this repo: [#853](https://github.com/bigstack-oss/cube-cos-ui/pull/853) turns the blank cells this PR leaves behind into a dash plus a reason (#823).

#### Special notes for your reviewer

> Note

- **Both dependencies are merged.** The submodule tracks `cube-cos-openapi`
  develop (`c865681`), which carries bigstack-oss/cube-cos-openapi#108;
  bigstack-oss/cube-cos-api#636 implements the endpoint side. Nothing here waits
  on another repo.
- **develop also carries the #823 spec change**, which marks the unmeasurable GPU
  stats and an instance's Grafana link nullable. You cannot take the per-card
  links without it — that commit landed first. The last commit is the null-safety
  this forces: a value the host cannot measure renders as an empty cell (today's
  behaviour for a card with no `vram` object), and the instance Grafana link
  renders only when the API supplies one. **Telling the operator why a number is
  missing is still #823's story, not this PR's.**
- **The first two commits used device-scoped endpoints** (`.../grafana/devices/{hostname}/gpuUtilization`
  and `.../gpuVram`), which returned one link per node — so every row of a node
  opened the same chart. Later commits replace that with the per-card links. The
  device-scoped endpoints stay in the spec but have no consumer here.
- Both MSW mocks for the old endpoints are deleted; `src/mocks/gpu.ts` now builds
  each card's links from its PCI address and stays unregistered, matching the
  other GPU mocks.
- The two i18n keys live in the JSON resources only. Add the rows to the
  translation sheet, or the next `pnpm i18n:sync` drops them.

Verified with the MSW mocks on a node carrying 12 cards across all four resource
types: all 12 enabled entries open `var-GPU_PCIID=<that row's own PCI address>`
with `viewPanel=50` / `51` in a new tab (`noopener,noreferrer`), no two rows share
a URL, every disabled entry opens nothing, and the console stays clean. `pnpm
lint` passes and `pnpm test` reports 106 passing tests, 5 of them new.

#### Additional documentation

```docs

```
