### PR TITLE
feat(advisor-ui): cluster workspace — the grounding vocabulary

### DIFF
--- a/packages/cube-advisor-ui/src/components/ClusterWorkspace/ClusterWorkspace.tsx
+++ b/packages/cube-advisor-ui/src/components/ClusterWorkspace/ClusterWorkspace.tsx
@@ -1,0 +1,162 @@
+import classNames from 'classnames'
+
+import {
+  citationLabel,
+  commandBadge,
+  coverageLabel,
+  isGrounded,
+  isLayerConflict,
+  type AnswerSegment,
+  type Citation,
+  type CommandBlock,
+  type Conflict,
+  type Coverage,
+} from './answer'
+
+const layerClass: Record<Citation['layer'], string> = {
+  bigstack: 'text-status-neutral',
+  partner: 'text-status-paused',
+}
+
+/**
+ * A citation chip.
+ *
+ * The layer is in the text and in the colour, because the brief requires
+ * provenance to be distinguishable at a glance rather than on hover.
+ */
+export const CitationChip = (props: {
+  citation: Citation
+  onOpen?: (ref: string) => void
+}) => {
+  const { citation, onOpen } = props
+  return (
+    <button
+      type="button"
+      onClick={() => onOpen?.(citation.ref)}
+      className={classNames(
+        'rounded border border-functional-border-divider px-1 text-xs',
+        layerClass[citation.layer],
+      )}
+      data-testid="citation-chip"
+      data-layer={citation.layer}
+    >
+      {citationLabel(citation)}
+    </button>
+  )
+}
+
+/**
+ * The coverage meter.
+ *
+ * Partial coverage is stated prominently and the unread entries are listed —
+ * and that list has already been filtered to what this viewer may see, so it
+ * cannot disclose that an internal entry exists.
+ */
+export const CoverageMeter = (props: { coverage: Coverage }) => {
+  const { coverage } = props
+  return (
+    <div
+      className={classNames(
+        'text-xs',
+        coverage.complete
+          ? 'text-functional-text-light'
+          : 'text-status-warning',
+      )}
+      data-testid="coverage-meter"
+      data-complete={coverage.complete}
+    >
+      {coverageLabel(coverage)}
+      {!coverage.complete && coverage.unread.length > 0 && (
+        <span>
+          {' '}
+          · not consulted: {coverage.unread.map((e) => e.title).join(', ')}
+        </span>
+      )}
+    </div>
+  )
+}
+
+/**
+ * One segment of an answer.
+ *
+ * An uncited segment renders visibly differently. Absence of a citation is a
+ * claim about the answer, so it must not look the same as a grounded one.
+ */
+export const Segment = (props: {
+  segment: AnswerSegment
+  onOpen?: (ref: string) => void
+}) => {
+  const { segment, onOpen } = props
+  const grounded = isGrounded(segment)
+  return (
+    <p
+      className={classNames(
+        'text-sm',
+        grounded
+          ? 'text-functional-text'
+          : 'border-l-2 border-status-warning pl-2 text-status-warning',
+      )}
+      data-testid="answer-segment"
+      data-grounded={grounded}
+    >
+      {segment.text}
+      {!grounded && <span className="ml-1 text-xs">(ungrounded)</span>}
+      {segment.citations.map((c) => (
+        <CitationChip key={`${c.kind}:${c.ref}`} citation={c} onOpen={onOpen} />
+      ))}
+    </p>
+  )
+}
+
+/**
+ * A conflict between knowledge layers.
+ *
+ * Both sides, with provenance, and no winner. An operator mid-incident is
+ * exactly who needs to see the disagreement rather than one side of it — which
+ * is why this is a first-class card and not an error state.
+ */
+export const ConflictCard = (props: { conflict: Conflict }) => {
+  const { conflict } = props
+  if (!isLayerConflict(conflict)) return null
+  return (
+    <div
+      className="flex flex-col gap-y-1 rounded border border-status-warning p-2"
+      data-testid="conflict-card"
+    >
+      <span className="text-xs text-status-warning">
+        Sources disagree — both shown, neither preferred
+      </span>
+      {conflict.sides.map((side) => (
+        <div key={side.citation.ref} className="flex flex-col gap-y-0.5">
+          <CitationChip citation={side.citation} />
+          <span className="text-sm text-functional-text">{side.claim}</span>
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/**
+ * A recommended command.
+ *
+ * The badge is always present. A command block with no badge reads as endorsed,
+ * so an unsupported command must say so rather than say nothing.
+ */
+export const CommandRecommendation = (props: { block: CommandBlock }) => {
+  const { block } = props
+  return (
+    <div className="flex flex-col gap-y-0.5" data-testid="command-block">
+      <code className="rounded bg-functional-hover-grey px-1 text-sm">
+        {block.command}
+      </code>
+      <span
+        className={classNames(
+          'text-xs',
+          block.supported ? 'text-status-positive-text' : 'text-status-warning',
+        )}
+      >
+        {block.supported ? '✅' : '⚠️'} {commandBadge(block)}
+      </span>
+    </div>
+  )
+}

--- a/packages/cube-advisor-ui/src/components/ClusterWorkspace/answer.test.ts
+++ b/packages/cube-advisor-ui/src/components/ClusterWorkspace/answer.test.ts
@@ -1,0 +1,217 @@
+import { describe, expect, it } from 'vitest'
+import {
+  canSee,
+  citationLabel,
+  commandBadge,
+  coverageLabel,
+  coverageOf,
+  isGrounded,
+  isLayerConflict,
+  type Citation,
+  type Conflict,
+  type OutlineEntry,
+} from './answer'
+
+const outline: OutlineEntry[] = [
+  {
+    slug: 'ceph-recovery',
+    title: 'Ceph recovery behaviour',
+    layer: 'bigstack',
+    audience: 'client',
+  },
+  {
+    slug: 'ceph-slow-ops',
+    title: 'Slow ops',
+    layer: 'bigstack',
+    audience: 'client',
+  },
+  {
+    slug: 'internal-escalation',
+    title: 'Internal escalation path',
+    layer: 'bigstack',
+    audience: 'internal',
+  },
+  {
+    slug: 'nw-storage-runbook',
+    title: 'NorthWind storage runbook',
+    layer: 'partner',
+    audience: 'client',
+  },
+]
+
+const kb = (
+  ref: string,
+  layer: Citation['layer'] = 'bigstack',
+  layerName?: string,
+): Citation => ({
+  kind: 'kb',
+  ref,
+  layer,
+  layerName,
+})
+
+describe('canSee', () => {
+  // Internal titles must never reach a customer role, "even in 'not consulted'
+  // lists" — so this filters before anything is rendered or counted.
+  it('hides internal entries from partner and customer roles', () => {
+    const internal = outline[2]
+    expect(canSee(internal, 'bigstack')).toBe(true)
+    expect(canSee(internal, 'partner')).toBe(false)
+    expect(canSee(internal, 'customer')).toBe(false)
+  })
+
+  it('shows client entries to everyone', () => {
+    expect(canSee(outline[0], 'customer')).toBe(true)
+  })
+})
+
+describe('citationLabel', () => {
+  // Provenance must be readable at a glance, not on hover.
+  it('names the layer in the chip text', () => {
+    expect(citationLabel(kb('ceph-slow-ops'))).toBe(
+      'kb: ceph-slow-ops · Bigstack',
+    )
+    expect(
+      citationLabel(kb('nw-storage-runbook', 'partner', 'NorthWind')),
+    ).toBe('kb: nw-storage-runbook · Partner: NorthWind')
+  })
+
+  it('never renders a bare reference with no source', () => {
+    expect(citationLabel(kb('x'))).toContain('·')
+  })
+})
+
+describe('coverageOf', () => {
+  const citations = [
+    kb('ceph-recovery'),
+    kb('nw-storage-runbook', 'partner', 'NorthWind'),
+  ]
+
+  // The denominator counts only what the viewer may see. Reporting 2/4 to a
+  // customer would disclose that an internal entry exists.
+  it('counts only entries the viewer may see, in both numerator and denominator', () => {
+    expect(coverageOf(outline, citations, 'customer').total).toBe(3)
+    expect(coverageOf(outline, citations, 'bigstack').total).toBe(4)
+  })
+
+  it('never lists an internal entry as unread to a customer', () => {
+    const unread = coverageOf(outline, citations, 'customer').unread
+    expect(unread.map((e) => e.slug)).not.toContain('internal-escalation')
+    expect(unread.map((e) => e.title).join(' ')).not.toMatch(/internal/i)
+  })
+
+  it('splits the read count by layer', () => {
+    const c = coverageOf(outline, citations, 'customer')
+    expect(c.byLayer).toEqual({ bigstack: 1, partner: 1 })
+    // The split must account for every entry read, or the meter lies.
+    expect(c.byLayer.bigstack + c.byLayer.partner).toBe(c.read)
+  })
+
+  it('reports completeness against what the viewer can see', () => {
+    const all = [
+      kb('ceph-recovery'),
+      kb('ceph-slow-ops'),
+      kb('nw-storage-runbook', 'partner', 'NW'),
+    ]
+    expect(coverageOf(outline, all, 'customer').complete).toBe(true)
+    // The same answer is incomplete for Bigstack, who can see one more entry.
+    expect(coverageOf(outline, all, 'bigstack').complete).toBe(false)
+  })
+
+  // The tool ref deliberately collides with an outline slug. A ref that
+  // matched nothing would make this pass whether or not kb-only filtering
+  // happens, which is no test at all.
+  it('ignores tool citations even when a ref collides with an entry slug', () => {
+    const tool: Citation = {
+      kind: 'tool',
+      ref: 'ceph-recovery',
+      layer: 'bigstack',
+    }
+    const c = coverageOf(outline, [tool], 'customer')
+    expect(c.read).toBe(0)
+    expect(c.unread.map((e) => e.slug)).toContain('ceph-recovery')
+  })
+})
+
+describe('coverageLabel', () => {
+  it('states the split when both layers contributed', () => {
+    const c = coverageOf(
+      outline,
+      [kb('ceph-recovery'), kb('nw-storage-runbook', 'partner', 'NW')],
+      'customer',
+    )
+    expect(coverageLabel(c)).toBe('Based on 2/3 · 1 Bigstack · 1 Partner')
+  })
+
+  it('omits a layer that contributed nothing rather than printing a zero', () => {
+    const c = coverageOf(outline, [kb('ceph-recovery')], 'customer')
+    expect(coverageLabel(c)).toBe('Based on 1/3 · 1 Bigstack')
+  })
+})
+
+describe('isGrounded', () => {
+  it('is false for a segment with no citation', () => {
+    expect(isGrounded({ text: 'probably fine', citations: [] })).toBe(false)
+    expect(
+      isGrounded({ text: 'osd.7 restarted', citations: [kb('ceph-recovery')] }),
+    ).toBe(true)
+  })
+})
+
+describe('isLayerConflict', () => {
+  const across: Conflict = {
+    question: 'how to remediate',
+    sides: [
+      { citation: kb('backup-retry-policy'), claim: 'retry once then fail' },
+      {
+        citation: kb('nw-backup-failover', 'partner', 'NorthWind'),
+        claim: 're-run against secondary',
+      },
+    ],
+  }
+
+  it('is a conflict when two layers disagree', () => {
+    expect(isLayerConflict(across)).toBe(true)
+  })
+
+  // Two Bigstack entries disagreeing is ours to fix, not the operator's to
+  // adjudicate mid-incident.
+  it('is not a conflict when both sides come from the same layer', () => {
+    expect(
+      isLayerConflict({
+        question: 'q',
+        sides: [
+          { citation: kb('a'), claim: 'x' },
+          { citation: kb('b'), claim: 'y' },
+        ],
+      }),
+    ).toBe(false)
+  })
+
+  it('is not a conflict with a single side', () => {
+    expect(
+      isLayerConflict({
+        question: 'q',
+        sides: [{ citation: kb('a'), claim: 'x' }],
+      }),
+    ).toBe(false)
+  })
+
+  // The type must not be able to express a winner: the brief says show both and
+  // do not pick one.
+  it('has no notion of a winning side', () => {
+    expect(Object.keys(across)).toEqual(['question', 'sides'])
+  })
+})
+
+describe('commandBadge', () => {
+  // Absence of a warning is itself a claim, so unsupported is stated.
+  it('states unsupported rather than omitting a badge', () => {
+    expect(commandBadge({ command: 'cluster x', supported: false })).toMatch(
+      /not a CubeCOS/,
+    )
+    expect(commandBadge({ command: 'cluster check', supported: true })).toMatch(
+      /valid CubeCOS/,
+    )
+  })
+})

--- a/packages/cube-advisor-ui/src/components/ClusterWorkspace/answer.ts
+++ b/packages/cube-advisor-ui/src/components/ClusterWorkspace/answer.ts
@@ -1,0 +1,159 @@
+/**
+ * The grounding vocabulary of an answer: citations, coverage, conflicts and
+ * command validation.
+ *
+ * The product's commercial risk is a confident wrong answer, so the UI's job is
+ * to make reliability inspectable rather than to hide the machinery. Everything
+ * here is a pure function over an answer so the claims the screen makes can be
+ * tested without a browser.
+ */
+
+/** Which knowledge layer a citation came from (ADR 0006). */
+export type SourceLayer = 'bigstack' | 'partner'
+
+/** Who may read a knowledge entry. */
+export type Audience = 'internal' | 'client'
+
+export type Citation = {
+  kind: 'kb' | 'tool'
+  /** Entry slug or tool call id, e.g. `ceph-slow-ops` or `cluster check @14:02`. */
+  ref: string
+  layer: SourceLayer
+  /** Partner name, when layer is `partner`. */
+  layerName?: string
+  /** Absent for tool observations, which are always the viewer's own cluster. */
+  audience?: Audience
+}
+
+/** A knowledge entry in the topic outline a broad question should cover. */
+export type OutlineEntry = {
+  slug: string
+  title: string
+  layer: SourceLayer
+  audience: Audience
+}
+
+export type ViewerRole = 'bigstack' | 'partner' | 'customer'
+
+/**
+ * Whether a viewer may see an entry at all.
+ *
+ * Internal entries are for Bigstack staff. Everyone else must not learn they
+ * exist — the brief is explicit that internal titles must never reach customer
+ * roles "even in 'not consulted' lists", which is why filtering happens here
+ * rather than in the renderer.
+ */
+export const canSee = (entry: OutlineEntry, role: ViewerRole): boolean =>
+  entry.audience === 'client' || role === 'bigstack'
+
+/**
+ * The label a citation chip renders.
+ *
+ * The layer is part of the chip text, not a hover affordance: the brief
+ * requires provenance to be distinguishable at a glance.
+ */
+export const citationLabel = (c: Citation): string => {
+  const source =
+    c.layer === 'partner' ? `Partner: ${c.layerName ?? 'partner'}` : 'Bigstack'
+  return `${c.kind}: ${c.ref} · ${source}`
+}
+
+export type Coverage = {
+  read: number
+  total: number
+  byLayer: Record<SourceLayer, number>
+  /** Entries the viewer may see and the answer did not read. */
+  unread: OutlineEntry[]
+  complete: boolean
+}
+
+/**
+ * Coverage of a topic outline, from the viewer's point of view.
+ *
+ * Both numerator and denominator count only entries this viewer may see. The
+ * same question can therefore legitimately show different coverage to different
+ * roles — that is correct, not a bug: reporting 5/7 to a customer whose two
+ * unseen entries are internal would disclose that two internal entries exist.
+ */
+export const coverageOf = (
+  outline: OutlineEntry[],
+  citations: Citation[],
+  role: ViewerRole,
+): Coverage => {
+  const visible = outline.filter((e) => canSee(e, role))
+  const cited = new Set(
+    citations.filter((c) => c.kind === 'kb').map((c) => c.ref),
+  )
+  const read = visible.filter((e) => cited.has(e.slug))
+  const byLayer: Record<SourceLayer, number> = { bigstack: 0, partner: 0 }
+  for (const entry of read) byLayer[entry.layer] += 1
+  return {
+    read: read.length,
+    total: visible.length,
+    byLayer,
+    unread: visible.filter((e) => !cited.has(e.slug)),
+    complete: read.length === visible.length,
+  }
+}
+
+/** `Based on 5/7 · 3 Bigstack · 2 Partner` */
+export const coverageLabel = (c: Coverage): string => {
+  const parts = [`Based on ${c.read}/${c.total}`]
+  if (c.byLayer.bigstack > 0) parts.push(`${c.byLayer.bigstack} Bigstack`)
+  if (c.byLayer.partner > 0) parts.push(`${c.byLayer.partner} Partner`)
+  return parts.join(' · ')
+}
+
+export type AnswerSegment = {
+  text: string
+  citations: Citation[]
+}
+
+/**
+ * Whether a segment is backed by anything.
+ *
+ * An uncited segment is rendered visibly differently rather than silently — the
+ * whole point is that an ungrounded claim should not look like a grounded one.
+ */
+export const isGrounded = (segment: AnswerSegment): boolean =>
+  segment.citations.length > 0
+
+/**
+ * A disagreement between the base pack and a partner overlay.
+ *
+ * Deliberately has no winner field. The brief requires both sides shown with
+ * their provenance and no winner picked — an operator mid-incident is exactly
+ * who needs to see the disagreement rather than one side of it.
+ */
+export type Conflict = {
+  question: string
+  sides: { citation: Citation; claim: string }[]
+}
+
+/**
+ * Whether a set of sources actually constitutes a conflict worth a card.
+ *
+ * Two claims from the same layer are a knowledge-base inconsistency for
+ * Bigstack or the partner to fix, not a layering conflict for the operator to
+ * adjudicate. A card needs at least two distinct layers.
+ */
+export const isLayerConflict = (conflict: Conflict): boolean => {
+  const layers = new Set(conflict.sides.map((s) => s.citation.layer))
+  return conflict.sides.length >= 2 && layers.size >= 2
+}
+
+/** A command the answer recommends, with its validation verdict. */
+export type CommandBlock = {
+  command: string
+  /** `true` only when the command is in the supported CubeCOS surface. */
+  supported: boolean
+}
+
+/**
+ * The badge a recommended command carries.
+ *
+ * Unsupported is stated, never omitted. A command block with no badge reads as
+ * endorsed, so absence of a warning is itself a claim.
+ */
+export const commandBadge = (block: CommandBlock): string =>
+  block.supported ? 'valid CubeCOS command' : 'not a CubeCOS-supported command'

--- a/packages/cube-advisor-ui/src/index.ts
+++ b/packages/cube-advisor-ui/src/index.ts
@@ -53,3 +53,28 @@ export {
   type PackVersion,
   type PartnerGroup,
 } from './components/FleetHome/fleet'
+export {
+  CitationChip,
+  CommandRecommendation,
+  ConflictCard,
+  CoverageMeter,
+  Segment,
+} from './components/ClusterWorkspace/ClusterWorkspace'
+export {
+  canSee,
+  citationLabel,
+  commandBadge,
+  coverageLabel,
+  coverageOf,
+  isGrounded,
+  isLayerConflict,
+  type AnswerSegment,
+  type Audience,
+  type Citation,
+  type CommandBlock,
+  type Conflict,
+  type Coverage,
+  type OutlineEntry,
+  type SourceLayer,
+  type ViewerRole,
+} from './components/ClusterWorkspace/answer'


### PR DESCRIPTION
## What this PR does / why we need it

The main screen's chat surface: **citation chips with provenance, the coverage meter, ungrounded segments, conflict cards and command validation**. The layout itself is unchanged from the base brief — the partner-tier brief says only these elements change.

Stacked on #859 → #857 → #856 → #855.

Refs #854

## Special notes for your reviewer

### Audience filtering is the load-bearing rule, and it lives in the model

`coverageOf` counts only entries the viewer may see — **in both numerator and denominator**. So the same question legitimately shows different coverage to different roles. That is correct, not a bug:

> reporting 5/7 to a customer whose two unseen entries are internal would disclose that two internal entries exist

The unread list is filtered the same way, because the brief is explicit that internal titles must not reach customer roles *"even in 'not consulted' lists"*. Filtering in the renderer would leave the counts wrong even when the list looked right.

### Provenance at a glance, not on hover

`kb: ceph-slow-ops · Bigstack` versus `kb: nw-storage-runbook · Partner: NorthWind` — the layer is in the chip **text** and the colour, per the brief. The coverage meter splits by layer (`Based on 2/3 · 1 Bigstack · 1 Partner`), and a layer that contributed nothing is omitted rather than printed as a zero.

### Conflicts have no winner, and same-layer disagreements aren't conflicts

`Conflict` has **no winner field**, so the type cannot express one — the brief requires both sides shown with provenance and no winner picked.

`isLayerConflict` additionally requires **two distinct layers**. Two Bigstack entries disagreeing is a knowledge-base inconsistency for us to fix, not something to hand an operator mid-incident to adjudicate.

### Absence of a marker is itself a claim

- An **uncited segment** renders visibly differently (amber, left rule, `(ungrounded)`), because it must not look like a grounded one.
- A **command block always carries a badge**. A block with no badge reads as endorsed, so unsupported is stated rather than omitted.

## Mutation testing — and one test that was passing for the wrong reason

Nine mutations, **eight caught first time**. Worth reporting the ninth honestly:

**"tool citations counted as knowledge coverage" survived.** My test used a tool ref of `cluster check @14:02`, which matches no outline slug — so removing the `kind === 'kb'` filter changed nothing and the test passed regardless of whether the filtering existed. I rewrote it so the tool ref **collides with a real entry slug** (`ceph-recovery`), which is also the realistic case. It now fails against the mutation.

The other eight: internal entries visible to customers, the denominator counting unseeable entries, internal titles leaking into the unread list, the layer dropped from a chip, a partner labelled as Bigstack, same-layer disagreement treated as a conflict, an uncited segment reported as grounded, and an unsupported command getting no badge.

## Verification

`tsc` clean · `eslint` clean · 61 tests pass · prettier applied.

## Scope

Built from the **written brief**, not pixel-matched to `03 Cube AI Advisor Cluster Workspace.dc.html`. Semantics and invariants first; the visual pass against the Design export is outstanding, and needs someone with the mockup open.

Not included from this screen: the **tool-activity trace**, **approval cards** for bounded probes, and the **right-hand panel** that swaps between source viewer / tool output / session history. Those are stateful and belong with the API wiring rather than with the grounding vocabulary.