### PR TITLE
feat(advisor-ui): the provider badge, and the pinned-control affordance

### DIFF
--- a/packages/cube-advisor-ui/src/components/ProviderBadge/ProviderBadge.tsx
+++ b/packages/cube-advisor-ui/src/components/ProviderBadge/ProviderBadge.tsx
@@ -1,0 +1,130 @@
+import classNames from 'classnames'
+
+import {
+  badgeText,
+  isCloudMode,
+  modeLabel,
+  type Model,
+  type ModelAvailability,
+} from './provider'
+
+export type ProviderBadgeProps = {
+  model: Model
+  /** Shown when pooled inference has degraded to the local pack. */
+  degraded?: boolean
+  className?: string
+}
+
+const modeClass: Record<Model['mode'], string> = {
+  pooled: 'text-status-neutral',
+  'own-key': 'text-functional-text',
+  'local-pack': 'text-status-positive-text',
+}
+
+/**
+ * Which brain is active, and who pays for it.
+ *
+ * The mode is not decoration. Before ADR 0007 the badge answered "which model";
+ * with a pooled credential, "which model" alone no longer tells an operator
+ * where their cluster's data went.
+ */
+export const ProviderBadge = (props: ProviderBadgeProps) => {
+  const { model, degraded, className } = props
+  return (
+    <span
+      className={classNames(
+        'inline-flex items-center gap-x-1 whitespace-nowrap text-sm',
+        className,
+      )}
+      data-testid="provider-badge"
+      title={badgeText(model)}
+    >
+      <span className="text-functional-title">{model.name}</span>
+      <span aria-hidden className="text-functional-text-light">
+        ·
+      </span>
+      <span className={modeClass[model.mode]}>{modeLabel[model.mode]}</span>
+      {isCloudMode(model.mode) && (
+        <span className="sr-only">(prompts leave the cluster)</span>
+      )}
+      {degraded && (
+        // Visible, because a silent fallback means an operator believes they
+        // are talking to a model they are not.
+        <span className="text-status-paused">
+          · gateway unavailable, degraded
+        </span>
+      )}
+    </span>
+  )
+}
+
+export type PinnedControlProps = {
+  /** The one-line reason, which must name the tier that decided. */
+  reason: string
+  children: React.ReactNode
+  className?: string
+}
+
+/**
+ * A control the viewer cannot exercise because it belongs to another tier.
+ *
+ * Rendered visibly pinned with its reason, never hidden and never greyed out
+ * with no explanation. "Only Acme Corp can revoke enrollment" is the honest
+ * state, and it reassures the customer reading over a partner's shoulder.
+ */
+export const PinnedControl = (props: PinnedControlProps) => {
+  const { reason, children, className } = props
+  return (
+    <span
+      className={classNames('inline-flex flex-col gap-y-0.5', className)}
+      data-testid="pinned-control"
+    >
+      <span className="opacity-60" aria-disabled>
+        {children}
+      </span>
+      <span className="text-xs text-status-paused">🔒 {reason}</span>
+    </span>
+  )
+}
+
+export type ModelOptionProps = {
+  availability: ModelAvailability
+  onSelect?: (id: string) => void
+}
+
+/**
+ * One row of the bounded model picker.
+ *
+ * A model the tenant may not use stays in the list, pinned with its reason. A
+ * silently shorter list reads as the product lacking the model rather than a
+ * policy excluding it, which is the wrong thing for an operator to conclude.
+ */
+export const ModelOption = (props: ModelOptionProps) => {
+  const { availability, onSelect } = props
+  const { model, selectable, pinnedReason } = availability
+
+  const label = (
+    <span className="inline-flex items-center gap-x-2">
+      <span className="text-functional-title">{model.name}</span>
+      <span className="text-xs text-functional-text-light">{model.class}</span>
+      <span className="text-xs">{modeLabel[model.mode]}</span>
+    </span>
+  )
+
+  if (!selectable) {
+    return (
+      <PinnedControl reason={pinnedReason ?? 'Unavailable'}>
+        {label}
+      </PinnedControl>
+    )
+  }
+  return (
+    <button
+      type="button"
+      className="text-left"
+      onClick={() => onSelect?.(model.id)}
+    >
+      {label}
+    </button>
+  )
+}

--- a/packages/cube-advisor-ui/src/components/ProviderBadge/provider.test.ts
+++ b/packages/cube-advisor-ui/src/components/ProviderBadge/provider.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it } from 'vitest'
+import {
+  applyCloudPolicy,
+  badgeText,
+  isCloudMode,
+  resolveCloudPolicy,
+  type Model,
+  type TierPolicy,
+} from './provider'
+
+const sonnet: Model = {
+  id: 's',
+  name: 'Claude Sonnet 4.5',
+  class: 'balanced',
+  mode: 'pooled',
+}
+const ownKey: Model = {
+  id: 'o',
+  name: 'Claude Opus 4',
+  class: 'deep',
+  mode: 'own-key',
+}
+const local: Model = {
+  id: 'l',
+  name: 'gpt-oss-120b',
+  class: 'fast',
+  mode: 'local-pack',
+}
+
+describe('badgeText', () => {
+  // The badge answered "which model" before ADR 0007. Model alone no longer
+  // tells an operator where their cluster's data went.
+  it('always names the mode alongside the model', () => {
+    expect(badgeText(sonnet)).toBe('Claude Sonnet 4.5 · Bigstack-hosted')
+    expect(badgeText(ownKey)).toBe('Claude Opus 4 · your key')
+    expect(badgeText(local)).toBe('gpt-oss-120b · local pack')
+  })
+
+  it('never renders a model name on its own', () => {
+    for (const m of [sonnet, ownKey, local]) {
+      expect(badgeText(m)).not.toBe(m.name)
+      expect(badgeText(m)).toContain('·')
+    }
+  })
+})
+
+describe('isCloudMode', () => {
+  it('treats only the local pack as staying on the cluster', () => {
+    expect(isCloudMode('pooled')).toBe(true)
+    expect(isCloudMode('own-key')).toBe(true)
+    expect(isCloudMode('local-pack')).toBe(false)
+  })
+})
+
+describe('resolveCloudPolicy', () => {
+  const bigstack: TierPolicy = { tenant: 'Bigstack', cloudAllowed: true }
+  const partner: TierPolicy = { tenant: 'NorthWind', cloudAllowed: true }
+  const customerDenies: TierPolicy = {
+    tenant: 'Acme Corp',
+    cloudAllowed: false,
+  }
+
+  // ADR 0007: a partner cannot loosen cloud-allowed:no for their customer.
+  it('lets a deny anywhere in the chain win over any allow', () => {
+    expect(resolveCloudPolicy([bigstack, partner, customerDenies])).toEqual({
+      cloudAllowed: false,
+      setBy: 'Acme Corp',
+    })
+    // And the same when the denier is the ancestor rather than the leaf — a
+    // nearer tier must not be able to re-permit it.
+    expect(
+      resolveCloudPolicy([
+        { tenant: 'Bigstack', cloudAllowed: false },
+        partner,
+      ]),
+    ).toEqual({ cloudAllowed: false, setBy: 'Bigstack' })
+  })
+
+  // The UI must say WHICH tier disabled it, not merely that it is disabled.
+  it('names the tenant whose policy decided', () => {
+    expect(resolveCloudPolicy([bigstack, customerDenies]).setBy).toBe(
+      'Acme Corp',
+    )
+  })
+
+  it('allows when a tier says so and nobody denies', () => {
+    expect(resolveCloudPolicy([bigstack, partner])).toEqual({
+      cloudAllowed: true,
+      setBy: 'Bigstack',
+    })
+  })
+
+  it('defaults to allowed with no attribution when nobody has an opinion', () => {
+    expect(resolveCloudPolicy([{ tenant: 'Acme Corp' }])).toEqual({
+      cloudAllowed: true,
+      setBy: '',
+    })
+    expect(resolveCloudPolicy([])).toEqual({ cloudAllowed: true, setBy: '' })
+  })
+})
+
+describe('applyCloudPolicy', () => {
+  const models = [sonnet, ownKey, local]
+
+  it('leaves everything selectable when cloud egress is allowed', () => {
+    const out = applyCloudPolicy(models, {
+      cloudAllowed: true,
+      setBy: 'Bigstack',
+    })
+    expect(out.every((m) => m.selectable)).toBe(true)
+    expect(out.every((m) => m.pinnedReason === undefined)).toBe(true)
+  })
+
+  // "absent or pinned with a reason, not silently missing" — a shorter list
+  // reads as the product lacking the model, not as a policy excluding it.
+  it('pins cloud models rather than dropping them', () => {
+    const out = applyCloudPolicy(models, {
+      cloudAllowed: false,
+      setBy: 'Acme Corp',
+    })
+    expect(out).toHaveLength(models.length)
+    const pinned = out.filter((m) => !m.selectable)
+    expect(pinned.map((p) => p.model.id).sort()).toEqual(['o', 's'])
+  })
+
+  it('names the deciding tier in the pinned reason', () => {
+    const out = applyCloudPolicy(models, {
+      cloudAllowed: false,
+      setBy: 'Acme Corp',
+    })
+    const pinned = out.find((m) => !m.selectable)
+    expect(pinned?.pinnedReason).toContain('Acme Corp')
+    expect(pinned?.pinnedReason).toMatch(/data-egress/i)
+  })
+
+  it('keeps the local pack selectable when cloud is denied', () => {
+    const out = applyCloudPolicy(models, {
+      cloudAllowed: false,
+      setBy: 'Acme Corp',
+    })
+    const localOut = out.find((m) => m.model.id === 'l')
+    expect(localOut?.selectable).toBe(true)
+    expect(localOut?.pinnedReason).toBeUndefined()
+  })
+})

--- a/packages/cube-advisor-ui/src/components/ProviderBadge/provider.ts
+++ b/packages/cube-advisor-ui/src/components/ProviderBadge/provider.ts
@@ -1,0 +1,110 @@
+/**
+ * Provider modes, model availability, and the cloud-egress policy.
+ *
+ * Two independent "who owns this" ideas run through the Advisor UI: who owns
+ * the *data* (tenant scoping) and who owns the *inference* (provider mode).
+ * They do not imply each other — a partner-managed customer might use their own
+ * key, and a direct customer might use the pooled one — so nothing here derives
+ * a mode from a tier.
+ */
+
+/** Where inference runs and who pays for it (ADR 0007). */
+export type ProviderMode = 'pooled' | 'own-key' | 'local-pack'
+
+/** How the mode reads in the badge. Short, because it sits after a model name. */
+export const modeLabel: Record<ProviderMode, string> = {
+  pooled: 'Bigstack-hosted',
+  'own-key': 'your key',
+  'local-pack': 'local pack',
+}
+
+/** Whether a mode sends prompts off the cluster's own network. */
+export const isCloudMode = (mode: ProviderMode): boolean =>
+  mode !== 'local-pack'
+
+export type Model = {
+  id: string
+  name: string
+  /** Rough capability tier, shown in the picker so a choice is informed. */
+  class: 'fast' | 'balanced' | 'deep'
+  mode: ProviderMode
+}
+
+/** One tier's stance on cloud egress, ordered root-first in a policy chain. */
+export type TierPolicy = {
+  /** Display name of the tier that set it, e.g. "Acme Corp". */
+  tenant: string
+  /** Absent means "no opinion" — inherit whatever an ancestor said. */
+  cloudAllowed?: boolean
+}
+
+export type CloudPolicy = {
+  cloudAllowed: boolean
+  /** Which tenant's policy decided this. Empty when nobody expressed one. */
+  setBy: string
+}
+
+/**
+ * Resolves cloud egress across a policy chain, most-restrictive-wins.
+ *
+ * ADR 0007: a partner cannot loosen `cloud allowed: no` for their customer. So
+ * a single deny anywhere in the chain denies, whoever set it and whatever a
+ * nearer tier says — and `setBy` names that tenant, because the UI has to tell
+ * the viewer *which* tier disabled it rather than that it is merely disabled.
+ *
+ * Defaults to allowed only when no tier expressed an opinion at all.
+ */
+export const resolveCloudPolicy = (chain: TierPolicy[]): CloudPolicy => {
+  const denier = chain.find((p) => p.cloudAllowed === false)
+  if (denier) return { cloudAllowed: false, setBy: denier.tenant }
+  const allower = chain.find((p) => p.cloudAllowed === true)
+  if (allower) return { cloudAllowed: true, setBy: allower.tenant }
+  return { cloudAllowed: true, setBy: '' }
+}
+
+/**
+ * A model as the picker should render it.
+ *
+ * `pinned` carries the reason a model cannot be chosen. It is never a signal to
+ * hide the model: the brief requires models the tenant may not use to be
+ * "absent or pinned with a reason, not silently missing", and pinned-with-a-
+ * reason is the honest one — a silently shorter list looks like the product
+ * lacks the model rather than that a policy excluded it.
+ */
+export type ModelAvailability = {
+  model: Model
+  selectable: boolean
+  pinnedReason?: string
+}
+
+/**
+ * Applies the resolved policy to an allowlist.
+ *
+ * Every model the tenant is entitled to stays in the list; cloud models become
+ * pinned when egress is disallowed, with a reason naming the tier that decided.
+ */
+export const applyCloudPolicy = (
+  models: Model[],
+  policy: CloudPolicy,
+): ModelAvailability[] =>
+  models.map((model) => {
+    if (policy.cloudAllowed || !isCloudMode(model.mode)) {
+      return { model, selectable: true }
+    }
+    const who = policy.setBy ? `${policy.setBy}'s` : 'your organisation’s'
+    return {
+      model,
+      selectable: false,
+      pinnedReason: `Disabled by ${who} data-egress policy`,
+    }
+  })
+
+/**
+ * The badge text: which brain is active, and who pays for it.
+ *
+ * The mode is never optional. The badge existed before ADR 0007 to answer
+ * "which model", and the whole point of the new dimension is that "which
+ * model" alone no longer tells an operator where their cluster's data went.
+ */
+export const badgeText = (model: Model): string =>
+  `${model.name} · ${modeLabel[model.mode]}`

--- a/packages/cube-advisor-ui/src/index.ts
+++ b/packages/cube-advisor-ui/src/index.ts
@@ -18,3 +18,22 @@ export {
   type TenantNode,
   type TenantTier,
 } from './components/ScopeSwitcher/scope'
+export {
+  ModelOption,
+  PinnedControl,
+  ProviderBadge,
+  type PinnedControlProps,
+  type ProviderBadgeProps,
+} from './components/ProviderBadge/ProviderBadge'
+export {
+  applyCloudPolicy,
+  badgeText,
+  isCloudMode,
+  modeLabel,
+  resolveCloudPolicy,
+  type CloudPolicy,
+  type Model,
+  type ModelAvailability,
+  type ProviderMode,
+  type TierPolicy,
+} from './components/ProviderBadge/provider'


### PR DESCRIPTION
## What this PR does / why we need it

The third and last cross-cutting element from the redraw brief: **which brain is active, and who pays for it** — plus the pinned-control affordance it depends on.

Stacked on `feat/advisor-scope-switcher` (#856), itself stacked on #855. Retarget down the chain as each lands.

Refs #854

## Special notes for your reviewer

### The mode is not decoration

Before ADR 0007 the badge answered "which model". With a pooled credential, **"which model" alone no longer tells an operator where their cluster's data went** — so `badgeText` always emits both, and there is a test that it never renders a model name on its own.

```
Claude Sonnet 4.5 · Bigstack-hosted
Claude Opus 4 · your key
gpt-oss-120b · local pack
```

### Cloud egress resolves most-restrictive-wins, and names who decided

ADR 0007 §6: a partner **cannot** loosen `cloud allowed: no` for their customer. So a deny anywhere in the chain beats an allow anywhere, regardless of depth — the mutation for "nearest tier wins" is one of the seven caught.

The resolved policy also carries **which tenant decided**, because the brief requires the reason line to name the tier:

> Disabled by Acme Corp's data-egress policy

Merely saying "disabled" would leave a partner's engineer unable to tell whether they or their customer set it.

### Pinned, not silently absent

The brief allows "absent or pinned with a reason". Pinned is the honest option: **a silently shorter list reads as the product lacking the model**, not as a policy excluding it, and an operator mid-incident shouldn't have to guess which. `PinnedControl` generalises the wave-1 affordance — visibly pinned with a one-line reason, never hidden and never greyed with no explanation.

### Two smaller decisions

- **Gateway degradation renders visibly.** A silent fallback to the local pack means an operator believes they are talking to a model they are not.
- **Data ownership and inference ownership stay separate.** Nothing here derives a mode from a tier — a partner-managed customer might use their own key, and a direct customer might use the pooled one. The brief warns specifically against conflating them.

## Mutation testing

Seven, each caught: nearest-tier-wins, a deny losing to an earlier allow, cloud models dropped rather than pinned, a reason omitting the deciding tier, the local pack pinned too, the badge dropping the mode, and `own-key` misclassified as staying on-cluster.

## Verification

`tsc` clean · `eslint` clean · 35 tests pass · prettier applied.

## What this completes

The three cross-cutting elements the redraw says appear on every screen — authority chain (#855), scope switcher (#856), provider badge (this). The twelve screens come next, translated onto real `Cos*` components rather than ported from the Figma export.