### PR TITLE
fix(nodes): 1294 keep the GPU row action menu in view and lead with PCI Address

### DIFF
--- a/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/DetailCell/CustomizedDetailCell.tsx
+++ b/packages/cube-frontend-ui-library/src/components/CosViewDetailsTable/DetailCell/CustomizedDetailCell.tsx
@@ -8,5 +8,16 @@ type CustomizedDetailCellProps = {
 export const CustomizedDetailCell = (props: CustomizedDetailCellProps) => {
   const { isExpanded, children } = props
 
-  return <div className={containerClasses({ isExpanded })}>{children}</div>
+  /**
+   * A collapsed cell only sets `max-h-0`, so children stay in the DOM and keep
+   * reporting their width. The parent table uses `table-layout: auto`, which
+   * sizes every column from the widest cell content — a wide detail table then
+   * stretches the card row and pushes the last column, the overflow menu, far
+   * off screen. Mount the children on expand so a collapsed row costs nothing.
+   */
+  return (
+    <div className={containerClasses({ isExpanded })}>
+      {isExpanded && children}
+    </div>
+  )
 }

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetails.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/GpuDetails.tsx
@@ -70,8 +70,16 @@ const GpuDetails = (props: GpuDetailsProps) => {
     )
   }
 
+  /**
+   * Both tables scroll horizontally, but a scroll container still reports its
+   * content width to the table cell above it, and the GPU table sizes its
+   * columns from that. Without a cap, a card with many profiles widens the whole
+   * table and pushes the overflow menu out of view. The cap subtracts the page
+   * chrome around this cell — sidebar, panel padding, the expand-button column
+   * and the cell padding — so the tables never ask for more than the row shows.
+   */
   return (
-    <div className="flex flex-col gap-y-9">
+    <div className="flex max-w-[calc(100vw-460px)] flex-col gap-y-9">
       {profiles.length > 0 && (
         <GpuProfilesInfoTable
           title={profileTitle}

--- a/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/NodeGpuResources.tsx
+++ b/packages/cube-frontend-web-app/src/pages/node/[name]/_components/NodeGpuResources/NodeGpuResources.tsx
@@ -301,6 +301,10 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
             {renderName}
           </GpuResourceTable.Column>
           <GpuResourceTable.Column
+            label={t('nodes.details.gpuList.pciAddress')}
+            property="pciAddress"
+          />
+          <GpuResourceTable.Column
             label={t('nodes.details.gpuList.resourceType')}
             property="resourceType"
           >
@@ -324,10 +328,6 @@ const NodeGpuResources = (props: NodeGpuResourcesProps) => {
           >
             {(_, row) => renderGpuUtilization(row)}
           </GpuResourceTable.Column>
-          <GpuResourceTable.Column
-            label={t('nodes.details.gpuList.pciAddress')}
-            property="pciAddress"
-          />
           <GpuResourceTable.Column
             label={t('nodes.details.gpuList.status')}
             property="status"


### PR DESCRIPTION
#### What type of PR is this?

/kind bug

#### What this PR does / why we need it

**TLDR:** A GPU card with many vGPU profiles stretched the GPU Resources table to
4173 px inside a 1312 px panel and pushed the row `⋯` menu ~2700 px off screen —
with every row collapsed. Two changes keep the table inside the panel: a collapsed
detail row no longer renders, and the expanded detail content has a width cap.
The table also leads with **PCI Address** now, right after GPU Card.

### QA view

Before this PR, on a node whose GPU cards report many profiles (about 20 is
enough, 40 is obvious):

- The GPU Resources panel showed only **GPU Card** and **Resource Type**.
- **Status**, **Allocation**, and the `⋯` action menu were off screen, so
  **Edit GPU Type**, **View Workload History**, and **View VRAM History** were
  unreachable until you dragged the table sideways.
- The rows were collapsed. Nothing on screen explained the width.

After this PR:

- All nine columns and the `⋯` menu fit the panel, collapsed or expanded.
- A card with many profiles scrolls its own **Profiles / ID (n)** box sideways.
  The card table above keeps its layout.
- Nothing changes for a card with one or two profiles.
- **PCI Address is the second column**, right after GPU Card. It used to sit
  sixth, after the three utilization columns. Same value, same format — only the
  position changes.

Only **cube-cos-ui** is involved. `cube-cos-api` already answers correct data; a
longer profile list only made the UI bug visible.

Check list for QA is in bigstack-oss/cubecos#1294 (QA Verification), including the
1280 px case.

### Developer view

Column order, before and after:

| | Order |
| --- | --- |
| before | GPU Card, Resource Type, VRAM Allocation, VRAM Utilization, GPU Utilization, **PCI Address**, Status, Allocation |
| after | GPU Card, **PCI Address**, Resource Type, VRAM Allocation, VRAM Utilization, GPU Utilization, Status, Allocation |

Widths, measured in Chrome at a 1600x1000 viewport, sidebar expanded, 40 profiles
per card:

| State | GPU table width | Panel width | `⋯` icon x | Panel right edge |
| --- | --- | --- | --- | --- |
| before, all collapsed | 4173 px | 1312 px | 4253 px | 1556 px |
| before, one expanded | 4238 px | 1312 px | 4253 px | 1556 px |
| after, all collapsed | 1312 px | 1312 px | 1517 px | 1556 px |
| after, one expanded | 1312 px | 1312 px | 1517 px | 1556 px |

Three things combined to cause it:

1. `CosViewDetailsTable` kept the detail row in the DOM when collapsed — it only
   sets `max-h-0` (`DetailCell/styles.ts`). Height went to 0, but the children
   still reported their width.
2. `InfoTable` with `scrollBehavior="horizontal"` splits rows into blocks of 5 and
   lays them out side by side, each `min-w-[491px] shrink-0`. 40 profiles = 8
   blocks ≈ 3900 px.
3. The card table uses `table-layout: auto`, which sizes every column from the
   widest cell content — the collapsed detail cell included.

So 36 collapsed rows paid the full width of 96 nested tables they never showed.

The fix, in two files:

| File | Change |
| --- | --- |
| `CosViewDetailsTable/DetailCell/CustomizedDetailCell.tsx` | render children only while `isExpanded`, so a collapsed row costs no width and no nested table |
| `NodeGpuResources/GpuDetails.tsx` | cap the detail content at `max-w-[calc(100vw-460px)]`, so one expanded card cannot stretch the table either |
| `NodeGpuResources/NodeGpuResources.tsx` | move the `pciAddress` column to second place (second commit) |

The cap has to be `px` / `vw` / `calc()`. `max-width: 100%` does nothing here —
the percentage resolves against the auto-sized cell, and the cell is sized from
its content, so the constraint is circular. Verified both ways in the browser.

##### Screenshots

**1. Before — every row collapsed, 40 profiles per card. Only two columns fit.**

<img width="1600" height="1000" alt="before-collapsed" src="https://github.com/user-attachments/assets/a8b982d1-b432-4abd-87e8-4dd8e9badacd" />

**2. Before — one card expanded. The card row is still stretched and the profile blocks run past the panel.**

<img width="1600" height="1000" alt="before-expanded" src="https://github.com/user-attachments/assets/0d3c6e06-4326-4355-88b6-add2838ae858" />

The three **after** shots also show the new column order.

**3. After — all rows collapsed. Eight columns plus the `⋯` menu fit the panel, PCI Address second.**

<img width="1600" height="1000" alt="after-collapsed" src="https://github.com/user-attachments/assets/1035603c-a7c3-4d30-9916-febdce726ab3" />

**4. After — the same card expanded. Profiles / ID (40) scrolls inside its own box; the columns hold.**

<img width="1600" height="1000" alt="after-expanded" src="https://github.com/user-attachments/assets/7b7daa14-699a-4d42-9759-5aac0889a76e" />

**5. After — the row menu opens where it belongs, with the row expanded.**

<img width="1600" height="1000" alt="after-menu-open" src="https://github.com/user-attachments/assets/aabb7a97-d93b-4b90-a02b-9354d09d0d48" />

#### Which issue(s) this PR fixes

Fixes bigstack-oss/cubecos#1294

#### Special notes for your reviewer

> Note

- **Stacked on #853.** The base branch is `fix/823-show-unmeasurable-gpu-stats` so
  you can test the whole GPU work in one place. Merge #853 first; this branch then
  rebases onto develop cleanly. The two files here do not overlap #853's changes.
- **`CustomizedDetailCell` is shared.** Every `CosViewDetailsTable` that passes
  `getCustomizedDetailCell` now mounts its detail content on expand instead of
  keeping it hidden. There is no open/close animation to lose: the collapsed
  variant sets `max-h-0` and the expanded variant sets no `max-height`, so the
  `transition` never had two lengths to run between.
- **`DetailCell` (the `getDetailItems` variant) is untouched.** Its items are
  label/value pairs, which do not grow wide enough to move a column. Same change
  applies there if it ever does.
- **The cap value is layout-derived, not arbitrary.** 460 px = sidebar and panel
  padding on the left (244) + the panel gap on the right (44) + the expand-button
  column, cell padding, and the full-view button inside the row (~172). Wider
  windows get more room; a narrower window or a collapsed sidebar leaves the cap
  conservative, never short.
- **Below about 1300 px the nine card columns alone need more room than the panel
  gives**, so a small horizontal scroll can remain there. That is the columns'
  own min-content width, not this bug: measured at 1280 px the table is 1019 px
  whether the row is collapsed or expanded, and the `⋯` menu stays reachable.
- **Two commits, two concerns.** The first keeps the menu in view; the second
  moves the PCI Address column. Review them separately if that is easier — the
  column move touches only the column order in `NodeGpuResources.tsx`.
- **The mocks are not in this PR.** I raised the mock profile count to 40 per card
  locally to reproduce; `src/mocks/gpu.ts` stays as #853 left it.

Verified in a browser against the inflated mocks, reading widths back out of the
DOM: collapsed table 1312 px with 0 nested tables rendered, expanded table 1312 px
with 0 px of horizontal overflow, profile box 1140 px wide over 4072 px of content,
`⋯` at x=1517 inside a container ending at x=1556, and the menu opens with all
three items. Console clean. `pnpm lint` passes; `pnpm test` passes (109 tests).

#### Additional documentation

```docs

```
