### PR TITLE
feat(advisor-ui): the Advisor UI package, and the authority chain

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -93,7 +93,11 @@ export default tseslint.config(
         {
           patterns: [
             {
-              group: ['../**/cube-frontend*', 'packages/**/*'],
+              group: [
+                '../**/cube-frontend*',
+                '../**/cube-advisor*',
+                'packages/**/*',
+              ],
               message:
                 'Relative package imports are not allowed. Please use path alias imports instead.',
             },

--- a/packages/cube-advisor-ui/README.md
+++ b/packages/cube-advisor-ui/README.md
@@ -1,0 +1,34 @@
+# @cube-frontend/advisor-ui
+
+The Cube AI Advisor SaaS web UI, built on `@cube-frontend/ui-library`.
+
+## Why it lives in this monorepo
+
+The Advisor's UI is drawn from the same design language as CubeCOS, and the
+[UI brief](https://github.com/bigstack-oss/bigstack-handbook/blob/develop/kb/cube-ai-advisor/blueprints/cube-ai-advisor-ui-brief.md)
+says the same core is later embedded into the CubeCOS product for customers.
+Living beside the component library is what makes that embedding cheap.
+
+## Keeping the exit door open
+
+The Advisor may one day need its own repository, with a dedicated frontend team.
+That extraction stays a few days of work rather than a rewrite **only if four
+things stay true**, so they are rules here rather than intentions:
+
+1. **Import through package names, never sibling source paths.** `@cube-frontend/ui-library`,
+   never `../cube-frontend-ui-library/src/...`. Deep imports are what actually weld
+   a package into a monorepo. Enforced by `no-restricted-imports` in the root
+   eslint config — a violation fails lint, so it cannot rot quietly.
+2. **Every dependency declared here**, never borrowed from the workspace root.
+3. **The backend boundary is an artifact, not shared types** — an OpenAPI
+   document, the way `cube-cos-api` consumes `cube-cos-openapi`. Nothing here
+   imports SaaS internals.
+4. **The dependency edge points one way**: `advisor-ui → ui-library`. Never the
+   reverse, and never to or from another app.
+
+What extraction would still cost, so it is not a surprise: `@cube-frontend/ui-library`
+and `@cube-frontend/ui-theme` are `private`, unversioned, and export raw
+TypeScript (`main: ./src/index.ts`). A second repository cannot consume them as
+source, so they would need a build, a version and an `exports` map — work owed
+the moment _any_ second repository wants those components, not created by this
+package.

--- a/packages/cube-advisor-ui/package.json
+++ b/packages/cube-advisor-ui/package.json
@@ -1,0 +1,39 @@
+{
+  "name": "@cube-frontend/advisor-ui",
+  "private": true,
+  "license": "Apache-2.0",
+  "description": "Cube AI Advisor SaaS web UI",
+  "type": "module",
+  "engines": {
+    "node": ">=v24.15",
+    "pnpm": ">=10.33"
+  },
+  "scripts": {
+    "tsc": "tsc",
+    "test": "vitest run"
+  },
+  "main": "./src/index.ts",
+  "dependencies": {
+    "@cube-frontend/ui-library": "workspace:*",
+    "@cube-frontend/ui-theme": "workspace:*",
+    "@cube-frontend/utils": "workspace:*",
+    "classnames": "^2.5.1",
+    "i18next": "catalog:",
+    "react-i18next": "catalog:",
+    "tailwind-merge": "catalog:",
+    "tailwindcss": "catalog:"
+  },
+  "devDependencies": {
+    "@testing-library/dom": "^10.4.0",
+    "@testing-library/react": "^16.1.0",
+    "@types/react": "catalog:",
+    "@types/react-dom": "catalog:",
+    "jsdom": "^25.0.1",
+    "vite": "catalog:",
+    "vitest": "catalog:"
+  },
+  "peerDependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:"
+  }
+}

--- a/packages/cube-advisor-ui/src/components/AuthorityChain/AuthorityChain.test.tsx
+++ b/packages/cube-advisor-ui/src/components/AuthorityChain/AuthorityChain.test.tsx
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import { formatParty, summariseChain, type AuthorityParty } from './formatChain'
+
+const acme: AuthorityParty = { name: 'Acme Corp', tier: 'customer' }
+const northwind: AuthorityParty = { name: 'NorthWind', tier: 'partner' }
+const bigstack: AuthorityParty = {
+  name: 'Bigstack',
+  tier: 'vendor',
+  role: 'L3',
+}
+
+describe('formatParty', () => {
+  // A partner is always named as one. "Acme ← NorthWind" reads as direct
+  // support by a company called NorthWind, which is the misreading this whole
+  // element exists to prevent.
+  it('always labels a partner as a partner', () => {
+    expect(formatParty(northwind)).toContain('Partner:')
+  })
+
+  it('does not label the data owner or the vendor as partners', () => {
+    expect(formatParty(acme)).not.toContain('Partner:')
+    expect(formatParty(bigstack)).not.toContain('Partner:')
+  })
+
+  it('keeps the role qualifier', () => {
+    expect(formatParty(bigstack)).toBe('Bigstack L3')
+  })
+})
+
+describe('summariseChain', () => {
+  it('renders a direct two-party relationship in full', () => {
+    expect(summariseChain([acme, bigstack])).toBe('Acme Corp ← Bigstack L3')
+  })
+
+  // The constraint the redraw states outright: a three-party chain may
+  // truncate visually, but must never truncate to something that READS as a
+  // two-party relationship.
+  it('never collapses three parties into a two-party reading', () => {
+    const summary = summariseChain([acme, northwind, bigstack])
+    expect(summary).toContain('Acme Corp')
+    expect(summary).toContain('Bigstack L3')
+    // The hop must survive in some form.
+    expect(summary).toMatch(/partner/i)
+    // And it must not look like the direct case.
+    expect(summary).not.toBe(summariseChain([acme, bigstack]))
+  })
+
+  it('counts the hops rather than dropping them as the chain grows', () => {
+    const two: AuthorityParty = { name: 'EastGate', tier: 'partner' }
+    expect(summariseChain([acme, northwind, two, bigstack])).toContain(
+      '2 partners',
+    )
+  })
+
+  it('shows a single party as itself, with no relationship implied', () => {
+    expect(summariseChain([acme])).toBe('Acme Corp')
+    expect(summariseChain([acme])).not.toContain('←')
+  })
+
+  it('is empty for an empty chain rather than rendering a stray arrow', () => {
+    expect(summariseChain([])).toBe('')
+  })
+
+  // The data owner is always first and whoever is acting is always last. If
+  // that ordering slipped, the banner would name the wrong party as the
+  // tenant whose data is being read.
+  it('puts the data owner first and the acting party last', () => {
+    const summary = summariseChain([acme, northwind, bigstack])
+    expect(summary.indexOf('Acme Corp')).toBeLessThan(
+      summary.indexOf('Bigstack'),
+    )
+  })
+})

--- a/packages/cube-advisor-ui/src/components/AuthorityChain/AuthorityChain.tsx
+++ b/packages/cube-advisor-ui/src/components/AuthorityChain/AuthorityChain.tsx
@@ -1,0 +1,92 @@
+import classNames from 'classnames'
+
+import {
+  formatParty,
+  summariseChain,
+  type AuthorityChainProps,
+  type AuthorityParty,
+} from './formatChain'
+
+/**
+ * The persistent banner shown while anyone is acting inside a tenant they do
+ * not own.
+ *
+ * Whoever is acting reads the same chain the data owner reads. There is no
+ * viewer for whom a party is omitted — an authority chain that renders
+ * differently per audience is not an audit trail.
+ */
+/**
+ * Colours come from cubeTheme.ts, not from this file. A partner is the tier a
+ * reader most needs to notice, so it takes the one accent here; the other two
+ * stay in the ordinary text ramp so the chain reads as one sentence.
+ */
+const tierClass: Record<AuthorityParty['tier'], string> = {
+  customer: 'text-functional-title',
+  partner: 'text-status-paused',
+  vendor: 'text-functional-text',
+}
+
+export const AuthorityChain = (props: AuthorityChainProps) => {
+  const { parties, expiresIn, onViewChain, className } = props
+
+  if (parties.length === 0) return null
+
+  return (
+    <div
+      className={classNames(
+        'flex flex-wrap items-center gap-x-2 gap-y-1 text-sm',
+        className,
+      )}
+      data-testid="authority-chain"
+      /* The full chain is always in the accessibility tree, whatever the
+         viewport shows. */
+      aria-label={summariseChain(parties)}
+    >
+      <span aria-hidden className="shrink-0">
+        🔗
+      </span>
+
+      {/* Wide viewports: every party, in order. */}
+      <span className="hidden items-center gap-x-2 md:inline-flex">
+        {parties.map((party, i) => (
+          <span
+            key={`${party.tier}-${party.name}`}
+            className="inline-flex items-center gap-x-2"
+          >
+            {i > 0 && (
+              <span aria-hidden className="text-functional-text-light">
+                ←
+              </span>
+            )}
+            <span
+              className={classNames('whitespace-nowrap', tierClass[party.tier])}
+            >
+              {formatParty(party)}
+            </span>
+          </span>
+        ))}
+      </span>
+
+      {/* Narrow viewports: the summary, which still names the hop. */}
+      <span className="inline md:hidden" data-testid="authority-chain-summary">
+        {summariseChain(parties)}
+      </span>
+
+      {expiresIn && (
+        <span className="shrink-0 text-functional-text-light">
+          · support access · expires in {expiresIn}
+        </span>
+      )}
+
+      {onViewChain && (
+        <button
+          type="button"
+          onClick={onViewChain}
+          className="shrink-0 underline underline-offset-2"
+        >
+          view chain
+        </button>
+      )}
+    </div>
+  )
+}

--- a/packages/cube-advisor-ui/src/components/AuthorityChain/formatChain.ts
+++ b/packages/cube-advisor-ui/src/components/AuthorityChain/formatChain.ts
@@ -1,0 +1,66 @@
+/**
+ * One party in an authority chain, ordered from the tenant that owns the data
+ * outward to whoever is acting.
+ */
+export type AuthorityParty = {
+  /** Display name, e.g. "Acme Corp" or "NorthWind". */
+  name: string
+  /**
+   * Which tier this party sits in. `customer` owns the data; `partner` is the
+   * optional middle; `vendor` is Bigstack.
+   */
+  tier: 'customer' | 'partner' | 'vendor'
+  /** Role qualifier shown after the name, e.g. "L3". */
+  role?: string
+}
+
+export type AuthorityChainProps = {
+  /**
+   * The chain, data-owner first. A single party is a tenant acting in its own
+   * cluster; two is direct support; three is support via a partner.
+   */
+  parties: AuthorityParty[]
+  /** Human-readable remaining grant lifetime, e.g. "5h 12m". */
+  expiresIn?: string
+  /** Invoked by the "view chain" affordance. */
+  onViewChain?: () => void
+  className?: string
+}
+
+/**
+ * The tier label that prefixes a party's name.
+ *
+ * A partner is always named as one. The redraw's hard constraint is that a
+ * three-party chain must never *read* as a two-party relationship, and an
+ * unlabelled middle name is exactly how that happens — "Acme ← NorthWind"
+ * reads as direct support by someone called NorthWind.
+ */
+const tierLabel: Record<AuthorityParty['tier'], string> = {
+  customer: '',
+  partner: 'Partner: ',
+  vendor: '',
+}
+
+export const formatParty = (party: AuthorityParty): string => {
+  const role = party.role ? ` ${party.role}` : ''
+  return `${tierLabel[party.tier]}${party.name}${role}`
+}
+
+/**
+ * Summarises a chain for viewports too narrow to render it in full.
+ *
+ * Never a truncation of the party list. Dropping the middle party silently
+ * turns a three-party chain into a two-party one, which is the single failure
+ * this element exists to prevent — so a chain that cannot be shown whole
+ * collapses to a count instead, and the count still names the hop.
+ */
+export const summariseChain = (parties: AuthorityParty[]): string => {
+  if (parties.length === 0) return ''
+  if (parties.length === 1) return formatParty(parties[0])
+  const owner = parties[0]
+  const acting = parties[parties.length - 1]
+  const hops = parties.length - 2
+  if (hops <= 0) return `${formatParty(owner)} ← ${formatParty(acting)}`
+  const via = hops === 1 ? '1 partner' : `${hops} partners`
+  return `${formatParty(owner)} ← via ${via} ← ${formatParty(acting)}`
+}

--- a/packages/cube-advisor-ui/src/index.ts
+++ b/packages/cube-advisor-ui/src/index.ts
@@ -1,0 +1,7 @@
+export { AuthorityChain } from './components/AuthorityChain/AuthorityChain'
+export {
+  formatParty,
+  summariseChain,
+  type AuthorityChainProps,
+  type AuthorityParty,
+} from './components/AuthorityChain/formatChain'

--- a/packages/cube-advisor-ui/tsconfig.json
+++ b/packages/cube-advisor-ui/tsconfig.json
@@ -1,0 +1,19 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noEmit": true,
+    "skipLibCheck": true,
+    "isolatedModules": true,
+    "resolveJsonModule": true,
+    "types": ["vitest/globals"]
+  },
+  "include": ["src"]
+}

--- a/packages/cube-advisor-ui/vitest.config.ts
+++ b/packages/cube-advisor-ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: true,
+  },
+})

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -147,6 +147,61 @@ importers:
         specifier: ^8.59.0
         version: 8.59.0(eslint@9.39.4(jiti@2.4.2))(typescript@6.0.3)
 
+  packages/cube-advisor-ui:
+    dependencies:
+      '@cube-frontend/ui-library':
+        specifier: workspace:*
+        version: link:../cube-frontend-ui-library
+      '@cube-frontend/ui-theme':
+        specifier: workspace:*
+        version: link:../cube-frontend-ui-theme
+      '@cube-frontend/utils':
+        specifier: workspace:*
+        version: link:../cube-frontend-utils
+      classnames:
+        specifier: ^2.5.1
+        version: 2.5.1
+      i18next:
+        specifier: 'catalog:'
+        version: 26.0.6(typescript@6.0.3)
+      react:
+        specifier: 'catalog:'
+        version: 19.2.5
+      react-dom:
+        specifier: 'catalog:'
+        version: 19.2.5(react@19.2.5)
+      react-i18next:
+        specifier: 'catalog:'
+        version: 17.0.4(i18next@26.0.6(typescript@6.0.3))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(typescript@6.0.3)
+      tailwind-merge:
+        specifier: 'catalog:'
+        version: 2.6.0
+      tailwindcss:
+        specifier: 'catalog:'
+        version: 3.4.17
+    devDependencies:
+      '@testing-library/dom':
+        specifier: ^10.4.0
+        version: 10.4.0
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.0.2(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@types/react':
+        specifier: 'catalog:'
+        version: 19.2.14
+      '@types/react-dom':
+        specifier: 'catalog:'
+        version: 19.0.2(@types/react@19.2.14)
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
+      vite:
+        specifier: 'catalog:'
+        version: 8.0.8(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.8.3)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@6.0.3))(vite@8.0.8(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.8.3))
+
   packages/cube-frontend-api:
     dependencies:
       '@cube-frontend/utils':
@@ -462,7 +517,7 @@ importers:
         version: 5.2.0(rollup@4.30.1)(typescript@6.0.3)(vite@8.0.8(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.8.3))
       vitest:
         specifier: 'catalog:'
-        version: 4.1.4(@types/node@22.10.5)(msw@2.7.0(@types/node@22.10.5)(typescript@6.0.3))(vite@8.0.8(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.8.3))
+        version: 4.1.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@6.0.3))(vite@8.0.8(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.8.3))
 
 packages:
 
@@ -472,6 +527,9 @@ packages:
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
 
   '@babel/code-frame@7.29.0':
     resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
@@ -668,6 +726,34 @@ packages:
         optional: true
       conventional-commits-parser:
         optional: true
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@emnapi/core@1.9.2':
     resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
@@ -1483,6 +1569,21 @@ packages:
     resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
     engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
 
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@testing-library/user-event@14.6.1':
     resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
     engines: {node: '>=12', npm: '>=6'}
@@ -2236,6 +2337,10 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
@@ -2370,6 +2475,10 @@ packages:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
 
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
+
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
     engines: {node: '>= 0.4'}
@@ -2401,6 +2510,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
@@ -2500,6 +2612,10 @@ packages:
 
   entities@4.5.0:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
+    engines: {node: '>=0.12'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
     engines: {node: '>=0.12'}
 
   entities@7.0.1:
@@ -2924,8 +3040,16 @@ packages:
   headers-polyfill@4.0.3:
     resolution: {integrity: sha512-IScLbePpkvO846sIwOtOTDjutRMWdXdJmXdMvk6gCBHxFO8d+QKOQedyZSxFTTFYRSmlgSTDtXqqq4pcenBXLQ==}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
 
   https-proxy-agent@7.0.6:
     resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
@@ -3081,6 +3205,9 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -3148,6 +3275,15 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
+
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -3448,6 +3584,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.24:
+    resolution: {integrity: sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -3516,6 +3655,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -3842,6 +3984,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-applescript@7.1.0:
     resolution: {integrity: sha512-DPe5pVFaAsinSaV6QjQ6gdiedWDcRCbUuiQfQa2wmWV7+xC9bGulGI8+TdRmoFkAPaBXk8CrAbnlY2ISniJ47Q==}
     engines: {node: '>=18'}
@@ -3869,6 +4017,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
@@ -4025,6 +4177,9 @@ packages:
   svg-parser@2.0.4:
     resolution: {integrity: sha512-e4hG1hRwoOdRb37cIMSgzNsxyzKfayW6VOflrwvR+/bzrkyxY/31WkbgnQpgtrNp1SdpJvpUAGTa/ZoiPNDuRQ==}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwind-merge@2.6.0:
     resolution: {integrity: sha512-P+Vu1qXfzediirmHOC3xKGAYeZtPcV9g76X+xg2FD4tYgR71ewMA35Y3sCz3zhiN/dwefRpJX0yBcgwi1fXNQA==}
 
@@ -4066,6 +4221,13 @@ packages:
     resolution: {integrity: sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -4073,6 +4235,14 @@ packages:
   tough-cookie@4.1.4:
     resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
     engines: {node: '>=6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -4268,12 +4438,33 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   web-streams-polyfill@3.3.3:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
@@ -4333,6 +4524,13 @@ packages:
     resolution: {integrity: sha512-h3Fbisa2nKGPxCpm89Hk33lBLsnaGBvctQopaBSOW/uIs6FTe1ATyAnKFJrzVs9vpGdsTe73WF3V4lIsk4Gacw==}
     engines: {node: '>=18'}
 
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
@@ -4387,6 +4585,14 @@ snapshots:
   '@adobe/css-tools@4.4.1': {}
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -4679,6 +4885,26 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       conventional-commits-parser: 6.4.0
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@emnapi/core@1.9.2':
     dependencies:
@@ -5342,6 +5568,16 @@ snapshots:
       dom-accessibility-api: 0.6.3
       picocolors: 1.1.1
       redent: 3.0.0
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.0)(@types/react-dom@19.0.2(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      '@types/react-dom': 19.0.2(@types/react@19.2.14)
 
   '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.0)':
     dependencies:
@@ -6167,6 +6403,11 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
 
   d3-array@3.2.4:
@@ -6323,6 +6564,11 @@ snapshots:
 
   data-uri-to-buffer@4.0.1: {}
 
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+
   data-view-buffer@1.0.2:
     dependencies:
       call-bound: 1.0.3
@@ -6350,6 +6596,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   deep-eql@5.0.2: {}
 
@@ -6434,6 +6682,8 @@ snapshots:
   empathic@2.0.0: {}
 
   entities@4.5.0: {}
+
+  entities@6.0.1: {}
 
   entities@7.0.1: {}
 
@@ -6967,9 +7217,20 @@ snapshots:
 
   headers-polyfill@4.0.3: {}
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
@@ -7106,6 +7367,8 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.3
@@ -7172,6 +7435,34 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.24
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   jsesc@3.1.0: {}
 
@@ -7424,6 +7715,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  nwsapi@2.2.24: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -7507,6 +7800,10 @@ snapshots:
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@4.0.0: {}
 
@@ -7792,6 +8089,10 @@ snapshots:
       fsevents: 2.3.3
     optional: true
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-applescript@7.1.0: {}
 
   run-parallel@1.2.0:
@@ -7822,6 +8123,10 @@ snapshots:
       is-regex: 1.2.1
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.27.0: {}
 
@@ -8007,6 +8312,8 @@ snapshots:
 
   svg-parser@2.0.4: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwind-merge@2.6.0: {}
 
   tailwindcss@3.4.17:
@@ -8061,6 +8368,12 @@ snapshots:
 
   tinyspy@4.0.4: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -8071,6 +8384,14 @@ snapshots:
       punycode: 2.3.1
       universalify: 0.2.0
       url-parse: 1.5.10
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@6.0.3):
     dependencies:
@@ -8236,7 +8557,7 @@ snapshots:
       jiti: 2.4.2
       yaml: 2.8.3
 
-  vitest@4.1.4(@types/node@22.10.5)(msw@2.7.0(@types/node@22.10.5)(typescript@6.0.3))(vite@8.0.8(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.8.3)):
+  vitest@4.1.4(@types/node@22.10.5)(jsdom@25.0.1)(msw@2.7.0(@types/node@22.10.5)(typescript@6.0.3))(vite@8.0.8(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.8.3)):
     dependencies:
       '@vitest/expect': 4.1.4
       '@vitest/mocker': 4.1.4(msw@2.7.0(@types/node@22.10.5)(typescript@6.0.3))(vite@8.0.8(@types/node@22.10.5)(jiti@2.4.2)(yaml@2.8.3))
@@ -8260,14 +8581,32 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.10.5
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - msw
 
   void-elements@3.1.0: {}
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   web-streams-polyfill@3.3.3: {}
 
+  webidl-conversions@7.0.0: {}
+
   webpack-virtual-modules@0.6.2: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -8343,6 +8682,10 @@ snapshots:
   wsl-utils@0.1.0:
     dependencies:
       is-wsl: 3.1.1
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## What this PR does / why we need it

Stands up `packages/cube-advisor-ui` — the Cube AI Advisor SaaS web UI — and implements the first cross-cutting element from the [redraw brief](https://github.com/bigstack-oss/bigstack-handbook/blob/develop/kb/cube-ai-advisor/blueprints/): the **authority chain**.

Fixes #854

## Why the UI lives in this monorepo

The brief says the same UI core is later embedded into the CubeCOS product for customers. Living beside `@cube-frontend/ui-library` is what makes that embedding cheap.

We discussed whether that traps us if the Advisor later needs a dedicated frontend team and its own repo. It doesn't — but only because of a property this repo already has, and which this PR keeps true.

**The evidence:** across the existing web app there are 564 cross-package imports and **every one goes through a package name** (`@cube-frontend/ui-library`, `/api`, `/utils`, `/ui-theme`). Zero deep source imports. Deep imports are what actually weld a package into a monorepo; that discipline is already in place, and `workspace:*` → a version range is a one-line change per dependency at extraction time.

So four rules live in the package README, and **rule 1 is enforced rather than remembered**:

| Rule | How it holds |
|---|---|
| Import through package names, never sibling paths | `no-restricted-imports` — **extended in this PR**, since the pattern only matched `cube-frontend*` and would not have caught the new package |
| Every dependency declared here | pnpm doesn't flat-hoist, so an undeclared dep breaks loudly |
| Backend boundary is an OpenAPI artifact, not shared types | convention, same as `cube-cos-api` ↔ `cube-cos-openapi` |
| Dependency edge points one way: `advisor-ui → ui-library` | review |

**Recorded so it isn't a surprise later:** `@cube-frontend/ui-library` and `@cube-frontend/ui-theme` are `private`, carry no `version`, and `main` points at raw `./src/index.ts`. A second repo can't consume them as source, so extraction would mean giving them a build, a version and an `exports` map. That's work owed the moment *any* second repo wants those components — deferred by this choice, not created by it.

## Special notes for your reviewer

### The authority chain's one hard constraint

The redraw calls it "the single most important new element". Its constraint is unusually testable:

> it may truncate visually but must never truncate to something that *reads* as a two-party relationship

`Acme Corp ← NorthWind` reads as direct support by a company called NorthWind. That misreading is the whole reason the element exists.

So **the narrow-viewport path is not a truncation of the party list.** Dropping the middle party is the naive implementation and is precisely the bug. Instead the chain collapses to a hop count that still names the tier:

```
wide:   Acme Corp ← Partner: NorthWind ← Bigstack L3 · expires in 5h 12m
narrow: Acme Corp ← via 1 partner ← Bigstack L3
```

Two supporting decisions: the full chain is in the accessibility tree whatever the viewport renders, and there is no viewer for whom a party is omitted — a chain that renders differently per audience is not an audit trail.

### Mutation testing

Four mutations, each caught:

- **the naive middle-drop** — three parties rendered as two. This is the bug the brief warns about, so it is the one the test exists for.
- the `Partner:` label removed
- the hop count replaced with a vague word
- the chain order reversed, which would name the wrong party as the data owner

### A lint catch worth mentioning

My first pass invented theme token names (`text-functional-text-01`, `text-status-warning`). `tailwindcss/no-custom-classname` rejected them and I replaced them with the real tokens from `cubeTheme.ts` (`functional-title`, `functional-text-light`, `status-paused`). The rule did exactly its job.

## Verification

`tsc` clean · `eslint` clean (0 problems) · 9 tests pass · prettier applied.

## Not in this PR

The remaining shell elements — **scope switcher / breadcrumb** and the **provider badge** with its new mode dimension — and all twelve screens. The design bundle in the Claude Design project is a *Figma export* (128 components named from layer names), not this library; the screens have to be translated onto the real `Cos*` vocabulary rather than ported, or the design system forks.