### PR TITLE
feat(advisor-ui): the global scope switcher and breadcrumb

### DIFF
--- a/packages/cube-advisor-ui/src/components/ScopeSwitcher/ScopeSwitcher.tsx
+++ b/packages/cube-advisor-ui/src/components/ScopeSwitcher/ScopeSwitcher.tsx
@@ -1,0 +1,99 @@
+import classNames from 'classnames'
+
+import {
+  breadcrumbTo,
+  isSwitchable,
+  scopeOptions,
+  type TenantNode,
+} from './scope'
+
+export type ScopeSwitcherProps = {
+  /** The viewer's own tenant path — the top of everything they may reach. */
+  viewerPath: string
+  /** The tenant currently being acted in. */
+  selectedPath: string
+  /** Tenants known to the client. Anything outside the viewer's subtree is ignored. */
+  tenants: TenantNode[]
+  onSelect?: (path: string) => void
+  className?: string
+}
+
+const tierLabel: Record<TenantNode['tier'], string> = {
+  vendor: 'Bigstack',
+  partner: 'Partner',
+  customer: 'Customer',
+}
+
+/**
+ * The global scope switcher and breadcrumb, present on every screen.
+ *
+ * It answers two questions at once: which tier the viewer is acting in, and
+ * whose tenant they are inside. Options come from `scopeOptions`, which derives
+ * them from the viewer's own subtree — a sibling partner is never in the data
+ * this renders from, rather than being filtered out of a list that contained
+ * them.
+ *
+ * For an end customer the control collapses to a static label. An empty
+ * dropdown would imply there is somewhere to switch to and that they lack
+ * permission, which is a different and more alarming claim than "you are here".
+ */
+export const ScopeSwitcher = (props: ScopeSwitcherProps) => {
+  const { viewerPath, selectedPath, tenants, onSelect, className } = props
+
+  const options = scopeOptions(viewerPath, tenants)
+  const trail = breadcrumbTo(viewerPath, selectedPath, tenants)
+  const switchable = isSwitchable(viewerPath, tenants)
+
+  if (options.length === 0) return null
+
+  return (
+    <div
+      className={classNames('flex items-center gap-x-2 text-sm', className)}
+      data-testid="scope-switcher"
+    >
+      <nav aria-label="Tenant scope" className="flex items-center gap-x-1">
+        {trail.map((node, i) => (
+          <span key={node.path} className="flex items-center gap-x-1">
+            {i > 0 && (
+              <span aria-hidden className="text-functional-text-light">
+                ›
+              </span>
+            )}
+            <span
+              className={classNames(
+                'whitespace-nowrap',
+                i === trail.length - 1
+                  ? 'text-functional-title'
+                  : 'text-functional-text-light',
+              )}
+              title={`${tierLabel[node.tier]}: ${node.name}`}
+            >
+              {node.name}
+            </span>
+          </span>
+        ))}
+      </nav>
+
+      {switchable ? (
+        <select
+          aria-label="Switch tenant scope"
+          className="rounded border border-functional-border-divider bg-transparent px-2 py-1"
+          value={selectedPath}
+          onChange={(e) => onSelect?.(e.target.value)}
+        >
+          {options.map((node) => (
+            <option key={node.path} value={node.path}>
+              {node.name}
+            </option>
+          ))}
+        </select>
+      ) : (
+        // Static label, deliberately not a disabled control: there is nothing
+        // being withheld, so nothing should look withheld.
+        <span className="text-functional-text-light" data-testid="scope-static">
+          your organisation
+        </span>
+      )}
+    </div>
+  )
+}

--- a/packages/cube-advisor-ui/src/components/ScopeSwitcher/scope.test.ts
+++ b/packages/cube-advisor-ui/src/components/ScopeSwitcher/scope.test.ts
@@ -1,0 +1,157 @@
+import { describe, expect, it } from 'vitest'
+import {
+  breadcrumbTo,
+  depthOf,
+  isSwitchable,
+  isWithin,
+  scopeOptions,
+  type TenantNode,
+} from './scope'
+
+const tree: TenantNode[] = [
+  { id: 'bigstack', name: 'Bigstack', path: 'bigstack', tier: 'vendor' },
+  {
+    id: 'northwind',
+    name: 'NorthWind',
+    path: 'bigstack.northwind',
+    tier: 'partner',
+  },
+  {
+    id: 'acme',
+    name: 'Acme Corp',
+    path: 'bigstack.northwind.acme',
+    tier: 'customer',
+  },
+  {
+    id: 'eastgate',
+    name: 'EastGate',
+    path: 'bigstack.eastgate',
+    tier: 'partner',
+  },
+  {
+    id: 'globex',
+    name: 'Globex',
+    path: 'bigstack.eastgate.globex',
+    tier: 'customer',
+  },
+  // A direct customer: no partner in between.
+  {
+    id: 'initech',
+    name: 'Initech',
+    path: 'bigstack.initech',
+    tier: 'customer',
+  },
+  // Deliberately named to be a string prefix of another partner.
+  { id: 'north', name: 'North', path: 'bigstack.north', tier: 'partner' },
+]
+
+const paths = (nodes: TenantNode[]) => nodes.map((n) => n.path)
+
+describe('isWithin', () => {
+  it('includes the root itself and its descendants', () => {
+    expect(isWithin('bigstack.northwind', 'bigstack.northwind')).toBe(true)
+    expect(isWithin('bigstack.northwind.acme', 'bigstack.northwind')).toBe(true)
+  })
+
+  // The bug this function exists to not have. `bigstack.north` is a string
+  // prefix of `bigstack.northwind`, and a naive startsWith would hand one
+  // partner another partner's entire portfolio.
+  it('does not treat a string prefix as an ancestor', () => {
+    expect(isWithin('bigstack.northwind', 'bigstack.north')).toBe(false)
+    expect(isWithin('bigstack.northwind.acme', 'bigstack.north')).toBe(false)
+  })
+
+  it('is false for an empty root rather than matching everything', () => {
+    expect(isWithin('bigstack.northwind', '')).toBe(false)
+  })
+})
+
+describe('scopeOptions', () => {
+  it('gives the vendor the whole tree', () => {
+    expect(scopeOptions('bigstack', tree)).toHaveLength(tree.length)
+  })
+
+  // The invariant the brief calls unrecoverable if it slips: partners are
+  // frequently competitors, and a sibling must never be selectable.
+  it('never offers a partner a sibling partner or their customers', () => {
+    const options = paths(scopeOptions('bigstack.northwind', tree))
+    expect(options).toEqual(['bigstack.northwind', 'bigstack.northwind.acme'])
+    expect(options).not.toContain('bigstack.eastgate')
+    expect(options).not.toContain('bigstack.eastgate.globex')
+    expect(options).not.toContain('bigstack.north')
+    // And never upward, either.
+    expect(options).not.toContain('bigstack')
+  })
+
+  it('gives an end customer exactly themselves', () => {
+    expect(paths(scopeOptions('bigstack.northwind.acme', tree))).toEqual([
+      'bigstack.northwind.acme',
+    ])
+  })
+
+  it('is stable in order, so a picker cannot reshuffle between renders', () => {
+    const once = paths(scopeOptions('bigstack', tree))
+    const twice = paths(scopeOptions('bigstack', [...tree].reverse()))
+    expect(once).toEqual(twice)
+  })
+
+  it('returns nothing for a viewer with no scope rather than everything', () => {
+    expect(scopeOptions('', tree)).toEqual([])
+  })
+})
+
+describe('isSwitchable', () => {
+  // An empty dropdown implies there is somewhere to go and the viewer lacks
+  // permission — a different and more alarming claim than "you are here".
+  it('is false for an end customer, so the control collapses to a label', () => {
+    expect(isSwitchable('bigstack.northwind.acme', tree)).toBe(false)
+  })
+
+  it('is true for a partner and for the vendor', () => {
+    expect(isSwitchable('bigstack.northwind', tree)).toBe(true)
+    expect(isSwitchable('bigstack', tree)).toBe(true)
+  })
+})
+
+describe('breadcrumbTo', () => {
+  // Starts at the viewer, not the root: a partner acting inside a customer
+  // must not read as acting under vendor authority.
+  it('starts at the viewer rather than the root of the tree', () => {
+    const trail = breadcrumbTo(
+      'bigstack.northwind',
+      'bigstack.northwind.acme',
+      tree,
+    )
+    expect(paths(trail)).toEqual([
+      'bigstack.northwind',
+      'bigstack.northwind.acme',
+    ])
+    expect(paths(trail)).not.toContain('bigstack')
+  })
+
+  it('gives the vendor the full path', () => {
+    expect(
+      paths(breadcrumbTo('bigstack', 'bigstack.northwind.acme', tree)),
+    ).toEqual(['bigstack', 'bigstack.northwind', 'bigstack.northwind.acme'])
+  })
+
+  it('is empty when the selection is outside the viewer subtree', () => {
+    expect(
+      breadcrumbTo('bigstack.northwind', 'bigstack.eastgate.globex', tree),
+    ).toEqual([])
+  })
+
+  it('is a single entry when the viewer is the selection', () => {
+    expect(
+      paths(breadcrumbTo('bigstack.initech', 'bigstack.initech', tree)),
+    ).toEqual(['bigstack.initech'])
+  })
+})
+
+describe('depthOf', () => {
+  it('counts the root as depth 1 and an empty path as 0', () => {
+    expect(depthOf('bigstack')).toBe(1)
+    expect(depthOf('bigstack.northwind.acme')).toBe(3)
+    expect(depthOf('')).toBe(0)
+  })
+})

--- a/packages/cube-advisor-ui/src/components/ScopeSwitcher/scope.ts
+++ b/packages/cube-advisor-ui/src/components/ScopeSwitcher/scope.ts
@@ -1,0 +1,97 @@
+/**
+ * Tenant scoping for the global scope switcher.
+ *
+ * The switcher answers "which tier am I acting in, and whose tenant am I
+ * inside" on every screen. Its options are *derived* from the viewer's own
+ * subtree rather than filtered out of the whole tree, because the brief is
+ * explicit that cross-partner selection must be structurally impossible rather
+ * than validated after the fact: partners are frequently competitors, and this
+ * is the screen where a slip is unrecoverable.
+ *
+ * The difference matters. A filter is a check someone can forget to apply, or
+ * apply to the wrong list; deriving from the subtree means a sibling partner is
+ * never in the data the picker renders from at all.
+ */
+
+/** Where a tenant sits in the three-tier tree (ADR 0004 caps the depth at three). */
+export type TenantTier = 'vendor' | 'partner' | 'customer'
+
+export type TenantNode = {
+  id: string
+  name: string
+  /** Dotted path from the root, e.g. `bigstack.northwind.acme`. */
+  path: string
+  tier: TenantTier
+}
+
+/**
+ * Whether `path` is `root` or sits beneath it.
+ *
+ * Compared segment by segment, never as a raw string prefix. `bigstack.north`
+ * is a string prefix of `bigstack.northwind` but is not its ancestor, and a
+ * naive prefix test would hand one partner another partner's whole portfolio.
+ */
+export const isWithin = (path: string, root: string): boolean => {
+  if (root === '') return false
+  if (path === root) return true
+  return path.startsWith(root + '.')
+}
+
+/** Depth of a path, where the root tenant is depth 1. */
+export const depthOf = (path: string): number =>
+  path === '' ? 0 : path.split('.').length
+
+/**
+ * The scopes a viewer may act in: their own tenant and everything beneath it.
+ *
+ * Ordered by path so the result reads as a tree walk, and so the same inputs
+ * always produce the same menu — a picker whose order varies between renders is
+ * one an operator can misclick during an incident.
+ */
+export const scopeOptions = (
+  viewerPath: string,
+  tenants: TenantNode[],
+): TenantNode[] =>
+  tenants
+    .filter((t) => isWithin(t.path, viewerPath))
+    .sort((a, b) => a.path.localeCompare(b.path))
+
+/**
+ * Whether the switcher should render as a control at all.
+ *
+ * A viewer with exactly one reachable scope — an end customer — gets a static
+ * label. An empty dropdown is worse than no dropdown: it implies there is
+ * something to switch to and that the viewer lacks permission, which is a
+ * different and more alarming statement than "you are here".
+ */
+export const isSwitchable = (
+  viewerPath: string,
+  tenants: TenantNode[],
+): boolean => scopeOptions(viewerPath, tenants).length > 1
+
+/**
+ * The breadcrumb from the viewer's own tenant down to the selected one.
+ *
+ * Starts at the viewer, not at the root: a partner acting inside a customer
+ * should read `NorthWind › Acme Corp`, not a chain that begins with Bigstack
+ * and implies they are acting under vendor authority. Who is acting under whose
+ * authority is the authority chain's job, and conflating the two is how a
+ * viewer misreads their own permissions.
+ */
+export const breadcrumbTo = (
+  viewerPath: string,
+  selectedPath: string,
+  tenants: TenantNode[],
+): TenantNode[] => {
+  if (!isWithin(selectedPath, viewerPath)) return []
+  const byPath = new Map(tenants.map((t) => [t.path, t]))
+  const segments = selectedPath.split('.')
+  const trail: TenantNode[] = []
+  for (let i = 1; i <= segments.length; i++) {
+    const path = segments.slice(0, i).join('.')
+    if (!isWithin(path, viewerPath)) continue
+    const node = byPath.get(path)
+    if (node) trail.push(node)
+  }
+  return trail
+}

--- a/packages/cube-advisor-ui/src/index.ts
+++ b/packages/cube-advisor-ui/src/index.ts
@@ -5,3 +5,16 @@ export {
   type AuthorityChainProps,
   type AuthorityParty,
 } from './components/AuthorityChain/formatChain'
+export {
+  ScopeSwitcher,
+  type ScopeSwitcherProps,
+} from './components/ScopeSwitcher/ScopeSwitcher'
+export {
+  breadcrumbTo,
+  depthOf,
+  isSwitchable,
+  isWithin,
+  scopeOptions,
+  type TenantNode,
+  type TenantTier,
+} from './components/ScopeSwitcher/scope'


### PR DESCRIPTION
## What this PR does / why we need it

The second cross-cutting element from the redraw brief, present on every screen: **which tier am I acting in, and whose tenant am I inside**.

Stacked on `feat/advisor-ui` (#855), which is awaiting review — retarget to `develop` once that lands.

Refs #854

## Special notes for your reviewer

### Cross-partner selection is structurally impossible, not validated

The brief is blunt about this one:

> Make cross-partner selection structurally impossible in the picker rather than validated after the fact — partners are frequently competitors and this is the screen where a slip is unrecoverable.

So `scopeOptions` **derives** the menu from the viewer's own subtree rather than filtering a global list. The difference is not stylistic: a filter is a check someone can forget to apply, or apply to the wrong list. Deriving means a sibling partner is never in the data the picker renders from at all.

### The prefix bug this is built to not have

Containment is compared **segment by segment**, never as a raw string prefix. `bigstack.north` is a string prefix of `bigstack.northwind` but is not its ancestor — `startsWith` alone hands one partner another partner's entire portfolio. The test fixture contains a partner named `North` specifically to trigger it.

### An end customer gets a label, not an empty dropdown

And deliberately not a *disabled* control either. An empty or greyed picker implies there is somewhere to switch to and that the viewer lacks permission — a different and more alarming claim than "you are here". Nothing is being withheld, so nothing should look withheld.

### The breadcrumb starts at the viewer, not the root

A partner acting inside a customer reads `NorthWind › Acme Corp`, not a chain beginning with Bigstack that implies they are acting under vendor authority. Who acts under whose authority is the **authority chain's** job (#855); conflating the two is how a viewer misreads their own permissions.

## Mutation testing

Seven mutations, **six caught**: naive `startsWith`, an empty viewer scope matching everything, options leaking upward so a partner sees the vendor, the customer getting an empty dropdown, the breadcrumb starting at the root, and unsorted options.

**The seventh survived, and it is not a test gap.** Removing the early return for an out-of-subtree selection changes nothing observable, because the per-segment check inside the loop already yields an empty trail. It is defence in depth, and I kept it because it states the intent at the boundary — but I am not claiming a kill I did not get.

## Verification

`tsc` clean · `eslint` clean · 24 tests pass · prettier applied.