### PR TITLE
fix(nodes): 1293 block Edit GPU Type while a card is still changing

### DIFF
--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/NodeGpuResources.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/NodeGpuResources.tsx
@@ -25,7 +25,11 @@ import { nodesApi } from '@cube-frontend/web-app/api/cosApi'
 import { usePolling } from '@cube-frontend/web-app/hooks/usePolling'
 import { GpuDetailsFullViewModal } from './GpuDetailsFullViewModal/GpuDetailsFullViewModal'
 import { EditGPUResourceModal } from './EditGPUResourceModal/EditGPUResourceModal'
-import { GpuResourceRow, GpuTypeLabelKeyMap } from './utils'
+import {
+  GpuResourceRow,
+  GpuTypeLabelKeyMap,
+  isGpuTypeEditDisabled,
+} from './utils'
 import { useTranslation } from 'react-i18next'
 import { ParseKeys } from 'i18next'
 
@@ -177,7 +181,7 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
           title={t('nodes.details.editGpuType')}
           type="plain"
           onClick={() => openResourceEditModal(row)}
-          disabled={row.status.current === GPUCardStatus.InUse}
+          disabled={isGpuTypeEditDisabled(row.status)}
         />
       </CosOverflowMenu>
     )

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/utils.test.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest'
-import { GPUResourceType } from '@cube-frontend/api'
-import { isProfileRemainingSupported } from './utils'
+import { GPUCardStatus, GPUResourceType } from '@cube-frontend/api'
+import { isGpuTypeEditDisabled, isProfileRemainingSupported } from './utils'
 
 describe('isProfileRemainingSupported', () => {
   test('returns true for MIG-backed vGPU, which limits instances per profile', () => {
@@ -16,5 +16,46 @@ describe('isProfileRemainingSupported', () => {
   test('returns false for resource types without profiles', () => {
     expect(isProfileRemainingSupported(GPUResourceType.Pgpu)).toBe(false)
     expect(isProfileRemainingSupported(GPUResourceType.Unset)).toBe(false)
+  })
+})
+
+describe('isGpuTypeEditDisabled', () => {
+  test('blocks a card a VM already holds', () => {
+    expect(
+      isGpuTypeEditDisabled({
+        current: GPUCardStatus.InUse,
+        isProcessing: false,
+      }),
+    ).toBe(true)
+  })
+
+  test('blocks a card whose previous change has not settled', () => {
+    expect(
+      isGpuTypeEditDisabled({
+        current: GPUCardStatus.Idle,
+        isProcessing: true,
+      }),
+    ).toBe(true)
+    expect(
+      isGpuTypeEditDisabled({
+        current: GPUCardStatus.Unassigned,
+        isProcessing: true,
+      }),
+    ).toBe(true)
+  })
+
+  test('allows an idle or unassigned card that is not changing', () => {
+    expect(
+      isGpuTypeEditDisabled({
+        current: GPUCardStatus.Idle,
+        isProcessing: false,
+      }),
+    ).toBe(false)
+    expect(
+      isGpuTypeEditDisabled({
+        current: GPUCardStatus.Unassigned,
+        isProcessing: false,
+      }),
+    ).toBe(false)
   })
 })

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/utils.ts
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/utils.ts
@@ -1,7 +1,9 @@
 import {
+  GPUCardStatus,
   GPUProfile,
   GPUResourceType,
   ListNodeGPUCardsResponseDataInner,
+  ListNodeGPUCardsResponseDataInnerStatus,
 } from '@cube-frontend/api'
 import { CosTableRow } from '@cube-frontend/ui-library'
 import { ParseKeys } from 'i18next'
@@ -38,6 +40,16 @@ export const getProfilesByResourceType = (
 export const isProfileRemainingSupported = (
   resourceType: GPUResourceType,
 ): boolean => resourceType === GPUResourceType.MigBackedVgpu
+
+/**
+ * Changing a card's resource type re-partitions the device, so it needs the card
+ * to be free *and* settled: a VM holding it would lose the device underneath it,
+ * and a card whose previous change is still running would take a second one on
+ * top of an unfinished state. `isProcessing` is what the row's spinner reads.
+ */
+export const isGpuTypeEditDisabled = (
+  status: ListNodeGPUCardsResponseDataInnerStatus,
+): boolean => status.current === GPUCardStatus.InUse || status.isProcessing
 
 export const GpuTypeLabelKeyMap: Record<GPUResourceType, ParseKeys> = {
   [GPUResourceType.Unset]: 'nodes.details.gpuList.resourceType.unset',


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

`Edit GPU Type` stayed clickable while the same card was still applying a previous
change. The row already showed a spinner for that state — the API reports
`status.isProcessing` next to `status.current` precisely so an in-flight operation
can be represented — but the menu entry only read `status.current`. An operator
could open the modal again and submit a second resource-type change on top of an
unfinished one.

Changing a resource type re-partitions the card, so the entry now needs the card to
be **free and settled**:

| `status.current` | `status.isProcessing` | Edit GPU Type | Change |
| --- | --- | --- | --- |
| `inUse` | `false` | disabled | same as before |
| `inUse` | `true` | disabled | same as before |
| `idle` | `true` | **disabled** | **this PR** |
| `unassigned` | `true` | **disabled** | **this PR** |
| `idle` | `false` | enabled | same as before |
| `unassigned` | `false` | enabled | same as before |

The two history entries stay clickable. They open a Grafana panel, which is where
an operator would watch the change land.

##### Screenshots

Same card in all three: `NVIDIA A100 40GB`, status `Idle`, a change still running —
the spinner next to the card name is the same signal the fix now reads.

**Before — the entry is clickable during the change**

<img width="1500" height="950" alt="1293-0-before" src="https://github.com/user-attachments/assets/aee84f72-1a5a-4f31-b863-cb713d6ccfb1" />

**After — the entry is greyed out**

<img width="1500" height="950" alt="1293-1-idle-processing" src="https://github.com/user-attachments/assets/951a3005-603c-4467-9c27-4d7d66af6f65" />

**After — an idle card with nothing running still opens the modal**

<img width="1500" height="950" alt="1293-2-idle-settled" src="https://github.com/user-attachments/assets/1637f614-079e-40fb-a580-fa26fe17e99b" />

#### QA perspective

**Where.** `Nodes > <node> > GPU Resources`, the `⋯` menu on a GPU card row.

**What changed.** Only when a card is mid-change. A card that is idle, unassigned,
or in use behaves exactly as before. No API contract changes, so no other repo is
involved.

**Check list**

- [ ] On a card whose status is `Idle`, change its resource type from the `⋯` menu and confirm. A spinner appears next to the card name.
- [ ] While that spinner shows, reopen the same row's `⋯` menu: `Edit GPU Type` is greyed out and clicking it opens nothing.
- [ ] After the spinner disappears, reopen the menu: `Edit GPU Type` is clickable again.
- [ ] On a card with status `In-use` and no change running: `Edit GPU Type` stays greyed out, as before this PR.
- [ ] On a card with status `Unassigned` and no change running: `Edit GPU Type` is clickable.
- [ ] While a card is mid-change, `View Workload History` and `View VRAM History` on that row stay clickable and still open Grafana.

#### Developer perspective

Two files under `src/pages/node/[name]/_components/NodeGpuResources/`:

- `utils.ts` — new `isGpuTypeEditDisabled(status)` holding both conditions, next to the other row predicates.
- `NodeGpuResources.tsx` — the menu entry calls it instead of comparing `status.current` inline.

`utils.test.ts` covers all six status combinations from the table above.

Verified in a browser against the MSW GPU mocks, which already carry three cards
with `isProcessing: true`. Every one of the 12 rows was read back out of the DOM
and matched what the table predicts — including `0000:07:00.0`, which is `In-use`
*and* processing, and the three settled `Idle` rows that must stay clickable.
Console clean. The "before" screenshot comes from reverting just that one line with
the same mocks, so the two shots differ only by the fix.

`pnpm lint` passes; `pnpm test` reports 104 passing tests, 3 of them new.

#### Which issue(s) this PR fixes

Fixes https://github.com/bigstack-oss/cubecos/issues/1293

#### Special notes for your reviewer

> Note

- **Open question from the ticket, not settled here:** whether the API rejects a
  concurrent `PUT /nodes/{nodeName}/gpuCards/{gpuId}`. `docs.yaml` documents `409`
  for that endpoint, but its only example is
  `GPU card does not support 'sriovVgpu' resource type`. If the API accepts a
  second request, this UI gate is the only thing preventing two overlapping
  changes, and the backend should get the same guard.
- The same node page already gates block-device actions this way
  (`devices/nodeDevicesUtils.ts:38`, `devices/NodeDevices.tsx:130`), which is where
  the pattern comes from. GPU rows had the spinner but not the gating.
- Touches the same menu block as #852 and #853, but a different line, so it merges
  either way round.

#### Additional documentation

```docs

```
