### PR TITLE
chore: deploy the dev build as one tar stream instead of 875 scp files

### DIFF
--- a/packages/cube-frontend-web-app/scripts/deployToDevRemote.sh
+++ b/packages/cube-frontend-web-app/scripts/deployToDevRemote.sh
@@ -18,18 +18,30 @@ if [[ ! -d "$LOCAL_DIST_DIR" ]]; then
   exit 1
 fi
 
+# `dist` holds ~875 files, and all but five of them are font subsets. `scp -r`
+# pays a few SFTP round trips per file, so on a link with any latency the deploy
+# spends minutes on round trips rather than on the 24 MB itself. One tar stream
+# over one ssh connection pays that cost once.
 for remote_host in "${remote_hosts[@]}"; do
   backup_date=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
   cos_ui_backup_path="${cos_ui_path}.${backup_date}.bak"
+  cos_ui_staging_path="${cos_ui_path}.${backup_date}.new"
 
   ssh_host="${user}@${remote_host}"
-  scp_cos_ui_path="${ssh_host}:${cos_ui_path}"
-  scp_cos_ui_backup_path="${ssh_host}:${cos_ui_backup_path}"
 
-  echo "[${ssh_host}] Backup: ${scp_cos_ui_path} -> ${scp_cos_ui_backup_path}"
+  echo "[${ssh_host}] Deploy: ${LOCAL_DIST_DIR} -> ${ssh_host}:${cos_ui_path}"
+  echo "[${ssh_host}] Backup: ${cos_ui_path} -> ${cos_ui_backup_path}"
+
+  # The staging directory is unpacked before anything moves, so the live site
+  # stays up for the whole transfer and a failed transfer leaves it untouched.
+  # Only the two `mv` calls at the end are visible to a user.
   # shellcheck disable=SC2029
-  ssh "$ssh_host" mv "${cos_ui_path}" "${cos_ui_backup_path}"
-
-  echo "[${ssh_host}] Deploy: ${LOCAL_DIST_DIR} -> $scp_cos_ui_path"
-  scp -r "$LOCAL_DIST_DIR" "$scp_cos_ui_path"
+  tar -czf - -C "$LOCAL_DIST_DIR" . |
+    ssh "$ssh_host" "set -eu
+      trap \"rm -rf '${cos_ui_staging_path}'\" EXIT
+      rm -rf '${cos_ui_staging_path}'
+      mkdir -p '${cos_ui_staging_path}'
+      tar -xzf - --no-same-owner -C '${cos_ui_staging_path}'
+      mv '${cos_ui_path}' '${cos_ui_backup_path}'
+      mv '${cos_ui_staging_path}' '${cos_ui_path}'"
 done


### PR DESCRIPTION
#### What type of PR is this?

/kind cleanup

#### What this PR does / why we need it

`pnpm --filter @cube-frontend/web-app deploy-dev` took over two and a half
minutes, and the dev site answered 404 for all of it. Both problems come from the
same line: `scp -r dist`.

`dist` holds ~875 files. All but five are font subsets, so the transfer is 875
small files rather than one 24 MB payload, and `scp` pays several SFTP round trips
per file. One compressed tar stream over one ssh connection pays that cost once.

**Measured against a dev host at 8.7 ms RTT, both methods writing to a scratch
directory, 875 files landing each time:**

| Method | Time |
| --- | --- |
| `scp -r dist` (before) | **153.7 s** |
| `tar -czf - \| ssh 'tar -xzf -'` (after) | **1.4 s** |
| repeat runs of the new method | 1.5 s / 1.2 s |

153.7 s ÷ 875 ≈ 176 ms per file ≈ 20 round trips per file. Compression is not what
helps — 24 MB only packs down to 21 MB, because woff and woff2 are already
compressed.

The deploy order changes as well:

```mermaid
sequenceDiagram
    participant L as Local
    participant R as Dev host

    Note over L,R: Before
    L->>R: mv live aside to .bak
    Note over R: 404 starts here
    L->>R: scp 875 files, 2.5 min
    Note over R: 404 lasts the whole copy
    Note over R: a failed copy leaves only the .bak

    Note over L,R: After
    L->>R: one tar stream into a staging dir
    Note over R: live site keeps serving
    L->>R: mv live aside to .bak
    L->>R: mv staging into place
    Note over R: 404 window is two mv calls
```

#### QA perspective

This is a **developer tool only**. It deploys a local build to a dev appliance and
ships in no RPM, so there is nothing to verify on a customer build and no product
behaviour changes.

To check it, from a `cube-cos-ui` checkout with
`packages/cube-frontend-web-app/scripts/remote_hosts.properties.local` filled in:

- [ ] `pnpm web-app:build && pnpm --filter @cube-frontend/web-app deploy-dev` finishes in seconds rather than minutes.
- [ ] The dev host serves the new UI afterwards — hard-reload the browser and confirm the change you built is there.
- [ ] `/usr/share/cube/ui` on the host holds the same number of files as the local `dist`.
- [ ] A timestamped `/usr/share/cube/ui.<UTC>.bak` exists next to it, holding the previous build.
- [ ] No `*.new` directory is left behind next to `/usr/share/cube/ui`.
- [ ] Load the UI in a browser **during** the deploy: it keeps answering, instead of 404 as before.
- [ ] Interrupt the deploy with Ctrl-C mid-transfer: the site still serves the old build, no `.bak` is created, and no `*.new` directory survives.

#### Developer perspective

One file: `packages/cube-frontend-web-app/scripts/deployToDevRemote.sh`.

- `tar -czf - -C dist .` pipes into a single `ssh` command that unpacks with
  `tar -xzf - --no-same-owner`. `--no-same-owner` matters because the login user is
  `root`, which would otherwise try to apply the local uid/gid.
- The remote script unpacks into `${cos_ui_path}.<stamp>.new`, then does
  `mv live .bak` and `mv .new live`. The staging directory shares the backup's
  timestamp, so it is obvious which deploy a leftover belongs to.
- `trap "rm -rf <staging>" EXIT` cleans up on any exit path, including a broken
  pipe.
- `set -euo pipefail` in the outer script plus `set -eu` in the remote one means a
  failure anywhere aborts before the swap.

Exercised locally with `ssh` replaced by `bash`, both paths:

| Scenario | Result |
| --- | --- |
| Normal run | 875 files land, `diff -r` against `dist` is clean, `.bak` kept, staging cleaned, exit 0 |
| Stream truncated to 5000 bytes | live tree untouched, no `.bak` created, staging cleaned, exit 1 |

#### Which issue(s) this PR fixes

Fixes #

No ticket — a one-file change to a local developer script, agreed as an exception.

#### Special notes for your reviewer

> Note

- The remote needs `tar`; the appliance ships GNU tar 1.34.
- `rsync -az --delete` would also fix the round trips, but it needs `rsync` on the
  appliance and buys little else here: Vite hashes JS and CSS filenames, so those
  are new files on every deploy.
- The 875-file count comes from `noto-sans-tc` being split into unicode-range
  subsets. Shrinking that is worth its own ticket and would cut transfer size,
  build output, and browser requests — out of scope here.

#### Additional documentation

```docs

```
