### PR TITLE
feat(advisor-ui): fleet home, with access and visibility kept apart

### DIFF
--- a/packages/cube-advisor-ui/src/components/FleetHome/FleetHome.tsx
+++ b/packages/cube-advisor-ui/src/components/FleetHome/FleetHome.tsx
@@ -1,0 +1,179 @@
+import classNames from 'classnames'
+
+import {
+  fleetCounts,
+  groupFleet,
+  isPackStale,
+  type ClusterRow,
+  type CustomerGroup,
+} from './fleet'
+import type { TenantNode } from '../ScopeSwitcher/scope'
+
+export type FleetHomeProps = {
+  viewerPath: string
+  tenants: TenantNode[]
+  clusters: ClusterRow[]
+  onOpenCluster?: (id: string) => void
+  className?: string
+}
+
+const healthClass: Record<ClusterRow['health'], string> = {
+  ok: 'text-status-positive-text',
+  warning: 'text-status-warning',
+  critical: 'text-status-negative',
+  unknown: 'text-functional-text-light',
+}
+
+const ChannelTag = (props: { channel: CustomerGroup['channel'] }) =>
+  props.channel.kind === 'direct' ? (
+    <span className="text-xs text-functional-text-light">direct</span>
+  ) : (
+    <span className="text-xs text-status-paused">
+      via {props.channel.partner}
+    </span>
+  )
+
+/**
+ * One cluster row.
+ *
+ * Access and visibility are rendered as different things, not as one row with
+ * a dimmer variant. A viewer who can only see that a cluster exists must not
+ * be able to mistake it for one they can work on — the brief calls conflating
+ * them the main way this screen goes wrong.
+ */
+const ClusterLine = (props: {
+  row: ClusterRow
+  onOpen?: (id: string) => void
+}) => {
+  const { row, onOpen } = props
+  const actionable = row.access === 'access'
+  return (
+    <div
+      className="flex items-center gap-x-3 py-1 text-sm"
+      data-testid="cluster-row"
+      data-access={row.access}
+    >
+      {actionable ? (
+        <button
+          type="button"
+          className="text-functional-title underline-offset-2 hover:underline"
+          onClick={() => onOpen?.(row.id)}
+        >
+          {row.name}
+        </button>
+      ) : (
+        <span className="text-functional-text-light">{row.name}</span>
+      )}
+
+      {!actionable && (
+        <span className="text-xs text-functional-text-light">
+          visible only — no access granted
+        </span>
+      )}
+
+      <span className={healthClass[row.health]}>{row.health}</span>
+
+      <span
+        className={
+          row.tunnelConnected
+            ? 'text-status-positive-text'
+            : 'text-status-negative'
+        }
+      >
+        {row.tunnelConnected
+          ? 'connected'
+          : `last seen ${row.lastSeen ?? 'unknown'}`}
+      </span>
+
+      <span className="text-functional-text-light">
+        {row.version}
+        {row.fixpack ? ` + ${row.fixpack}` : ''}
+      </span>
+
+      {/* Staleness is stated, not left for the reader to compute from a date. */}
+      {(isPackStale(row.knowledgePack) || isPackStale(row.advisoryPack)) && (
+        <span className="text-status-warning">packs stale</span>
+      )}
+
+      {row.openInsights > 0 && (
+        <span className="text-functional-text">
+          {row.openInsights} insights
+        </span>
+      )}
+      {row.activeWatches > 0 && (
+        <span className="text-functional-text">
+          {row.activeWatches} watches
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Fleet home: enrolled clusters, grouped by tier.
+ *
+ * Grouping is done by `groupFleet`, which drops anything outside the viewer's
+ * subtree before this component sees it — a sibling partner's clusters never
+ * reach the renderer.
+ */
+export const FleetHome = (props: FleetHomeProps) => {
+  const { viewerPath, tenants, clusters, onOpenCluster, className } = props
+  const groups = groupFleet(viewerPath, tenants, clusters)
+  const counts = fleetCounts(groups)
+
+  return (
+    <div
+      className={classNames('flex flex-col gap-y-4', className)}
+      data-testid="fleet-home"
+    >
+      {/* Two numbers, never one. A combined total would tell a partner they
+          can act on more clusters than they can. */}
+      <div className="flex gap-x-4 text-sm">
+        <span className="text-functional-title">
+          {counts.accessible} accessible
+        </span>
+        {counts.visibleOnly > 0 && (
+          <span className="text-functional-text-light">
+            {counts.visibleOnly} visible only
+          </span>
+        )}
+        {counts.disconnected > 0 && (
+          <span className="text-status-negative">
+            {counts.disconnected} disconnected
+          </span>
+        )}
+        {counts.openInsights > 0 && (
+          <span className="text-functional-text">
+            {counts.openInsights} open insights
+          </span>
+        )}
+      </div>
+
+      {groups.map((partner) => (
+        <section
+          key={partner.tenant?.path ?? 'direct'}
+          className="flex flex-col gap-y-2"
+        >
+          {partner.tenant && (
+            <h2 className="text-sm text-status-paused">
+              Partner: {partner.tenant.name}
+            </h2>
+          )}
+          {partner.customers.map((customer) => (
+            <div key={customer.tenant.path} className="flex flex-col">
+              <div className="flex items-center gap-x-2">
+                <h3 className="text-functional-title">
+                  {customer.tenant.name}
+                </h3>
+                <ChannelTag channel={customer.channel} />
+              </div>
+              {customer.clusters.map((row) => (
+                <ClusterLine key={row.id} row={row} onOpen={onOpenCluster} />
+              ))}
+            </div>
+          ))}
+        </section>
+      ))}
+    </div>
+  )
+}

--- a/packages/cube-advisor-ui/src/components/FleetHome/fleet.test.ts
+++ b/packages/cube-advisor-ui/src/components/FleetHome/fleet.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, it } from 'vitest'
+import type { TenantNode } from '../ScopeSwitcher/scope'
+import {
+  channelOf,
+  fleetCounts,
+  groupFleet,
+  isPackStale,
+  STALE_PACK_DAYS,
+  type ClusterRow,
+} from './fleet'
+
+const tenants: TenantNode[] = [
+  { id: 'bigstack', name: 'Bigstack', path: 'bigstack', tier: 'vendor' },
+  {
+    id: 'northwind',
+    name: 'NorthWind',
+    path: 'bigstack.northwind',
+    tier: 'partner',
+  },
+  {
+    id: 'acme',
+    name: 'Acme Corp',
+    path: 'bigstack.northwind.acme',
+    tier: 'customer',
+  },
+  {
+    id: 'eastgate',
+    name: 'EastGate',
+    path: 'bigstack.eastgate',
+    tier: 'partner',
+  },
+  {
+    id: 'globex',
+    name: 'Globex',
+    path: 'bigstack.eastgate.globex',
+    tier: 'customer',
+  },
+  {
+    id: 'initech',
+    name: 'Initech',
+    path: 'bigstack.initech',
+    tier: 'customer',
+  },
+]
+
+const cluster = (
+  id: string,
+  tenantPath: string,
+  over: Partial<ClusterRow> = {},
+): ClusterRow => ({
+  id,
+  name: id,
+  tenantPath,
+  tunnelConnected: true,
+  health: 'ok',
+  version: '3.1.10',
+  knowledgePack: { version: '2026.08', ageDays: 3 },
+  advisoryPack: { version: '2026.08', ageDays: 3 },
+  openInsights: 0,
+  activeWatches: 0,
+  access: 'access',
+  ...over,
+})
+
+const clusters: ClusterRow[] = [
+  cluster('acme-prod-01', 'bigstack.northwind.acme'),
+  cluster('acme-prod-02', 'bigstack.northwind.acme', { access: 'visibility' }),
+  cluster('globex-prod-01', 'bigstack.eastgate.globex'),
+  cluster('initech-01', 'bigstack.initech', {
+    tunnelConnected: false,
+    lastSeen: '2026-08-18T10:00:00Z',
+  }),
+]
+
+describe('channelOf', () => {
+  it('tags a customer sold to directly as direct', () => {
+    const initech = tenants.find((t) => t.id === 'initech')!
+    expect(channelOf(initech, tenants)).toEqual({ kind: 'direct' })
+  })
+
+  it('names the partner a customer is reached through', () => {
+    const acme = tenants.find((t) => t.id === 'acme')!
+    expect(channelOf(acme, tenants)).toEqual({
+      kind: 'via',
+      partner: 'NorthWind',
+    })
+  })
+})
+
+describe('groupFleet', () => {
+  // Same reasoning as the scope switcher: a sibling partner's clusters must
+  // never reach the component that draws rows.
+  it('never includes clusters outside the viewer subtree', () => {
+    const groups = groupFleet('bigstack.northwind', tenants, clusters)
+    const ids = groups.flatMap((p) =>
+      p.customers.flatMap((c) => c.clusters.map((x) => x.id)),
+    )
+    expect(ids).toEqual(['acme-prod-01', 'acme-prod-02'])
+    expect(ids).not.toContain('globex-prod-01')
+    expect(ids).not.toContain('initech-01')
+  })
+
+  it('nests customers under partners for a vendor viewer', () => {
+    const groups = groupFleet('bigstack', tenants, clusters)
+    const partnerNames = groups.map((g) => g.tenant?.name ?? null)
+    expect(partnerNames).toContain('NorthWind')
+    expect(partnerNames).toContain('EastGate')
+    // Direct customers sit in the unparented bucket, not under a partner.
+    const direct = groups.find((g) => g.tenant === null)
+    expect(direct?.customers.map((c) => c.tenant.id)).toEqual(['initech'])
+  })
+
+  // A partner is already inside their own subtree; repeating their name above
+  // every row says nothing.
+  it('does not nest a partner viewer under their own name', () => {
+    const groups = groupFleet('bigstack.northwind', tenants, clusters)
+    expect(groups).toHaveLength(1)
+    expect(groups[0].tenant).toBeNull()
+  })
+
+  it('is stable in order', () => {
+    const once = groupFleet('bigstack', tenants, clusters)
+    const twice = groupFleet('bigstack', tenants, [...clusters].reverse())
+    expect(JSON.stringify(once)).toBe(JSON.stringify(twice))
+  })
+})
+
+describe('fleetCounts', () => {
+  // The conflation the brief calls "the main way this screen goes wrong".
+  it('reports access and visibility separately, never as one total', () => {
+    const counts = fleetCounts(
+      groupFleet('bigstack.northwind', tenants, clusters),
+    )
+    expect(counts.total).toBe(2)
+    expect(counts.accessible).toBe(1)
+    expect(counts.visibleOnly).toBe(1)
+    // The two must not be summed into "accessible".
+    expect(counts.accessible).not.toBe(counts.total)
+  })
+
+  it('counts disconnected tunnels', () => {
+    const counts = fleetCounts(groupFleet('bigstack', tenants, clusters))
+    expect(counts.disconnected).toBe(1)
+  })
+})
+
+describe('isPackStale', () => {
+  it('is false at the threshold and true past it', () => {
+    expect(isPackStale({ version: 'x', ageDays: STALE_PACK_DAYS })).toBe(false)
+    expect(isPackStale({ version: 'x', ageDays: STALE_PACK_DAYS + 1 })).toBe(
+      true,
+    )
+  })
+})

--- a/packages/cube-advisor-ui/src/components/FleetHome/fleet.ts
+++ b/packages/cube-advisor-ui/src/components/FleetHome/fleet.ts
@@ -1,0 +1,173 @@
+/**
+ * Fleet home: the enrolled clusters a viewer can see, grouped by tier.
+ *
+ * The brief names the way this screen goes wrong:
+ *
+ *   "each cluster shows whether the viewer currently *has* access or merely
+ *    visibility. Those are different states and conflating them is the main way
+ *    this screen goes wrong."
+ *
+ * So access and visibility are separate fields here, never one boolean, and the
+ * counts report them separately. A single "clusters: 12" that silently mixes
+ * the two tells a partner engineer they can act on twelve clusters when they
+ * can act on three.
+ */
+import { isWithin, type TenantNode } from '../ScopeSwitcher/scope'
+
+/**
+ * Whether the viewer may act on a cluster, or only knows it exists.
+ *
+ * `visibility` is not a weaker access — it is the absence of access with the
+ * presence of knowledge, which is exactly what a partner has over a customer
+ * who has not granted them anything yet.
+ */
+export type AccessState = 'access' | 'visibility'
+
+export type PackVersion = {
+  version: string
+  /** Days since this pack was published. Staleness has to be visible. */
+  ageDays: number
+}
+
+export type ClusterRow = {
+  id: string
+  name: string
+  /** Owning tenant's dotted path. */
+  tenantPath: string
+  tunnelConnected: boolean
+  /** ISO timestamp; only meaningful when the tunnel is down. */
+  lastSeen?: string
+  health: 'ok' | 'warning' | 'critical' | 'unknown'
+  version: string
+  fixpack?: string
+  knowledgePack: PackVersion
+  advisoryPack: PackVersion
+  openInsights: number
+  activeWatches: number
+  access: AccessState
+}
+
+/** A customer and their clusters, as one group in the list. */
+export type CustomerGroup = {
+  tenant: TenantNode
+  /** `direct` when Bigstack sells to them, otherwise the partner's name. */
+  channel: { kind: 'direct' } | { kind: 'via'; partner: string }
+  clusters: ClusterRow[]
+}
+
+/** For a vendor viewer, customers are nested under their partner. */
+export type PartnerGroup = {
+  tenant: TenantNode | null
+  customers: CustomerGroup[]
+}
+
+/** How stale a pack is allowed to be before the UI must say so. */
+export const STALE_PACK_DAYS = 30
+
+export const isPackStale = (pack: PackVersion): boolean =>
+  pack.ageDays > STALE_PACK_DAYS
+
+/**
+ * The channel a customer is reached through.
+ *
+ * Direct sales and partner-managed must be distinguishable at a glance on this
+ * screen; the brief requires a `direct` or `via NorthWind` tag on every
+ * customer row.
+ */
+export const channelOf = (
+  customer: TenantNode,
+  tenants: TenantNode[],
+): CustomerGroup['channel'] => {
+  const segments = customer.path.split('.')
+  if (segments.length <= 2) return { kind: 'direct' }
+  const parentPath = segments.slice(0, -1).join('.')
+  const parent = tenants.find((t) => t.path === parentPath)
+  if (!parent || parent.tier !== 'partner') return { kind: 'direct' }
+  return { kind: 'via', partner: parent.name }
+}
+
+/**
+ * Groups the fleet for a viewer.
+ *
+ * Clusters outside the viewer's subtree are dropped here rather than hidden by
+ * the renderer — the same reasoning as the scope switcher: a sibling partner's
+ * clusters should never reach the component that draws rows.
+ */
+export const groupFleet = (
+  viewerPath: string,
+  tenants: TenantNode[],
+  clusters: ClusterRow[],
+): PartnerGroup[] => {
+  const reachable = clusters.filter((c) => isWithin(c.tenantPath, viewerPath))
+  const byPath = new Map(tenants.map((t) => [t.path, t]))
+
+  const customers = new Map<string, CustomerGroup>()
+  for (const cluster of reachable) {
+    const tenant = byPath.get(cluster.tenantPath)
+    if (!tenant) continue
+    let group = customers.get(tenant.path)
+    if (!group) {
+      group = { tenant, channel: channelOf(tenant, tenants), clusters: [] }
+      customers.set(tenant.path, group)
+    }
+    group.clusters.push(cluster)
+  }
+
+  for (const group of customers.values()) {
+    group.clusters.sort((a, b) => a.name.localeCompare(b.name))
+  }
+
+  // Only a vendor viewer sees a partner level. A partner is already inside
+  // their own subtree, so nesting their own name above every customer row
+  // would be a level of noise that says nothing.
+  const nested = tenantTierOf(viewerPath, tenants) === 'vendor'
+
+  const partners = new Map<string, PartnerGroup>()
+  for (const group of customers.values()) {
+    const key =
+      nested && group.channel.kind === 'via' ? group.channel.partner : ''
+    let bucket = partners.get(key)
+    if (!bucket) {
+      bucket = {
+        tenant: key
+          ? (tenants.find((t) => t.tier === 'partner' && t.name === key) ??
+            null)
+          : null,
+        customers: [],
+      }
+      partners.set(key, bucket)
+    }
+    bucket.customers.push(group)
+  }
+
+  const out = [...partners.values()]
+  for (const bucket of out) {
+    bucket.customers.sort((a, b) => a.tenant.path.localeCompare(b.tenant.path))
+  }
+  return out.sort((a, b) =>
+    (a.tenant?.path ?? '').localeCompare(b.tenant?.path ?? ''),
+  )
+}
+
+const tenantTierOf = (
+  path: string,
+  tenants: TenantNode[],
+): TenantNode['tier'] | undefined => tenants.find((t) => t.path === path)?.tier
+
+/**
+ * Fleet counts.
+ *
+ * `accessible` and `visibleOnly` are separate numbers on purpose. One combined
+ * total would tell a partner engineer they can act on more clusters than they
+ * can, which is the conflation the brief warns about.
+ */
+export const fleetCounts = (groups: PartnerGroup[]) => {
+  const clusters = groups.flatMap((p) => p.customers.flatMap((c) => c.clusters))
+  return {
+    total: clusters.length,
+    accessible: clusters.filter((c) => c.access === 'access').length,
+    visibleOnly: clusters.filter((c) => c.access === 'visibility').length,
+    disconnected: clusters.filter((c) => !c.tunnelConnected).length,
+    openInsights: clusters.reduce((n, c) => n + c.openInsights, 0),
+  }
+}

--- a/packages/cube-advisor-ui/src/index.ts
+++ b/packages/cube-advisor-ui/src/index.ts
@@ -37,3 +37,19 @@ export {
   type ProviderMode,
   type TierPolicy,
 } from './components/ProviderBadge/provider'
+export {
+  FleetHome,
+  type FleetHomeProps,
+} from './components/FleetHome/FleetHome'
+export {
+  channelOf,
+  fleetCounts,
+  groupFleet,
+  isPackStale,
+  STALE_PACK_DAYS,
+  type AccessState,
+  type ClusterRow,
+  type CustomerGroup,
+  type PackVersion,
+  type PartnerGroup,
+} from './components/FleetHome/fleet'


### PR DESCRIPTION
## What this PR does / why we need it

The first of the twelve screens: **fleet home**, the SaaS landing — enrolled clusters, grouped by tier.

Stacked on `feat/advisor-provider-badge` (#857) → #856 → #855. Retarget down the chain as each lands.

Refs #854

## Special notes for your reviewer

### The failure mode this screen is built around

The brief names it outright:

> each cluster shows whether the viewer currently *has* access or merely visibility. **Those are different states and conflating them is the main way this screen goes wrong.**

So:

- `access` and `visibility` are **separate fields**, never one boolean.
- `fleetCounts` reports **two numbers**, never a total. "12 clusters" tells a partner engineer they can act on twelve when they can act on three.
- The rows differ **structurally**: an accessible cluster is a `<button>`; a visible-only one is text carrying `visible only — no access granted`. Not a dimmed variant of the same thing, because dimming reads as "temporarily unavailable" rather than "you were never granted this".

### Grouping drops, it does not hide

Same rule as the scope switcher: clusters outside the viewer's subtree are removed in `groupFleet`, before the renderer sees them. A sibling partner's clusters never reach the component that draws rows.

A vendor viewer gets `partner → customer` nesting. A partner viewer **does not** get their own name repeated above every customer — they are already inside their own subtree, so it would be a level of noise that says nothing. Direct customers sit in an unparented bucket tagged `direct`; partner-managed ones are tagged `via NorthWind`.

### Smaller calls

- **Staleness is stated, not computed by the reader** — `packs stale` rather than a date to subtract from today.
- **The threshold is exclusive**: exactly 30 days is not yet stale. Off-by-one here would mark a freshly-published pack stale on a boundary day, and there's a mutation for it.

## Mutation testing

Seven, each caught. The two that matter most: **counting visibility as access**, and **letting clusters outside the viewer's subtree into the list**. Also caught: every customer tagged `direct`, a partner viewer nested under their own name, an inclusive staleness threshold, and unstable ordering.

## Verification

`tsc` clean · `eslint` clean · 44 tests pass · prettier applied.

## Scope — please read

This is built from the **written brief**, not pixel-matched to `02 Cube AI Advisor Fleet Home.dc.html`. The data model and the invariants are what I could verify and test; the visual pass against the Claude Design export is still outstanding.

That is deliberate rather than a shortcut: the mockup's component bundle is a *Figma export* (128 components named from layer names), not this library, so the screens have to be translated onto real `Cos*` components. Getting the semantics and the invariants right first means the visual pass is a styling exercise rather than a rewrite. Worth a look from someone with the mockup open.